### PR TITLE
Last develop → main promotion: preview CI & package publishing

### DIFF
--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -2,6 +2,9 @@ name: PR Preview Environments
 
 on:
   pull_request:
+    # Previews only for PRs into develop (not release PRs into main / hotfix→main).
+    branches:
+      - develop
     types:
       - opened
       - reopened
@@ -20,7 +23,8 @@ concurrency:
 
 jobs:
   preview-scope:
-    if: github.event.action != 'closed'
+    # Skip main→develop sync PRs (no feature preview; diff would match everything on develop).
+    if: github.event.action != 'closed' && (github.base_ref != 'develop' || github.head_ref != 'main')
     runs-on: ubuntu-latest
     outputs:
       run_deploy: ${{ steps.check.outputs.run_deploy }}
@@ -44,7 +48,7 @@ jobs:
         run: echo "Skipping PR preview deploy (no app/package/supabase/pr-preview changes)."
 
   deploy-preview:
-    if: github.event.action != 'closed' && needs.preview-scope.outputs.run_deploy == 'true'
+    if: github.event.action != 'closed' && needs.preview-scope.outputs.run_deploy == 'true' && (github.base_ref != 'develop' || github.head_ref != 'main')
     needs: preview-scope
     runs-on: ubuntu-latest
     env:
@@ -334,7 +338,7 @@ jobs:
             }
 
   teardown-preview:
-    if: github.event.action == 'closed'
+    if: github.event.action == 'closed' && (github.base_ref != 'develop' || github.head_ref != 'main')
     runs-on: ubuntu-latest
     env:
       PREVIEW_STACK_NAME: ${{ vars.PR_PREVIEW_STACK_NAME }}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,5 +1,6 @@
 {
   "name": "mobile-app",
+  "private": true,
   "version": "1.0.0",
   "main": "index.js",
   "overrides": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,6 @@
 {
   "name": "web",
+  "private": true,
   "version": "1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

This PR is the **last promotion from `develop` to `main`**: it merges the current `develop` tip into `main` so `main` reflects what has already been integrated on `develop`.

### Included changes

- **#24** — Only build PR preview environments for PRs targeting `develop` (reduces noise and cost for unrelated base branches).
- **#26** — CI/CD and npm package publishing fixes (including private package handling and related workflow updates).

## Merge strategy

⚠️ **This PR targets `main`.** Use **Create a merge commit** (not squash merge) so history stays compatible with future branch work. Squashing to `main` can make later merges harder to reconcile.

See [ARCHITECTURE.md](https://github.com/Artificer-Innovations/BeakerStack/blob/develop/ARCHITECTURE.md#pull-request-process) for the full PR process.

## Checklist

- [x] Changes already reviewed and merged on `develop` via #24 and #26
- [x] CI expectations understood (preview workflow applies on `develop`; `main` release behavior updated as in #26)
