### PR TITLE
only build preview PRs on develop

### DIFF
--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -2,6 +2,9 @@ name: PR Preview Environments
 
 on:
   pull_request:
+    # Previews only for PRs into develop (not release PRs into main / hotfix→main).
+    branches:
+      - develop
     types:
       - opened
       - reopened
@@ -20,7 +23,8 @@ concurrency:
 
 jobs:
   preview-scope:
-    if: github.event.action != 'closed'
+    # Skip main→develop sync PRs (no feature preview; diff would match everything on develop).
+    if: github.event.action != 'closed' && (github.base_ref != 'develop' || github.head_ref != 'main')
     runs-on: ubuntu-latest
     outputs:
       run_deploy: ${{ steps.check.outputs.run_deploy }}
@@ -44,7 +48,7 @@ jobs:
         run: echo "Skipping PR preview deploy (no app/package/supabase/pr-preview changes)."
 
   deploy-preview:
-    if: github.event.action != 'closed' && needs.preview-scope.outputs.run_deploy == 'true'
+    if: github.event.action != 'closed' && needs.preview-scope.outputs.run_deploy == 'true' && (github.base_ref != 'develop' || github.head_ref != 'main')
     needs: preview-scope
     runs-on: ubuntu-latest
     env:
@@ -334,7 +338,7 @@ jobs:
             }
 
   teardown-preview:
-    if: github.event.action == 'closed'
+    if: github.event.action == 'closed' && (github.base_ref != 'develop' || github.head_ref != 'main')
     runs-on: ubuntu-latest
     env:
       PREVIEW_STACK_NAME: ${{ vars.PR_PREVIEW_STACK_NAME }}


### PR DESCRIPTION
## Description

Gates **PR Preview Environments** so previews only run when they are useful:

- **`pull_request.branches: [develop]`** — The workflow only runs for PRs whose **base** is `develop`. Release PRs (`develop` → `main`) no longer trigger preview deploys or teardown (production still deploys on merge via `deploy-production.yml`).
- **Skip `main` → `develop` sync PRs** — Jobs `preview-scope`, `deploy-preview`, and `teardown-preview` use  
  `(github.base_ref != 'develop' || github.head_ref != 'main')`  
  so syncing `main` into `develop` does not fire a full preview (the diff would otherwise touch almost everything under the path allowlist).

**Tradeoff:** PR previews do **not** run for PRs whose base is `main` (e.g. hotfix branch → `main`). If that is needed later, extend the workflow trigger or add a separate preview path.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactoring
- [ ] Other (please describe)

## Merge Strategy Reminder

⚠️ **Important**: Please use the correct merge strategy when merging this PR:

- **If this PR targets `develop`**: Use **"Squash and merge"** ✅
- **If this PR targets `main`**: Use **"Create a merge commit"** ✅ (NOT squash merge)

Squash merging to `main` can cause conflicts when merging `develop` → `main` later.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [ ] Documentation updated (if needed)
- [x] No new warnings generated
- [ ] Tests added/updated (if needed)
- [ ] All tests pass locally

## Testing

- After merge: confirm a feature branch → `develop` PR still runs preview when paths match `check-preview-deploy-needed.sh`.
- Confirm `main` → `develop` sync PRs skip preview jobs; `develop` → `main` does not start this workflow.

## Related Issues

<!-- Link to related issues, if any -->
