### PR TITLE
Follow-up cleanup for the CodeQL/lint alignment work.

### DIFF
--- a/packages/shared-tests/__tests__/hooks/useAuth.native.test.ts
+++ b/packages/shared-tests/__tests__/hooks/useAuth.native.test.ts
@@ -555,12 +555,12 @@ describe('useAuth (Native)', () => {
       name: 'AuthError',
       status: 401,
     };
+    const { mockClient } = createMockSupabaseClient();
     (mockClient.auth.signInWithIdToken as jest.Mock).mockResolvedValueOnce({
       data: { user: null, session: null },
       error: authError,
     });
 
-    const { mockClient } = createMockSupabaseClient();
     const { result } = renderHook(() => useAuth(mockClient));
 
     await waitFor(() => {

--- a/packages/shared/src/components/profile/AvatarUpload.native.tsx
+++ b/packages/shared/src/components/profile/AvatarUpload.native.tsx
@@ -253,7 +253,7 @@ export function AvatarUpload({
         blob = new Blob([uint8Array], { type: mimeType });
 
         // Verify blob has content
-        if (!blob || blob.size === 0) {
+        if (blob.size === 0) {
           throw new Error('Image file is empty or could not be converted');
         }
 

--- a/tests/utils/test-database.ts
+++ b/tests/utils/test-database.ts
@@ -10,9 +10,9 @@ import { SupabaseClient } from '@supabase/supabase-js';
  * Falls back to local defaults if not set
  */
 export function getTestSupabaseConfig() {
-  const supabaseUrl = process.env.SUPABASE_URL || 'http://127.0.0.1:54321';
+  const supabaseUrl = process.env['SUPABASE_URL'] || 'http://127.0.0.1:54321';
   const supabaseAnonKey =
-    process.env.SUPABASE_ANON_KEY ||
+    process.env['SUPABASE_ANON_KEY'] ||
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
 
   return { supabaseUrl, supabaseAnonKey };
@@ -29,7 +29,7 @@ export async function cleanupTestUser(
 ): Promise<void> {
   try {
     const email = credentials?.email ?? `test-${userId}@example.com`;
-    const password = credentials?.password ?? process.env.TEST_PASSWORD;
+    const password = credentials?.password ?? process.env['TEST_PASSWORD'];
 
     // Without a stable password source we cannot authenticate for profile cleanup.
     if (!password) {


### PR DESCRIPTION
## Summary

Follow-up cleanup for the CodeQL/lint alignment work in [#33](https://github.com/Artificer-Innovations/BeakerStack/pull/33).

## What changed

- **`useAuth.native` test ordering fix:** initialize `mockClient` before stubbing `signInWithIdToken` in `packages/shared-tests/__tests__/hooks/useAuth.native.test.ts`.
- **Avatar upload guard cleanup:** simplify an always-truthy check in `packages/shared/src/components/profile/AvatarUpload.native.tsx` (`if (blob.size === 0)` instead of `if (!blob || blob.size === 0)`).
- **Test env access consistency:** switched env reads to bracket notation in `tests/utils/test-database.ts` (`process.env['SUPABASE_URL']`, etc.) for lint/code-quality consistency.

## Testing

- `npm run lint`
- `npm run lint:strict`

## Merge strategy reminder

This PR targets **`develop`**. Use **Squash and merge**.
