### PR TITLE
Promote develop to main: fix Release npm auth (NODE_AUTH_TOKEN)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # Required with registry-url: npm reads NPM_CONFIG_USERCONFIG, not only changesets' ~/.npmrc.
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Promotion PR: merge **`develop`** into **`main`**.

Includes the Release workflow fix from [#28](https://github.com/Artificer-Innovations/BeakerStack/pull/28): set **`NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`** at the job level so [`actions/setup-node`](https://github.com/actions/setup-node) with `registry-url` does not fall back to the placeholder token. That placeholder caused `npm publish` / Changesets to hit the registry without the real npm token (`NPM_CONFIG_USERCONFIG` vs `~/.npmrc`).

## Merge this PR with

✅ **Create a merge commit** (do **not** squash)

This branch is `develop` → `main`; squash merging here can complicate later `develop` → `main` promotions. Same guidance as the repo bot comment and [ARCHITECTURE.md](https://github.com/Artificer-Innovations/BeakerStack/blob/develop/ARCHITECTURE.md#pull-request-process).

## Type of change

- [ ] Feature
- [x] Bug fix (CI / release)
- [ ] Documentation
- [ ] Refactoring
- [ ] Other

## Checklist

- [x] Change already reviewed on `develop` via [#28](https://github.com/Artificer-Innovations/BeakerStack/pull/28)
- [x] Release workflow documents why `NODE_AUTH_TOKEN` is required

## Testing

- Validated against `setup-node` auth behavior (`NODE_AUTH_TOKEN` / `NPM_CONFIG_USERCONFIG`).
- After merge to `main`, confirm the **Release** workflow on `main` can publish when appropriate.

## Related

- [#28](https://github.com/Artificer-Innovations/BeakerStack/pull/28) — original PR into `develop`
