### PR TITLE
fix: remove self-referencing JSDoc links in test-emails.ts

### DIFF
--- a/tests/utils/test-emails.ts
+++ b/tests/utils/test-emails.ts
@@ -7,18 +7,10 @@
 
 import { randomUUID } from 'node:crypto';
 
-/**
- * Unique email for integration / API tests.
- * Thin wrapper target: {@link generateIntegrationTestEmail}; see `./test-database`.
- */
 export function generateIntegrationTestEmail(): string {
   return `test-${randomUUID()}@example.com`;
 }
 
-/**
- * Unique email for Playwright/Maestro E2E flows.
- * Thin wrapper target: {@link generateE2ETestEmail} in `../e2e/shared/test-data`.
- */
 export function generateE2ETestEmail(): string {
   return `e2e-test-${randomUUID()}@example.com`;
 }


### PR DESCRIPTION
Closes #47

## What

Removed per-function JSDoc blocks from `tests/utils/test-emails.ts`. The two `{@link}` tags each referenced the function being documented — a self-link that adds no information and triggers the AI code quality warning.

## Why this approach

The issue notes that "if the easier way to fix this is to say less, that's a fine answer" — and it is. The file-level comment already explains the two-prefix rationale (`test-` vs `e2e-test-`). The function names are self-documenting. The per-function JSDoc blocks were redundant and actively misleading.

## What was kept

The file-level JSDoc is unchanged — it's the right place to explain the dual-prefix design decision.