### PR TITLE
docs(tests): disambiguate JSDoc @link in test-emails

### DIFF
--- a/tests/utils/test-emails.ts
+++ b/tests/utils/test-emails.ts
@@ -7,12 +7,18 @@
 
 import { randomUUID } from 'node:crypto';
 
-/** Unique email for integration / API tests (see {@link generateTestEmail} in test-database). */
+/**
+ * Unique email for integration / API tests.
+ * Thin wrapper target: {@link import('./test-database').generateTestEmail}.
+ */
 export function generateIntegrationTestEmail(): string {
   return `test-${randomUUID()}@example.com`;
 }
 
-/** Unique email for Playwright/Maestro E2E flows (see {@link generateTestEmail} in e2e test-data). */
+/**
+ * Unique email for Playwright/Maestro E2E flows.
+ * Thin wrapper target: {@link import('../e2e/shared/test-data').generateTestEmail}.
+ */
 export function generateE2ETestEmail(): string {
   return `e2e-test-${randomUUID()}@example.com`;
 }


### PR DESCRIPTION
## Summary

Follow-up to [GitHub Code Quality](https://github.com/Artificer-Innovations/BeakerStack/security/quality/ai-findings) feedback on [`tests/utils/test-emails.ts`](tests/utils/test-emails.ts): `{@link generateTestEmail}` was ambiguous because both [`tests/utils/test-database.ts`](tests/utils/test-database.ts) and [`tests/e2e/shared/test-data.ts`](tests/e2e/shared/test-data.ts) export a function with that name.

JSDoc now uses module-qualified links so IDEs and doc tooling resolve the correct symbol:

- `{@link import('./test-database').generateTestEmail}`
- `{@link import('../e2e/shared/test-data').generateTestEmail}`

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Refactoring
- [ ] Other (please describe)

## Merge Strategy Reminder

⚠️ **Important**: Please use the correct merge strategy when merging this PR:

- **If this PR targets `develop`**: Use **"Squash and merge"** ✅
- **If this PR targets `main`**: Use **"Create a merge commit"** ✅ (NOT squash merge)

Squash merging to `main` can cause conflicts when merging `develop` → `main` later.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if needed)
- [x] No new warnings generated
- [ ] Tests added/updated (if needed)
- [x] All tests pass locally (`npx eslint tests/utils/test-emails.ts`)

## Testing

- `npx eslint tests/utils/test-emails.ts --resolve-plugins-relative-to .`

## Related Issues

N/A