### PR TITLE
CI/CD and package publishing fixes

### DIFF
--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -2,6 +2,9 @@ name: PR Preview Environments
 
 on:
   pull_request:
+    # Previews only for PRs into develop (not release PRs into main / hotfix→main).
+    branches:
+      - develop
     types:
       - opened
       - reopened
@@ -20,7 +23,8 @@ concurrency:
 
 jobs:
   preview-scope:
-    if: github.event.action != 'closed'
+    # Skip main→develop sync PRs (no feature preview; diff would match everything on develop).
+    if: github.event.action != 'closed' && (github.base_ref != 'develop' || github.head_ref != 'main')
     runs-on: ubuntu-latest
     outputs:
       run_deploy: ${{ steps.check.outputs.run_deploy }}
@@ -44,7 +48,7 @@ jobs:
         run: echo "Skipping PR preview deploy (no app/package/supabase/pr-preview changes)."
 
   deploy-preview:
-    if: github.event.action != 'closed' && needs.preview-scope.outputs.run_deploy == 'true'
+    if: github.event.action != 'closed' && needs.preview-scope.outputs.run_deploy == 'true' && (github.base_ref != 'develop' || github.head_ref != 'main')
     needs: preview-scope
     runs-on: ubuntu-latest
     env:
@@ -334,7 +338,7 @@ jobs:
             }
 
   teardown-preview:
-    if: github.event.action == 'closed'
+    if: github.event.action == 'closed' && (github.base_ref != 'develop' || github.head_ref != 'main')
     runs-on: ubuntu-latest
     env:
       PREVIEW_STACK_NAME: ${{ vars.PR_PREVIEW_STACK_NAME }}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,5 +1,6 @@
 {
   "name": "mobile-app",
+  "private": true,
   "version": "1.0.0",
   "main": "index.js",
   "overrides": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,6 @@
 {
   "name": "web",
+  "private": true,
   "version": "1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Description

### GitHub Actions — PR preview gating

- Restrict **PR Preview Environments** to pull requests whose **base branch is `develop`** (`pull_request.branches`).
- Skip preview deploy and teardown for **`main` → `develop` sync PRs** using job conditions so a large sync diff does not trigger full preview builds.

Release PRs (`develop` → `main`) no longer start this workflow. **Tradeoff:** previews do not run for PRs into `main` (e.g. hotfix → `main`); extend the workflow if that is needed later.

### Package metadata — `private` apps

- Set **`"private": true`** in [`apps/web/package.json`](apps/web/package.json) and [`apps/mobile/package.json`](apps/mobile/package.json) so these workspace apps are explicitly non-publishable to npm (avoids accidental publish and matches typical monorepo app package policy).

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [x] Refactoring
- [ ] Other (please describe)

## Merge Strategy Reminder

⚠️ **Important**: Please use the correct merge strategy when merging this PR:

- **If this PR targets `develop`**: Use **"Squash and merge"** ✅
- **If this PR targets `main`**: Use **"Create a merge commit"** ✅ (NOT squash merge)

Squash merging to `main` can cause conflicts when merging `develop` → `main` later.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [ ] Documentation updated (if needed)
- [x] No new warnings generated
- [ ] Tests added/updated (if needed)
- [ ] All tests pass locally

## Testing

- CI: confirm **Test** and any other required checks pass on this PR.
- After merge: feature branch → `develop` should still run PR preview when path filters allow; `develop` → `main` should not start the preview workflow.

## Related Issues

<!-- Link to related issues, if any -->
