### PR TITLE
fix: AI code quality findings — landing copy, test mocks, jest regex (closes #62)

### DIFF
--- a/apps/web/src/config/landing.ts
+++ b/apps/web/src/config/landing.ts
@@ -204,7 +204,7 @@ export const landingConfig: LandingConfig = {
     },
     {
       title: 'Web and mobile from a single codebase.',
-      body: 'Shared auth logic. Shared billing hooks. Shared business rules. Your React web app and React Native mobile app stay in sync without duplicated work. About 40–60% of the codebase is shared across platforms.',
+      body: 'Shared auth logic. Shared billing hooks. Shared business rules. Your React web app and React Native mobile app stay in sync without duplicating work. About 40–60% of the codebase is shared across platforms.',
       ctaLabel: 'Learn about mobile',
       ctaHref: '#features',
       mediaSrc: 'https://placehold.co/560x315?text=Mobile+App',

--- a/apps/web/src/config/landing.ts
+++ b/apps/web/src/config/landing.ts
@@ -161,7 +161,7 @@ export const landingConfig: LandingConfig = {
       {
         icon: Database,
         title: 'Supabase backend',
-        body: 'Postgres, Auth, Storage, and Edge Functions — with RLS-oriented patterns, migrations at repo root, generated TypeScript types from the schema, and local Supabase via Docker for dev/test parity.',
+        body: 'Postgres, Auth, Storage, and Edge Functions with RLS-first patterns, schema-generated TypeScript types, and local Docker parity for development and testing.',
       },
       {
         icon: Code2,
@@ -204,7 +204,7 @@ export const landingConfig: LandingConfig = {
     },
     {
       title: 'Web and mobile from a single codebase.',
-      body: 'Shared auth logic, shared billing hooks, shared business rules — your React web app and React Native mobile app stay in sync without duplicating code. 40–60% of the codebase is shared across platforms.',
+      body: 'Shared auth logic. Shared billing hooks. Shared business rules. Your React web app and React Native mobile app stay in sync without duplicated work. About 40–60% of the codebase is shared across platforms.',
       ctaLabel: 'Learn about mobile',
       ctaHref: '#features',
       mediaSrc: 'https://placehold.co/560x315?text=Mobile+App',
@@ -213,7 +213,7 @@ export const landingConfig: LandingConfig = {
     },
     {
       title: 'Environments that match your shipping workflow.',
-      body: 'Three Supabase databases — local Docker, shared PR testing, and staging — mirror your branching model so migrations are validated before they touch production. PR previews deploy to path-based S3/CloudFront URLs automatically. EAS Update channels give mobile the same preview → staging → production story.',
+      body: 'Three Supabase databases—local Docker, shared PR testing, and staging—mirror your branching model. Migrations are validated before they touch production. PR previews deploy automatically to path-based S3/CloudFront URLs. EAS Update channels give mobile the same preview → staging → production flow.',
       ctaLabel: 'Read the architecture docs',
       ctaHref: 'https://github.com/Artificer-Innovations/BeakerStack/blob/main/ARCHITECTURE.md',
       mediaSrc: 'https://placehold.co/560x315?text=Environments',
@@ -222,7 +222,7 @@ export const landingConfig: LandingConfig = {
     },
     {
       title: 'Set up in minutes. Documented for the long haul.',
-      body: 'A single `npm run setup` command provisions your local environment. QUICKSTART, ARCHITECTURE, and per-topic guides (OAuth, Stripe, testing) cover every decision. Environment variables and secrets follow a consistent layout that maps directly to GitHub Actions — no hunting for where a key goes.',
+      body: 'Run `npm run setup` to provision your local environment in one step. QUICKSTART, ARCHITECTURE, and focused guides (OAuth, Stripe, testing) explain key decisions. Env vars and secrets use a consistent layout that maps directly to GitHub Actions.',
       ctaLabel: 'Read the quickstart',
       ctaHref: 'https://github.com/Artificer-Innovations/BeakerStack/blob/main/QUICKSTART.md',
       mediaSrc: 'https://placehold.co/560x315?text=Setup',

--- a/apps/web/src/pages/__tests__/HomePage.test.tsx
+++ b/apps/web/src/pages/__tests__/HomePage.test.tsx
@@ -22,7 +22,7 @@ vi.mock('@/lib/supabase', () => ({
     }),
     channel: vi.fn().mockReturnValue({
       on: vi.fn().mockReturnThis(),
-      subscribe: vi.fn(cb => { cb('SUBSCRIBED'); return {}; }),
+      subscribe: vi.fn(cb => { cb('SUBSCRIBED'); return { unsubscribe: vi.fn().mockResolvedValue(undefined) }; }),
     }),
     removeChannel: vi.fn().mockResolvedValue({ status: 'ok', error: null }),
   },
@@ -84,7 +84,7 @@ describe('HomePage', () => {
       }),
       channel: vi.fn().mockReturnValue({
         on: vi.fn().mockReturnThis(),
-        subscribe: vi.fn(cb => { cb('SUBSCRIBED'); return {}; }),
+        subscribe: vi.fn(cb => { cb('SUBSCRIBED'); return { unsubscribe: vi.fn().mockResolvedValue(undefined) }; }),
       }),
       removeChannel: vi.fn().mockResolvedValue({ status: 'ok', error: null }),
     } as unknown as SupabaseClient;
@@ -113,8 +113,13 @@ describe('HomePage', () => {
           </AuthProvider>
         </MemoryRouter>
       );
-      await new Promise(resolve => setTimeout(resolve, 0));
     });
+    await waitFor(() =>
+      expect(
+        screen.queryByText('Build the full stack. Not the scaffolding.') ??
+          screen.queryByText('Dashboard')
+      ).toBeTruthy()
+    );
     return result!;
   };
 

--- a/packages/shared-tests/jest.web.cjs
+++ b/packages/shared-tests/jest.web.cjs
@@ -22,7 +22,7 @@ module.exports = {
     ]
   },
   transformIgnorePatterns: [
-    "node_modules/(?!^$)" // default; adjust to transpile specific libs if needed
+    "/node_modules/" // default; adjust to transpile specific libs if needed
   ],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
   collectCoverageFrom: [


### PR DESCRIPTION
## Summary

- **`apps/web/src/config/landing.ts`** — condense 4 feature row body strings per AI recommendations: shorter sentences, active voice, removed redundant clauses
- **`apps/web/src/pages/__tests__/HomePage.test.tsx`** — two fixes:
  - Subscribe mock now returns `{ unsubscribe: vi.fn().mockResolvedValue(undefined) }` so cleanup code that chains `.catch()` on `unsubscribe()` doesn't throw (the empty `{}` return was a latent crash in the authenticated redirect test)
  - Replace `setTimeout(resolve, 0)` flush with `waitFor()` outside `act()` — retries until the DOM settles rather than relying on an arbitrary delay
- **`packages/shared-tests/jest.web.cjs`** — clean up `transformIgnorePatterns` regex: `node_modules/(?!^$)` → `/node_modules/`. The original pattern was functionally correct (node_modules was excluded from transpilation) but the negative-lookahead on an empty string anchor was confusing and non-idiomatic. Replaced with the standard Jest pattern for readability.

Closes #62

## Test plan

- [x] `HomePage.test.tsx` — 5/5 passing locally after fixes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)