### PR TITLE
fix: GitHub Code Quality AI findings (DebugTools, test helpers)

### DIFF
--- a/apps/mobile/src/components/DebugTools.tsx
+++ b/apps/mobile/src/components/DebugTools.tsx
@@ -55,7 +55,7 @@ export function DebugTools() {
         clearTimeout(clickTimeoutRef.current);
       }
     };
-  }, [clickCount]);
+  }, []);
 
   if (!isVisible) {
     return (
@@ -441,9 +441,14 @@ function ValidationTestFormMobile() {
   >(null);
 
   const handleFieldChange = (field: keyof ProfileFormInput, value: string) => {
-    setFormData(prev => ({ ...prev, [field]: value }));
+    setFormData(prev =>
+      prev[field] === value ? prev : { ...prev, [field]: value }
+    );
     if (errors[field]) {
       setErrors(prev => {
+        if (!prev[field]) {
+          return prev;
+        }
         const newErrors = { ...prev };
         delete newErrors[field];
         return newErrors;
@@ -456,6 +461,9 @@ function ValidationTestFormMobile() {
     try {
       profileFormSchema.parse({ ...formData, [field]: value });
       setErrors(prev => {
+        if (!prev[field]) {
+          return prev;
+        }
         const newErrors = { ...prev };
         delete newErrors[field];
         return newErrors;

--- a/tests/e2e/shared/test-data.ts
+++ b/tests/e2e/shared/test-data.ts
@@ -18,7 +18,7 @@ let resolvedTestPassword: string | undefined;
  */
 export function getResolvedTestPassword(): string {
   if (resolvedTestPassword === undefined) {
-    const fromEnv = process.env['TEST_PASSWORD']?.trim();
+    const fromEnv = process.env.TEST_PASSWORD?.trim();
     resolvedTestPassword =
       fromEnv && fromEnv.length > 0 ? fromEnv : generateTestPassword();
   }

--- a/tests/e2e/shared/test-data.ts
+++ b/tests/e2e/shared/test-data.ts
@@ -3,7 +3,7 @@
  * Provides reusable test data that can be used across E2E test flows
  */
 
-import { randomUUID } from 'node:crypto';
+import { generateE2ETestEmail } from '../../utils/test-emails';
 import { generateTestPassword } from '../../utils/test-helpers';
 
 /** Email for the seeded “valid login” E2E user (password from {@link getResolvedTestPassword}). */
@@ -37,11 +37,11 @@ export function getPredefinedValidLoginUser(): TestUser {
 }
 
 /**
- * Generate a unique test email.
- * Uses crypto.randomUUID() to avoid collisions in parallel test runs.
+ * Generate a unique test email for E2E flows.
+ * Uses {@link generateE2ETestEmail}; integration tests use {@link generateIntegrationTestEmail}.
  */
 export function generateTestEmail(): string {
-  return `e2e-test-${randomUUID()}@example.com`;
+  return generateE2ETestEmail();
 }
 
 /**

--- a/tests/process-env.d.ts
+++ b/tests/process-env.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Declares environment variables read via dot notation in `tests/`.
+ *
+ * Root `tsconfig.json` sets `noPropertyAccessFromIndexSignature`, so
+ * `process.env.SUPABASE_URL` (etc.) requires an explicit `ProcessEnv` property;
+ * bracket access would also work but is inconsistent with `test-clients.ts`.
+ */
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      SUPABASE_URL?: string;
+      SUPABASE_ANON_KEY?: string;
+      SUPABASE_SERVICE_ROLE_KEY?: string;
+      TEST_PASSWORD?: string;
+    }
+  }
+}
+
+export {};

--- a/tests/utils/test-database.ts
+++ b/tests/utils/test-database.ts
@@ -5,6 +5,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { SupabaseClient } from '@supabase/supabase-js';
+import { generateIntegrationTestEmail } from './test-emails';
 import {
   LOCAL_SUPABASE_DEMO_ANON_KEY,
   assertLocalSupabaseEnvironment,
@@ -16,9 +17,9 @@ import {
  * local `supabase start` instance (see ./supabase-cli-defaults.ts).
  */
 export function getTestSupabaseConfig() {
-  const supabaseUrl = process.env['SUPABASE_URL'] || 'http://127.0.0.1:54321';
+  const supabaseUrl = process.env.SUPABASE_URL || 'http://127.0.0.1:54321';
   const supabaseAnonKey =
-    process.env['SUPABASE_ANON_KEY'] || LOCAL_SUPABASE_DEMO_ANON_KEY;
+    process.env.SUPABASE_ANON_KEY || LOCAL_SUPABASE_DEMO_ANON_KEY;
 
   // Run the local guard whenever the resolved key is the public CLI demo JWT,
   // including when someone copies it into the environment alongside a
@@ -41,7 +42,7 @@ export async function cleanupTestUser(
 ): Promise<void> {
   try {
     const email = credentials?.email ?? `test-${userId}@example.com`;
-    const password = credentials?.password ?? process.env['TEST_PASSWORD'];
+    const password = credentials?.password ?? process.env.TEST_PASSWORD;
 
     // Without a stable password source we cannot authenticate for profile cleanup.
     if (!password) {
@@ -66,11 +67,11 @@ export async function cleanupTestUser(
 }
 
 /**
- * Generate a unique test email.
- * Uses crypto.randomUUID() to avoid collisions in parallel test runs.
+ * Generate a unique test email for integration tests.
+ * Uses {@link generateIntegrationTestEmail}; E2E uses {@link generateE2ETestEmail} in test-emails.
  */
 export function generateTestEmail(): string {
-  return `test-${randomUUID()}@example.com`;
+  return generateIntegrationTestEmail();
 }
 
 /**

--- a/tests/utils/test-emails.ts
+++ b/tests/utils/test-emails.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared test email generators for integration and E2E suites.
+ *
+ * Two prefixes are intentional: integration helpers use `test-` while E2E uses
+ * `e2e-test-` so logs and database rows are easy to attribute to the suite.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+/** Unique email for integration / API tests (see {@link generateTestEmail} in test-database). */
+export function generateIntegrationTestEmail(): string {
+  return `test-${randomUUID()}@example.com`;
+}
+
+/** Unique email for Playwright/Maestro E2E flows (see {@link generateTestEmail} in e2e test-data). */
+export function generateE2ETestEmail(): string {
+  return `e2e-test-${randomUUID()}@example.com`;
+}


### PR DESCRIPTION
## Summary

Addresses [GitHub Code Quality](https://github.com/Artificer-Innovations/BeakerStack/security/quality/ai-findings) AI findings: React hook cleanup and form updates in the mobile debug panel, consistent `process.env` access in integration test config, and a single shared implementation for integration vs E2E test email prefixes.

## Changes

- **`apps/mobile/src/components/DebugTools.tsx`**
  - Run timeout cleanup only on unmount (`useEffect` with `[]`) so the 2s idle tap counter reset is not cleared on every click.
  - Use functional `setFormData` / `setErrors` updates that return the previous state when unchanged to avoid unnecessary updates while typing in the validation demo form.
- **`tests/utils/test-database.ts`**
  - Use dot notation for `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `TEST_PASSWORD`.
  - Delegate `generateTestEmail()` to the shared integration helper.
- **`tests/utils/test-emails.ts`** (new)
  - `generateIntegrationTestEmail()` (`test-…`) and `generateE2ETestEmail()` (`e2e-test-…`) with JSDoc explaining why both prefixes exist.
- **`tests/e2e/shared/test-data.ts`**
  - `generateTestEmail()` delegates to `generateE2ETestEmail()`.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [x] Refactoring
- [ ] Other (please describe)

## Merge Strategy Reminder

⚠️ **Important**: Please use the correct merge strategy when merging this PR:

- **If this PR targets `develop`**: Use **"Squash and merge"** ✅
- **If this PR targets `main`**: Use **"Create a merge commit"** ✅ (NOT squash merge)

Squash merging to `main` can cause conflicts when merging `develop` → `main` later.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if needed)
- [x] No new warnings generated
- [ ] Tests added/updated (if needed)
- [x] All tests pass locally (mobile `lint` + `type-check`; root `lint:repo`)

## Testing

- `cd apps/mobile && npm run lint && npm run type-check`
- `npm run lint:repo` (from repo root)

## Related Issues

N/A