### PR TITLE
test(landing): unit tests for all landing page sections (#59)

### DIFF
--- a/apps/web/src/components/landing/sections/__tests__/FAQ.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/FAQ.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FAQ } from '../FAQ';
+
+const config = {
+  heading: 'Frequently asked questions',
+  items: [
+    { q: 'What is BeakerStack?', a: 'A starter kit.' },
+    { q: 'Is it free?', a: 'Yes, there is a free tier.' },
+  ],
+};
+
+describe('FAQ', () => {
+  it('renders section heading', () => {
+    render(<FAQ config={config} />);
+    expect(
+      screen.getByRole('heading', { name: 'Frequently asked questions' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders each question', () => {
+    render(<FAQ config={config} />);
+    expect(screen.getByText('What is BeakerStack?')).toBeInTheDocument();
+    expect(screen.getByText('Is it free?')).toBeInTheDocument();
+  });
+
+  it('renders each answer in the DOM', () => {
+    render(<FAQ config={config} />);
+    expect(screen.getByText('A starter kit.')).toBeInTheDocument();
+    expect(screen.getByText('Yes, there is a free tier.')).toBeInTheDocument();
+  });
+
+  it('renders all items when multiple are provided', () => {
+    render(<FAQ config={config} />);
+    const details = document.querySelectorAll('details');
+    expect(details).toHaveLength(2);
+  });
+
+  it('renders empty list without error', () => {
+    render(<FAQ config={{ heading: 'FAQ', items: [] }} />);
+    expect(screen.getByRole('heading', { name: 'FAQ' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/FeatureGrid.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/FeatureGrid.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FeatureGrid } from '../FeatureGrid';
+
+const MockIcon = () => <svg data-testid='mock-icon' />;
+
+const base = {
+  heading: 'Everything wired.',
+  subhead: 'No hidden parts.',
+  items: [
+    { icon: MockIcon, title: 'Auth', body: 'Auth out of the box.' },
+    { icon: MockIcon, title: 'Billing', body: 'Billing that works.' },
+  ],
+};
+
+describe('FeatureGrid', () => {
+  it('renders heading and subhead', () => {
+    render(<FeatureGrid config={base} />);
+    expect(screen.getByRole('heading', { name: 'Everything wired.' })).toBeInTheDocument();
+    expect(screen.getByText('No hidden parts.')).toBeInTheDocument();
+  });
+
+  it('renders all items with title and body', () => {
+    render(<FeatureGrid config={base} />);
+    expect(screen.getByText('Auth')).toBeInTheDocument();
+    expect(screen.getByText('Auth out of the box.')).toBeInTheDocument();
+    expect(screen.getByText('Billing')).toBeInTheDocument();
+    expect(screen.getByText('Billing that works.')).toBeInTheDocument();
+  });
+
+  it('renders per-item CTA when both ctaLabel and ctaHref are provided', () => {
+    const config = {
+      ...base,
+      items: [
+        {
+          icon: MockIcon,
+          title: 'OSS',
+          body: 'Free.',
+          ctaLabel: 'View on GitHub',
+          ctaHref: 'https://github.com/example',
+        },
+      ],
+    };
+    render(<FeatureGrid config={config} />);
+    const link = screen.getByRole('link', { name: /view on github/i });
+    expect(link).toHaveAttribute('href', 'https://github.com/example');
+  });
+
+  it('adds target=_blank and rel=noopener for external CTA hrefs', () => {
+    const config = {
+      ...base,
+      items: [
+        {
+          icon: MockIcon,
+          title: 'OSS',
+          body: 'Free.',
+          ctaLabel: 'GitHub',
+          ctaHref: 'https://github.com/example',
+        },
+      ],
+    };
+    render(<FeatureGrid config={config} />);
+    const link = screen.getByRole('link', { name: /github/i });
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('does not add target=_blank for internal CTA hrefs', () => {
+    const config = {
+      ...base,
+      items: [
+        {
+          icon: MockIcon,
+          title: 'Features',
+          body: 'See them.',
+          ctaLabel: 'See features',
+          ctaHref: '#features',
+        },
+      ],
+    };
+    render(<FeatureGrid config={config} />);
+    const link = screen.getByRole('link', { name: /see features/i });
+    expect(link).not.toHaveAttribute('target');
+  });
+
+  it('does not render CTA when only ctaLabel is set', () => {
+    const config = {
+      ...base,
+      items: [{ icon: MockIcon, title: 'X', body: 'Y', ctaLabel: 'Click' }],
+    };
+    render(<FeatureGrid config={config} />);
+    expect(screen.queryByRole('link', { name: 'Click' })).not.toBeInTheDocument();
+  });
+
+  it('renders empty grid without error', () => {
+    render(<FeatureGrid config={{ ...base, items: [] }} />);
+    expect(screen.getByRole('heading', { name: 'Everything wired.' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/FeatureRows.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/FeatureRows.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FeatureRows } from '../FeatureRows';
+
+const row = {
+  title: 'Billing that ships.',
+  body: 'Plan gating, metering, and a portal.',
+  ctaLabel: 'See docs',
+  ctaHref: '#pricing',
+  mediaSrc: 'https://example.com/billing.png',
+  mediaAlt: 'Billing screenshot',
+  mediaSide: 'right' as const,
+};
+
+const externalRow = {
+  ...row,
+  title: 'Architecture docs',
+  ctaLabel: 'Read docs',
+  ctaHref: 'https://github.com/example/ARCHITECTURE.md',
+  mediaSide: 'left' as const,
+};
+
+describe('FeatureRows', () => {
+  it('renders row title and body', () => {
+    render(<FeatureRows config={[row]} />);
+    expect(screen.getByRole('heading', { name: 'Billing that ships.' })).toBeInTheDocument();
+    expect(screen.getByText('Plan gating, metering, and a portal.')).toBeInTheDocument();
+  });
+
+  it('renders image with correct alt text', () => {
+    render(<FeatureRows config={[row]} />);
+    expect(screen.getByRole('img', { name: 'Billing screenshot' })).toBeInTheDocument();
+  });
+
+  it('renders CTA link with correct label', () => {
+    render(<FeatureRows config={[row]} />);
+    const link = screen.getByRole('link', { name: /see docs/i });
+    expect(link).toHaveAttribute('href', '#pricing');
+  });
+
+  it('does not add target=_blank for internal CTA', () => {
+    render(<FeatureRows config={[row]} />);
+    const link = screen.getByRole('link', { name: /see docs/i });
+    expect(link).not.toHaveAttribute('target');
+  });
+
+  it('adds target=_blank and rel=noopener for external CTA', () => {
+    render(<FeatureRows config={[externalRow]} />);
+    const link = screen.getByRole('link', { name: /read docs/i });
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders multiple rows', () => {
+    render(<FeatureRows config={[row, externalRow]} />);
+    expect(screen.getByRole('heading', { name: 'Billing that ships.' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Architecture docs' })).toBeInTheDocument();
+  });
+
+  it('renders empty list without error', () => {
+    const { container } = render(<FeatureRows config={[]} />);
+    expect(container.querySelector('section')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/FinalCTA.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/FinalCTA.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { FinalCTA } from '../FinalCTA';
+
+const base = {
+  headline: 'Start building today.',
+  subhead: 'Everything wired in.',
+  ctaLabel: 'Get started free',
+  ctaHref: '/signup',
+};
+
+function renderFinalCTA(overrides = {}) {
+  return render(
+    <MemoryRouter>
+      <FinalCTA config={{ ...base, ...overrides }} />
+    </MemoryRouter>
+  );
+}
+
+describe('FinalCTA', () => {
+  it('renders headline', () => {
+    renderFinalCTA();
+    expect(
+      screen.getByRole('heading', { name: 'Start building today.' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders subhead', () => {
+    renderFinalCTA();
+    expect(screen.getByText('Everything wired in.')).toBeInTheDocument();
+  });
+
+  it('renders primary CTA with correct label and href', () => {
+    renderFinalCTA();
+    const link = screen.getByRole('link', { name: 'Get started free' });
+    expect(link).toHaveAttribute('href', '/signup');
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/Hero.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/Hero.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Hero } from '../Hero';
+
+const base = {
+  headline: 'Build something great.',
+  subhead: 'The subhead text.',
+  primaryCta: { label: 'Get started', href: '/signup' },
+  mediaSrc: 'https://example.com/img.png',
+  mediaAlt: 'Product screenshot',
+};
+
+function renderHero(overrides = {}) {
+  return render(
+    <MemoryRouter>
+      <Hero config={{ ...base, ...overrides }} />
+    </MemoryRouter>
+  );
+}
+
+describe('Hero', () => {
+  it('renders the headline', () => {
+    renderHero();
+    expect(screen.getByRole('heading', { level: 1, name: /build something great/i })).toBeInTheDocument();
+  });
+
+  it('renders the subhead', () => {
+    renderHero();
+    expect(screen.getByText('The subhead text.')).toBeInTheDocument();
+  });
+
+  it('renders the primary CTA with correct href', () => {
+    renderHero();
+    const link = screen.getByRole('link', { name: 'Get started' });
+    expect(link).toHaveAttribute('href', '/signup');
+  });
+
+  it('renders the hero image with correct alt text', () => {
+    renderHero();
+    expect(screen.getByRole('img', { name: 'Product screenshot' })).toBeInTheDocument();
+  });
+
+  it('renders eyebrow when provided', () => {
+    renderHero({ eyebrow: 'Open source' });
+    expect(screen.getByText('Open source')).toBeInTheDocument();
+  });
+
+  it('does not render eyebrow when absent', () => {
+    renderHero();
+    expect(screen.queryByText('Open source')).not.toBeInTheDocument();
+  });
+
+  it('renders secondary CTA when provided', () => {
+    renderHero({ secondaryCta: { label: 'See features', href: '#features' } });
+    expect(screen.getByRole('link', { name: 'See features' })).toHaveAttribute('href', '#features');
+  });
+
+  it('does not render secondary CTA when absent', () => {
+    renderHero();
+    expect(screen.queryByRole('link', { name: 'See features' })).not.toBeInTheDocument();
+  });
+
+  it('renders trust strip when provided', () => {
+    renderHero({ trustStrip: 'Built on React and Supabase.' });
+    expect(screen.getByText('Built on React and Supabase.')).toBeInTheDocument();
+  });
+
+  it('does not render trust strip when absent', () => {
+    renderHero();
+    expect(screen.queryByText(/built on/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { Nav } from '../Nav';
+
+const config = {
+  brand: { name: 'TestApp', tagline: 'tagline' },
+  links: [
+    { label: 'Features', href: '#features' },
+    { label: 'Pricing', href: '#pricing' },
+  ],
+  signInHref: '/login',
+  signUpHref: '/signup',
+};
+
+function renderNav(overrides = {}) {
+  return render(
+    <MemoryRouter>
+      <Nav config={{ ...config, ...overrides }} />
+    </MemoryRouter>
+  );
+}
+
+describe('Nav', () => {
+  it('renders the brand name', () => {
+    renderNav();
+    expect(screen.getByText('TestApp')).toBeInTheDocument();
+  });
+
+  it('renders nav links with correct hrefs', () => {
+    renderNav();
+    const featuresLink = screen.getByRole('link', { name: 'Features' });
+    expect(featuresLink).toHaveAttribute('href', '#features');
+    const pricingLink = screen.getByRole('link', { name: 'Pricing' });
+    expect(pricingLink).toHaveAttribute('href', '#pricing');
+  });
+
+  it('renders sign in link pointing to signInHref', () => {
+    renderNav();
+    const signInLinks = screen.getAllByRole('link', { name: /sign in/i });
+    expect(signInLinks.length).toBeGreaterThan(0);
+    signInLinks.forEach(l => expect(l).toHaveAttribute('href', '/login'));
+  });
+
+  it('renders get started link pointing to signUpHref', () => {
+    renderNav();
+    const link = screen.getByRole('link', { name: /get started/i });
+    expect(link).toHaveAttribute('href', '/signup');
+  });
+
+  it('renders the hamburger toggle button', () => {
+    renderNav();
+    expect(screen.getByRole('button', { name: /toggle menu/i })).toBeInTheDocument();
+  });
+
+  it('mobile nav is hidden by default', () => {
+    renderNav();
+    expect(screen.queryByRole('navigation', { name: 'Mobile' })).not.toBeInTheDocument();
+  });
+
+  it('mobile nav appears after hamburger click', async () => {
+    renderNav();
+    const btn = screen.getByRole('button', { name: /toggle menu/i });
+    await userEvent.click(btn);
+    expect(screen.getByRole('navigation', { name: 'Mobile' })).toBeInTheDocument();
+  });
+
+  it('mobile nav disappears after second hamburger click', async () => {
+    renderNav();
+    const btn = screen.getByRole('button', { name: /toggle menu/i });
+    await userEvent.click(btn);
+    await userEvent.click(btn);
+    expect(screen.queryByRole('navigation', { name: 'Mobile' })).not.toBeInTheDocument();
+  });
+
+  it('uses logoSrc from brand config when provided', () => {
+    renderNav({ brand: { name: 'TestApp', tagline: 't', logoSrc: '/custom-logo.svg' } });
+    const img = screen.getByRole('img', { name: 'TestApp' });
+    expect(img).toHaveAttribute('src', '/custom-logo.svg');
+  });
+
+  it('falls back to default logo path when logoSrc is absent', () => {
+    renderNav();
+    const img = screen.getByRole('img', { name: 'TestApp' });
+    expect(img.getAttribute('src')).toContain('flask-icon');
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PricingSection } from '../PricingSection';
+
+const mockUsePlanCatalog = vi.fn();
+
+vi.mock('@beakerstack/billing', () => ({
+  BillingProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  usePlanCatalog: () => mockUsePlanCatalog(),
+}));
+
+vi.mock('../../../../lib/supabase', () => ({ supabase: {} }));
+
+vi.mock('../../../../billing/beakerstackBillingConfig', () => ({
+  beakerstackBillingConfig: {},
+}));
+
+vi.mock('../../../billing/PlanCard.web', () => ({
+  PlanCard: ({
+    plan,
+    priceHeadline,
+  }: {
+    plan: { display_name: string };
+    priceHeadline: string;
+  }) => (
+    <div data-testid='plan-card'>
+      <span>{plan.display_name}</span>
+      <span>{priceHeadline}</span>
+    </div>
+  ),
+}));
+
+const fakePlans = [
+  { id: 'plan_free', display_name: 'Free', price_cents: 0, trial_period_days: 0 },
+  { id: 'plan_pro', display_name: 'Pro', price_cents: 1900, trial_period_days: 0 },
+];
+
+const base = {
+  heading: 'Simple pricing.',
+  subhead: 'No surprises.',
+};
+
+function renderSection(overrides = {}) {
+  return render(
+    <MemoryRouter>
+      <PricingSection config={{ ...base, ...overrides }} />
+    </MemoryRouter>
+  );
+}
+
+describe('PricingSection', () => {
+  beforeEach(() => {
+    mockUsePlanCatalog.mockReturnValue({ plans: fakePlans, loading: false });
+  });
+
+  it('renders section heading and subhead', () => {
+    renderSection();
+    expect(screen.getByRole('heading', { name: 'Simple pricing.' })).toBeInTheDocument();
+    expect(screen.getByText('No surprises.')).toBeInTheDocument();
+  });
+
+  it('renders disclaimer when provided', () => {
+    renderSection({ disclaimer: 'Prices exclude VAT.' });
+    expect(screen.getByText('Prices exclude VAT.')).toBeInTheDocument();
+  });
+
+  it('does not render disclaimer when absent', () => {
+    renderSection();
+    expect(screen.queryByText('Prices exclude VAT.')).not.toBeInTheDocument();
+  });
+
+  it('renders loading indicator while plans load', () => {
+    mockUsePlanCatalog.mockReturnValue({ plans: [], loading: true });
+    renderSection();
+    expect(screen.getByText(/loading plans/i)).toBeInTheDocument();
+  });
+
+  it('renders a PlanCard for each plan', () => {
+    renderSection();
+    expect(screen.getAllByTestId('plan-card')).toHaveLength(2);
+  });
+
+  it('shows US$0 price for free plan', () => {
+    renderSection();
+    expect(screen.getByText('US$0')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/SocialProof.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/SocialProof.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SocialProof } from '../SocialProof';
+
+describe('SocialProof', () => {
+  it('renders nothing when config is undefined', () => {
+    const { container } = render(<SocialProof />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders metric values and labels', () => {
+    render(
+      <SocialProof
+        config={{
+          kind: 'metrics',
+          items: [
+            { metric: '10k+', label: 'Developers' },
+            { metric: '99.9%', label: 'Uptime' },
+          ],
+        }}
+      />
+    );
+    expect(screen.getByText('10k+')).toBeInTheDocument();
+    expect(screen.getByText('Developers')).toBeInTheDocument();
+    expect(screen.getByText('99.9%')).toBeInTheDocument();
+    expect(screen.getByText('Uptime')).toBeInTheDocument();
+  });
+
+  it('renders testimonial quote and author', () => {
+    render(
+      <SocialProof
+        config={{
+          kind: 'testimonials',
+          items: [{ quote: 'Love it!', author: 'Jane Doe' }],
+        }}
+      />
+    );
+    expect(screen.getByText(/Love it!/)).toBeInTheDocument();
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+  });
+
+  it('renders testimonial role when provided', () => {
+    render(
+      <SocialProof
+        config={{
+          kind: 'testimonials',
+          items: [{ quote: 'Great!', author: 'Jane Doe', role: 'CTO at Acme' }],
+        }}
+      />
+    );
+    expect(screen.getByText(/CTO at Acme/)).toBeInTheDocument();
+  });
+
+  it('does not render role when absent', () => {
+    render(
+      <SocialProof
+        config={{
+          kind: 'testimonials',
+          items: [{ quote: 'Great!', author: 'Jane Doe' }],
+        }}
+      />
+    );
+    expect(screen.queryByText(/CTO/)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for unhandled kinds', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { container } = render(<SocialProof config={{ kind: 'logos', items: [] } as any} />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 54 unit tests across 8 test files, one per landing section component (Nav, Hero, FeatureGrid, FeatureRows, SocialProof, FAQ, FinalCTA, PricingSection)
- All tests verified passing locally before push
- Closes #59

PricingSection mocks `@beakerstack/billing` (BillingProvider passthrough + usePlanCatalog), `supabase`, `beakerstackBillingConfig`, and `PlanCard.web` so no real network calls are made.

## Test plan

- [x] `cd apps/web && npx vitest --run src/components/landing/sections/__tests__` → 54/54 passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)