### PR TITLE
feat(landing): expand feature content and strengthen CTAs

### DIFF
--- a/apps/web/src/components/landing/sections/FeatureGrid.tsx
+++ b/apps/web/src/components/landing/sections/FeatureGrid.tsx
@@ -34,6 +34,16 @@ export function FeatureGrid({ config }: FeatureGridProps) {
                 <p className='text-sm text-gray-600 dark:text-gray-400 leading-relaxed'>
                   {item.body}
                 </p>
+                {item.ctaLabel && item.ctaHref && (
+                  <a
+                    href={item.ctaHref}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    className='mt-3 inline-block text-sm font-medium text-primary-600 dark:text-primary-400 hover:underline'
+                  >
+                    {item.ctaLabel} →
+                  </a>
+                )}
               </div>
             );
           })}

--- a/apps/web/src/components/landing/sections/FeatureGrid.tsx
+++ b/apps/web/src/components/landing/sections/FeatureGrid.tsx
@@ -37,8 +37,9 @@ export function FeatureGrid({ config }: FeatureGridProps) {
                 {item.ctaLabel && item.ctaHref && (
                   <a
                     href={item.ctaHref}
-                    target='_blank'
-                    rel='noopener noreferrer'
+                    {...(item.ctaHref.startsWith('http')
+                      ? { target: '_blank', rel: 'noopener noreferrer' }
+                      : {})}
                     className='mt-3 inline-block text-sm font-medium text-primary-600 dark:text-primary-400 hover:underline'
                   >
                     {item.ctaLabel} →

--- a/apps/web/src/components/landing/sections/FeatureRows.tsx
+++ b/apps/web/src/components/landing/sections/FeatureRows.tsx
@@ -10,6 +10,7 @@ export function FeatureRows({ config }: FeatureRowsProps) {
       <div className='max-w-[1200px] mx-auto px-6 space-y-24'>
         {config.map(row => {
           const imageFirst = row.mediaSide === 'left';
+          const isExternal = row.ctaHref.startsWith('http');
           return (
             <div
               key={row.title}
@@ -38,6 +39,9 @@ export function FeatureRows({ config }: FeatureRowsProps) {
                 </p>
                 <a
                   href={row.ctaHref}
+                  {...(isExternal
+                    ? { target: '_blank', rel: 'noopener noreferrer' }
+                    : {})}
                   className='text-sm font-medium text-primary-600 dark:text-primary-400 hover:underline'
                 >
                   {row.ctaLabel} →

--- a/apps/web/src/components/landing/sections/FinalCTA.tsx
+++ b/apps/web/src/components/landing/sections/FinalCTA.tsx
@@ -15,12 +15,24 @@ export function FinalCTA({ config }: FinalCTAProps) {
         <p className='text-lg text-gray-600 dark:text-gray-400 mb-8 max-w-xl mx-auto'>
           {config.subhead}
         </p>
-        <Link
-          to={config.ctaHref}
-          className='inline-flex items-center px-6 py-3 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-lg transition-colors'
-        >
-          {config.ctaLabel}
-        </Link>
+        <div className='flex flex-col sm:flex-row items-center justify-center gap-4'>
+          <Link
+            to={config.ctaHref}
+            className='inline-flex items-center px-6 py-3 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-lg transition-colors'
+          >
+            {config.ctaLabel}
+          </Link>
+          {config.secondaryCta && (
+            <a
+              href={config.secondaryCta.href}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='inline-flex items-center px-6 py-3 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 rounded-lg transition-colors'
+            >
+              {config.secondaryCta.label}
+            </a>
+          )}
+        </div>
       </div>
     </section>
   );

--- a/apps/web/src/config/landing.ts
+++ b/apps/web/src/config/landing.ts
@@ -7,6 +7,9 @@ import {
   Smartphone,
   CreditCard,
   Github,
+  GitBranch,
+  TestTube,
+  Database,
 } from 'lucide-react';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -25,6 +28,8 @@ export interface FeatureGridItem {
   icon: LucideIcon;
   title: string;
   body: string;
+  ctaLabel?: string;
+  ctaHref?: string;
 }
 
 export interface FeatureRow {
@@ -99,6 +104,7 @@ export interface LandingConfig {
     subhead: string;
     ctaLabel: string;
     ctaHref: string;
+    secondaryCta?: Cta;
   };
   footer: {
     columns: FooterColumn[];
@@ -127,7 +133,7 @@ export const landingConfig: LandingConfig = {
     eyebrow: 'Open source SaaS template',
     headline: 'Everything you need to ship a real product.',
     subhead:
-      'BeakerStack gives you auth, billing, and a cross-platform React foundation — wired together and ready to customize.',
+      'BeakerStack gives you auth, billing, and a cross-platform React foundation — with a three-environment CI/CD pipeline, PR previews, and a layered test suite ready for production.',
     primaryCta: { label: 'Get started free', href: '/signup' },
     secondaryCta: { label: 'See features', href: '#features' },
     mediaSrc: 'https://placehold.co/600x338?text=BeakerStack',
@@ -154,9 +160,9 @@ export const landingConfig: LandingConfig = {
         body: 'Shared business logic between your React web app and React Native mobile app.',
       },
       {
-        icon: Shield,
-        title: 'Row-level security',
-        body: 'Supabase RLS policies pre-configured for multi-tenant data isolation.',
+        icon: Database,
+        title: 'Supabase backend',
+        body: 'Postgres, Auth, Storage, and Edge Functions — with RLS-oriented patterns, migrations at repo root, generated TypeScript types from the schema, and local Supabase via Docker for dev/test parity.',
       },
       {
         icon: Code2,
@@ -169,12 +175,22 @@ export const landingConfig: LandingConfig = {
         body: 'Track feature usage per user, enforce limits, and surface quota data in the UI.',
       },
       {
+        icon: GitBranch,
+        title: 'CI/CD pipeline',
+        body: 'Path-based PR previews on S3/CloudFront, a staging environment on the develop branch, and production on main — with EAS Update channels aligned for mobile.',
+      },
+      {
+        icon: TestTube,
+        title: 'Test discipline',
+        body: 'Unit, integration, E2E, and database test layers — colocated with the code they test and documented with a clear decision matrix.',
+      },
+      {
         icon: Github,
         title: 'Free and open source',
         body: 'MIT licensed. Fork it, own the code, and ship your product. No vendor lock-in, no royalties.',
         ctaLabel: 'View on GitHub',
         ctaHref: 'https://github.com/Artificer-Innovations/BeakerStack',
-      } as FeatureGridItem & { ctaLabel: string; ctaHref: string },
+      },
     ],
   },
   featureRows: [
@@ -189,20 +205,38 @@ export const landingConfig: LandingConfig = {
     },
     {
       title: 'Web and mobile from a single codebase.',
-      body: 'Shared auth logic, shared billing hooks, shared business rules — your React web app and React Native mobile app stay in sync without duplicating code.',
+      body: 'Shared auth logic, shared billing hooks, shared business rules — your React web app and React Native mobile app stay in sync without duplicating code. 40–60% of the codebase is shared across platforms.',
       ctaLabel: 'Learn about mobile',
       ctaHref: '#features',
       mediaSrc: 'https://placehold.co/560x315?text=Mobile+App',
       mediaAlt: 'Mobile app screenshot',
       mediaSide: 'left',
     },
+    {
+      title: 'Environments that match your shipping workflow.',
+      body: 'Three Supabase databases — local Docker, shared PR testing, and staging — mirror your branching model so migrations are validated before they touch production. PR previews deploy to path-based S3/CloudFront URLs automatically. EAS Update channels give mobile the same preview → staging → production story.',
+      ctaLabel: 'Read the architecture docs',
+      ctaHref: 'https://github.com/Artificer-Innovations/BeakerStack/blob/main/ARCHITECTURE.md',
+      mediaSrc: 'https://placehold.co/560x315?text=Environments',
+      mediaAlt: 'Three-environment pipeline diagram',
+      mediaSide: 'right',
+    },
+    {
+      title: 'Set up in minutes. Documented for the long haul.',
+      body: 'A single `npm run setup` command provisions your local environment. QUICKSTART, ARCHITECTURE, and per-topic guides (OAuth, Stripe, testing) cover every decision. Environment variables and secrets follow a consistent layout that maps directly to GitHub Actions — no hunting for where a key goes.',
+      ctaLabel: 'Read the quickstart',
+      ctaHref: 'https://github.com/Artificer-Innovations/BeakerStack/blob/main/QUICKSTART.md',
+      mediaSrc: 'https://placehold.co/560x315?text=Setup',
+      mediaAlt: 'Setup guide screenshot',
+      mediaSide: 'left',
+    },
   ],
   socialProof: {
     kind: 'metrics',
     items: [
-      { metric: '3 platforms', label: 'Web, iOS, and Android from one repo' },
-      { metric: '< 5 minutes', label: 'From clone to running locally' },
-      { metric: '100% open source', label: 'MIT licensed, no vendor lock-in' },
+      { metric: '40–60%', label: 'Code shared between web and mobile' },
+      { metric: '3 environments', label: 'PR preview, staging, and production' },
+      { metric: 'MIT licensed', label: '100% open source, no vendor lock-in' },
     ],
   },
   pricing: {
@@ -249,6 +283,10 @@ export const landingConfig: LandingConfig = {
     subhead: 'Clone BeakerStack, swap the config, and ship your product.',
     ctaLabel: 'Get started free',
     ctaHref: '/signup',
+    secondaryCta: {
+      label: 'View on GitHub',
+      href: 'https://github.com/Artificer-Innovations/BeakerStack',
+    },
   },
   footer: {
     columns: [

--- a/apps/web/src/config/landing.ts
+++ b/apps/web/src/config/landing.ts
@@ -1,7 +1,6 @@
 import type { LucideIcon } from 'lucide-react';
 import {
   Zap,
-  Shield,
   BarChart3,
   Code2,
   Smartphone,


### PR DESCRIPTION
Closes #54

## What

Expands the public landing page to communicate BeakerStack's full value proposition — CI/CD pipeline, environments, Supabase backend depth, test discipline, and operator setup story — alongside three small component improvements.

## Plan (approved)

> All copy lives in `landing.ts` config. Three small component edits handle rendering additions: `FeatureGrid.tsx` gets optional per-item CTA rendering, `FinalCTA.tsx` gets an optional secondary CTA, and `FeatureRows.tsx` gets conditional `target="_blank" rel="noopener noreferrer"` for external hrefs.

## Changes

### `landing.ts`
- **Hero subhead** strengthened to name the three-environment pipeline, PR previews, and layered test suite
- **Feature grid** expanded from 7 → 9 items (3×3): standalone "Row-level security" replaced with broader **"Supabase backend"** card covering Postgres, Auth, Storage, Edge Functions, migrations, generated types, RLS patterns, and local Docker; added **"CI/CD pipeline"** (path-based PR previews, staging, production, EAS channels) and **"Test discipline"** (unit, integration, E2E, database layers)
- **`FeatureGridItem` type** gains optional `ctaLabel?`/`ctaHref?` — OSS card CTA now renders
- **Feature rows** expanded from 2 → 4: added **"Environments that match your shipping workflow"** (3 Supabase databases, path-based previews, EAS channels → links to ARCHITECTURE.md) and **"Set up in minutes. Documented for the long haul"** (setup command, guides, secrets layout → links to QUICKSTART.md)
- **Social proof metrics** updated to verifiable figures from `ARCHITECTURE.md`: "40–60%" code shared, "3 environments", "MIT licensed"
- **`finalCta.secondaryCta?`** type added; config adds "View on GitHub" secondary CTA

### `FeatureGrid.tsx`
Renders optional `ctaLabel`/`ctaHref` per item as `<a target="_blank" rel="noopener noreferrer">`

### `FinalCTA.tsx`
Renders optional `secondaryCta` as `<a target="_blank" rel="noopener noreferrer">` alongside the primary `<Link>`; button pair uses flexbox layout for mobile stacking

### `FeatureRows.tsx`
Adds conditional `target="_blank" rel="noopener noreferrer"` on row CTAs when `href.startsWith('http')` — fixes open-link-safety for the two new rows pointing to GitHub docs

## Test evidence

All type additions are backwards-compatible (optional fields only). Existing `HomePage.test.tsx` tests are unaffected — component props did not change, config is mocked in tests. TypeScript compilation validates the new types.

## Deviations from plan

None.