### PR TITLE
fix(ci): set NODE_AUTH_TOKEN for npm publish with setup-node registry-url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # Required with registry-url: npm reads NPM_CONFIG_USERCONFIG, not only changesets' ~/.npmrc.
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

`actions/setup-node` with `registry-url` writes npm auth to `${RUNNER_TEMP}/.npmrc` and sets `NPM_CONFIG_USERCONFIG` so **all** npm commands use that file. The token line uses `${NODE_AUTH_TOKEN}`. If `NODE_AUTH_TOKEN` is unset, setup-node exports a **placeholder** value (`XXXXX-XXXXX-XXXXX-XXXXX`), so `npm publish` never uses the real `NPM_TOKEN` that `changesets/action` adds to `~/.npmrc`—which npm ignores in this configuration.

This PR sets `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` at the **job** level on the Release workflow so publish uses the same secret as the temp userconfig.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactoring
- [ ] Other (please describe)

## Merge Strategy Reminder

⚠️ **Important**: Please use the correct merge strategy when merging this PR:

- **If this PR targets `develop`**: Use **"Squash and merge"** ✅
- **If this PR targets `main`**: Use **"Create a merge commit"** ✅ (NOT squash merge)

Squash merging to `main` can cause conflicts when merging `develop` → `main` later.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex code (short workflow comment only)
- [ ] Documentation updated (if needed)
- [x] No new warnings generated
- [ ] Tests added/updated (if needed)
- [x] All tests pass locally (pre-commit hooks on commit)

## Testing

- Confirmed root cause against [`actions/setup-node` auth behavior](https://github.com/actions/setup-node/blob/main/src/authutil.ts) (`NODE_AUTH_TOKEN` placeholder when unset).
- After merge to `develop` / `main`, confirm the next Release run shows a **real** masked `NODE_AUTH_TOKEN` in logs (not the literal `XXXXX-...` placeholder) and npm publish succeeds.

## Related Issues

N/A (npm publish `E404` on scoped package due to auth not reaching registry).
