### PR TITLE
test: coverage for landing sections, LEGAL_CONFIG, and POLICIES (closes #63)

### DIFF
--- a/apps/web/src/components/landing/sections/__tests__/FAQ.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/FAQ.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FAQ } from '../FAQ';
+
+const faqConfig = {
+  heading: 'Frequently Asked Questions',
+  items: [
+    { q: 'What is BeakerStack?', a: 'An open-source SaaS template.' },
+    { q: 'Is it free?', a: 'Yes, MIT licensed.' },
+    { q: 'Does it support mobile?', a: 'Yes, React Native included.' },
+  ],
+};
+
+describe('FAQ', () => {
+  it('renders the section heading', () => {
+    render(<FAQ config={faqConfig} />);
+    expect(screen.getByText('Frequently Asked Questions')).toBeInTheDocument();
+  });
+
+  it('renders all FAQ questions', () => {
+    render(<FAQ config={faqConfig} />);
+    expect(screen.getByText('What is BeakerStack?')).toBeInTheDocument();
+    expect(screen.getByText('Is it free?')).toBeInTheDocument();
+    expect(screen.getByText('Does it support mobile?')).toBeInTheDocument();
+  });
+
+  it('renders all FAQ answers', () => {
+    render(<FAQ config={faqConfig} />);
+    expect(screen.getByText('An open-source SaaS template.')).toBeInTheDocument();
+    expect(screen.getByText('Yes, MIT licensed.')).toBeInTheDocument();
+    expect(screen.getByText('Yes, React Native included.')).toBeInTheDocument();
+  });
+
+  it('renders FAQ items as details elements', () => {
+    const { container } = render(<FAQ config={faqConfig} />);
+    const details = container.querySelectorAll('details');
+    expect(details.length).toBe(3);
+  });
+
+  it('renders summary for each FAQ item', () => {
+    const { container } = render(<FAQ config={faqConfig} />);
+    const summaries = container.querySelectorAll('summary');
+    expect(summaries.length).toBe(3);
+  });
+
+  it('renders empty FAQ section when items array is empty', () => {
+    render(<FAQ config={{ heading: 'FAQ', items: [] }} />);
+    expect(screen.getByText('FAQ')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/FeatureGrid.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/FeatureGrid.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FeatureGrid } from '../FeatureGrid';
+
+const TestIcon = () => <svg data-testid='icon' />;
+
+const config = {
+  heading: 'Everything you need',
+  subhead: 'A complete toolkit for modern SaaS.',
+  items: [
+    { icon: TestIcon, title: 'Auth', body: 'Secure authentication out of the box.' },
+    {
+      icon: TestIcon,
+      title: 'Billing',
+      body: 'Stripe-powered subscriptions.',
+      ctaLabel: 'Learn more',
+      ctaHref: '#billing',
+    },
+    {
+      icon: TestIcon,
+      title: 'Docs',
+      body: 'Full documentation included.',
+      ctaLabel: 'View docs',
+      ctaHref: 'https://docs.example.com/guide',
+    },
+  ],
+};
+
+describe('FeatureGrid', () => {
+  it('renders the section heading and subhead', () => {
+    render(<FeatureGrid config={config} />);
+    expect(screen.getByRole('heading', { name: 'Everything you need' })).toBeInTheDocument();
+    expect(screen.getByText('A complete toolkit for modern SaaS.')).toBeInTheDocument();
+  });
+
+  it('renders all feature item titles and bodies', () => {
+    render(<FeatureGrid config={config} />);
+    expect(screen.getByText('Auth')).toBeInTheDocument();
+    expect(screen.getByText('Secure authentication out of the box.')).toBeInTheDocument();
+    expect(screen.getByText('Billing')).toBeInTheDocument();
+    expect(screen.getByText('Stripe-powered subscriptions.')).toBeInTheDocument();
+  });
+
+  it('renders internal CTA link without target or rel', () => {
+    render(<FeatureGrid config={config} />);
+    const link = screen.getByRole('link', { name: /Learn more/ });
+    expect(link).toHaveAttribute('href', '#billing');
+    expect(link).not.toHaveAttribute('target');
+    expect(link).not.toHaveAttribute('rel');
+  });
+
+  it('renders external CTA link with target="_blank" and rel="noopener noreferrer"', () => {
+    render(<FeatureGrid config={config} />);
+    const link = screen.getByRole('link', { name: /View docs/ });
+    expect(link).toHaveAttribute('href', 'https://docs.example.com/guide');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('omits CTA when ctaLabel and ctaHref are absent', () => {
+    render(<FeatureGrid config={config} />);
+    // Auth item has no CTA — only 2 CTA links should exist
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/FeatureGrid.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/FeatureGrid.test.tsx
@@ -1,23 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { Zap } from 'lucide-react';
 import { FeatureGrid } from '../FeatureGrid';
-
-const TestIcon = () => <svg data-testid='icon' />;
 
 const config = {
   heading: 'Everything you need',
   subhead: 'A complete toolkit for modern SaaS.',
   items: [
-    { icon: TestIcon, title: 'Auth', body: 'Secure authentication out of the box.' },
+    { icon: Zap, title: 'Auth', body: 'Secure authentication out of the box.' },
     {
-      icon: TestIcon,
+      icon: Zap,
       title: 'Billing',
       body: 'Stripe-powered subscriptions.',
       ctaLabel: 'Learn more',
       ctaHref: '#billing',
     },
     {
-      icon: TestIcon,
+      icon: Zap,
       title: 'Docs',
       body: 'Full documentation included.',
       ctaLabel: 'View docs',

--- a/apps/web/src/components/landing/sections/__tests__/FeatureRows.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/FeatureRows.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FeatureRows } from '../FeatureRows';
+
+const rows = [
+  {
+    title: 'Web and mobile from one codebase.',
+    body: 'Shared auth, billing, and business rules across platforms.',
+    ctaLabel: 'Learn about mobile',
+    ctaHref: '#features',
+    mediaSrc: 'https://placehold.co/560x315?text=Mobile',
+    mediaAlt: 'Mobile app screenshot',
+    mediaSide: 'right' as const,
+  },
+  {
+    title: 'Set up in minutes.',
+    body: 'A single npm run setup provisions your local environment.',
+    ctaLabel: 'Read the architecture',
+    ctaHref: 'https://github.com/Artificer-Innovations/BeakerStack/blob/main/ARCHITECTURE.md',
+    mediaSrc: 'https://placehold.co/560x315?text=Setup',
+    mediaAlt: 'Setup screenshot',
+    mediaSide: 'left' as const,
+  },
+];
+
+describe('FeatureRows', () => {
+  it('renders each row title and body', () => {
+    render(<FeatureRows config={rows} />);
+    expect(
+      screen.getByRole('heading', { name: 'Web and mobile from one codebase.' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Shared auth, billing, and business rules across platforms.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Set up in minutes.' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders internal CTA link without target or rel', () => {
+    render(<FeatureRows config={rows} />);
+    const link = screen.getByRole('link', { name: /Learn about mobile/ });
+    expect(link).toHaveAttribute('href', '#features');
+    expect(link).not.toHaveAttribute('target');
+    expect(link).not.toHaveAttribute('rel');
+  });
+
+  it('renders external CTA link with target="_blank" and rel="noopener noreferrer"', () => {
+    render(<FeatureRows config={rows} />);
+    const link = screen.getByRole('link', { name: /Read the architecture/ });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://github.com/Artificer-Innovations/BeakerStack/blob/main/ARCHITECTURE.md'
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders images with lazy loading and correct alt text', () => {
+    render(<FeatureRows config={rows} />);
+    const images = screen.getAllByRole('img');
+    expect(images[0]).toHaveAttribute('alt', 'Mobile app screenshot');
+    expect(images[0]).toHaveAttribute('loading', 'lazy');
+    expect(images[1]).toHaveAttribute('alt', 'Setup screenshot');
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/FinalCTA.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/FinalCTA.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { FinalCTA } from '../FinalCTA';
+
+const baseConfig = {
+  headline: 'Ready to ship faster?',
+  subhead: 'Start building your SaaS today.',
+  ctaLabel: 'Get started free',
+  ctaHref: '/signup',
+};
+
+describe('FinalCTA', () => {
+  it('renders headline and subhead', () => {
+    render(
+      <MemoryRouter>
+        <FinalCTA config={baseConfig} />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Ready to ship faster?' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Start building your SaaS today.')).toBeInTheDocument();
+  });
+
+  it('renders the primary CTA link', () => {
+    render(
+      <MemoryRouter>
+        <FinalCTA config={baseConfig} />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: 'Get started free' })).toBeInTheDocument();
+  });
+
+  it('renders secondary CTA with target="_blank" and rel="noopener noreferrer"', () => {
+    const config = {
+      ...baseConfig,
+      secondaryCta: { label: 'View on GitHub', href: 'https://github.com/Artificer-Innovations/BeakerStack' },
+    };
+    render(
+      <MemoryRouter>
+        <FinalCTA config={config} />
+      </MemoryRouter>
+    );
+    const secondary = screen.getByRole('link', { name: 'View on GitHub' });
+    expect(secondary).toHaveAttribute('href', 'https://github.com/Artificer-Innovations/BeakerStack');
+    expect(secondary).toHaveAttribute('target', '_blank');
+    expect(secondary).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('does not render secondary CTA when absent', () => {
+    render(
+      <MemoryRouter>
+        <FinalCTA config={baseConfig} />
+      </MemoryRouter>
+    );
+    expect(screen.getAllByRole('link')).toHaveLength(1);
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/Hero.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/Hero.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Hero } from '../Hero';
+
+const baseConfig = {
+  headline: 'Build the full stack. Not the scaffolding.',
+  subhead: 'BeakerStack ships with everything a SaaS needs.',
+  primaryCta: { label: 'Get started free', href: '/signup' },
+  mediaSrc: 'https://placehold.co/600x338?text=Dashboard',
+  mediaAlt: 'Dashboard preview',
+};
+
+describe('Hero', () => {
+  it('renders the headline and subhead', () => {
+    render(
+      <MemoryRouter>
+        <Hero config={baseConfig} />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Build the full stack. Not the scaffolding.' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('BeakerStack ships with everything a SaaS needs.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the primary CTA link', () => {
+    render(
+      <MemoryRouter>
+        <Hero config={baseConfig} />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: 'Get started free' })).toBeInTheDocument();
+  });
+
+  it('renders the hero image with eager loading', () => {
+    render(
+      <MemoryRouter>
+        <Hero config={baseConfig} />
+      </MemoryRouter>
+    );
+    const img = screen.getByRole('img', { name: 'Dashboard preview' });
+    expect(img).toHaveAttribute('src', 'https://placehold.co/600x338?text=Dashboard');
+    expect(img).toHaveAttribute('loading', 'eager');
+  });
+
+  it('renders eyebrow text when provided', () => {
+    render(
+      <MemoryRouter>
+        <Hero config={{ ...baseConfig, eyebrow: 'Open source SaaS template' }} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Open source SaaS template')).toBeInTheDocument();
+  });
+
+  it('does not render eyebrow when absent', () => {
+    render(
+      <MemoryRouter>
+        <Hero config={baseConfig} />
+      </MemoryRouter>
+    );
+    expect(screen.queryByText('Open source SaaS template')).not.toBeInTheDocument();
+  });
+
+  it('renders secondary CTA when provided', () => {
+    render(
+      <MemoryRouter>
+        <Hero
+          config={{
+            ...baseConfig,
+            secondaryCta: { label: 'View on GitHub', href: 'https://github.com/Artificer-Innovations/BeakerStack' },
+          }}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: 'View on GitHub' })).toBeInTheDocument();
+  });
+
+  it('does not render secondary CTA when absent', () => {
+    render(
+      <MemoryRouter>
+        <Hero config={baseConfig} />
+      </MemoryRouter>
+    );
+    expect(screen.getAllByRole('link')).toHaveLength(1);
+  });
+
+  it('renders trust strip when provided', () => {
+    render(
+      <MemoryRouter>
+        <Hero config={{ ...baseConfig, trustStrip: 'MIT licensed · No vendor lock-in' }} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('MIT licensed · No vendor lock-in')).toBeInTheDocument();
+  });
+
+  it('does not render trust strip when absent', () => {
+    render(
+      <MemoryRouter>
+        <Hero config={baseConfig} />
+      </MemoryRouter>
+    );
+    expect(screen.queryByText(/MIT licensed/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { Nav } from '../Nav';
 
@@ -68,14 +68,13 @@ describe('Nav', () => {
     renderNav();
     fireEvent.click(screen.getByRole('button', { name: 'Toggle menu' }));
     const mobileNav = screen.getByRole('navigation', { name: 'Mobile' });
-    const featuresLink = mobileNav.querySelector('a[href="#features"]')!;
-    fireEvent.click(featuresLink);
+    fireEvent.click(within(mobileNav).getByRole('link', { name: 'Features' }));
     expect(screen.queryByRole('navigation', { name: 'Mobile' })).not.toBeInTheDocument();
   });
 
   it('adds shadow class after scrolling past threshold', () => {
-    const { container } = renderNav();
-    const header = container.querySelector('header')!;
+    renderNav();
+    const header = screen.getByRole('banner');
     expect(header.className).not.toContain('shadow-sm');
 
     act(() => {
@@ -87,8 +86,8 @@ describe('Nav', () => {
   });
 
   it('removes shadow class when scrolled back to top', () => {
-    const { container } = renderNav();
-    const header = container.querySelector('header')!;
+    renderNav();
+    const header = screen.getByRole('banner');
 
     act(() => {
       Object.defineProperty(window, 'scrollY', { value: 50, writable: true, configurable: true });

--- a/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { Nav } from '../Nav';
 
 const config = {
-  brand: { name: 'BeakerStack', logoSrc: '/logo.svg' },
+  brand: { name: 'BeakerStack', tagline: 'Ship your SaaS faster.', logoSrc: '/logo.svg' },
   links: [
     { href: '#features', label: 'Features' },
     { href: '#pricing', label: 'Pricing' },

--- a/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Nav } from '../Nav';
+
+const config = {
+  brand: { name: 'BeakerStack', logoSrc: '/logo.svg' },
+  links: [
+    { href: '#features', label: 'Features' },
+    { href: '#pricing', label: 'Pricing' },
+  ],
+  signInHref: '/signin',
+  signUpHref: '/signup',
+};
+
+function renderNav() {
+  return render(
+    <MemoryRouter>
+      <Nav config={config} />
+    </MemoryRouter>
+  );
+}
+
+describe('Nav', () => {
+  it('renders the brand name', () => {
+    renderNav();
+    expect(screen.getByText('BeakerStack')).toBeInTheDocument();
+  });
+
+  it('renders desktop navigation links', () => {
+    renderNav();
+    expect(screen.getByRole('navigation', { name: 'Main' })).toBeInTheDocument();
+    const mainNav = screen.getByRole('navigation', { name: 'Main' });
+    expect(mainNav).toHaveTextContent('Features');
+    expect(mainNav).toHaveTextContent('Pricing');
+  });
+
+  it('renders Sign in and Get started buttons', () => {
+    renderNav();
+    expect(screen.getByRole('link', { name: 'Sign in' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Get started' })).toBeInTheDocument();
+  });
+
+  it('mobile menu toggle starts with aria-expanded false', () => {
+    renderNav();
+    const toggle = screen.getByRole('button', { name: 'Toggle menu' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('clicking toggle opens mobile menu', () => {
+    renderNav();
+    const toggle = screen.getByRole('button', { name: 'Toggle menu' });
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('navigation', { name: 'Mobile' })).toBeInTheDocument();
+  });
+
+  it('mobile menu shows nav links and sign in', () => {
+    renderNav();
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle menu' }));
+    const mobileNav = screen.getByRole('navigation', { name: 'Mobile' });
+    expect(mobileNav).toHaveTextContent('Features');
+    expect(mobileNav).toHaveTextContent('Pricing');
+    expect(mobileNav).toHaveTextContent('Sign in');
+  });
+
+  it('clicking a mobile nav link closes the menu', () => {
+    renderNav();
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle menu' }));
+    const mobileNav = screen.getByRole('navigation', { name: 'Mobile' });
+    const featuresLink = mobileNav.querySelector('a[href="#features"]')!;
+    fireEvent.click(featuresLink);
+    expect(screen.queryByRole('navigation', { name: 'Mobile' })).not.toBeInTheDocument();
+  });
+
+  it('adds shadow class after scrolling past threshold', () => {
+    const { container } = renderNav();
+    const header = container.querySelector('header')!;
+    expect(header.className).not.toContain('shadow-sm');
+
+    act(() => {
+      Object.defineProperty(window, 'scrollY', { value: 50, writable: true, configurable: true });
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(header.className).toContain('shadow-sm');
+  });
+
+  it('removes shadow class when scrolled back to top', () => {
+    const { container } = renderNav();
+    const header = container.querySelector('header')!;
+
+    act(() => {
+      Object.defineProperty(window, 'scrollY', { value: 50, writable: true, configurable: true });
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(header.className).toContain('shadow-sm');
+
+    act(() => {
+      Object.defineProperty(window, 'scrollY', { value: 0, writable: true, configurable: true });
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(header.className).not.toContain('shadow-sm');
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PricingSection } from '../PricingSection';
+
+vi.mock('@beakerstack/billing', () => ({
+  BillingProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  usePlanCatalog: vi.fn(),
+}));
+vi.mock('../../../lib/supabase', () => ({ supabase: {} }));
+vi.mock('../../../billing/beakerstackBillingConfig', () => ({
+  beakerstackBillingConfig: { plans: [] },
+}));
+vi.mock('../../billing/PlanCard.web', () => ({
+  PlanCard: ({ plan }: { plan: { display_name: string } }) => (
+    <div data-testid='plan-card'>{plan.display_name}</div>
+  ),
+}));
+vi.mock('../../billing/CadenceToggle.web', () => ({
+  CadenceToggle: () => <div data-testid='cadence-toggle'>Toggle</div>,
+  getCadenceFromSearch: vi.fn(() => 'monthly'),
+}));
+vi.mock('../../../billing/billingSyncDisplay', () => ({
+  annualListCentsFromSync: vi.fn(() => 22800),
+  planAnnualSavingsCopy: vi.fn(() => null),
+  formatSavingsCalloutFromCopy: vi.fn(() => null),
+}));
+
+import { usePlanCatalog } from '@beakerstack/billing';
+
+const mockPlans = [
+  { id: 'free', display_name: 'Free', price_cents: 0, features: [] },
+  { id: 'pro', display_name: 'Pro', price_cents: 1900, features: [] },
+  { id: 'team', display_name: 'Team', price_cents: 4900, features: [] },
+];
+
+const baseConfig = {
+  heading: 'Simple, transparent pricing',
+  subhead: 'Start free. Scale as you grow.',
+};
+
+function renderSection(config = baseConfig) {
+  return render(
+    <MemoryRouter>
+      <PricingSection config={config} />
+    </MemoryRouter>
+  );
+}
+
+describe('PricingSection', () => {
+  beforeEach(() => {
+    vi.mocked(usePlanCatalog).mockReturnValue({ plans: mockPlans, loading: false } as ReturnType<typeof usePlanCatalog>);
+  });
+
+  it('renders heading and subhead', () => {
+    renderSection();
+    expect(
+      screen.getByRole('heading', { name: 'Simple, transparent pricing' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Start free. Scale as you grow.')).toBeInTheDocument();
+  });
+
+  it('renders the cadence toggle', () => {
+    renderSection();
+    expect(screen.getByTestId('cadence-toggle')).toBeInTheDocument();
+  });
+
+  it('renders a plan card for each plan', () => {
+    renderSection();
+    const cards = screen.getAllByTestId('plan-card');
+    expect(cards).toHaveLength(3);
+    expect(cards[0]).toHaveTextContent('Free');
+    expect(cards[1]).toHaveTextContent('Pro');
+    expect(cards[2]).toHaveTextContent('Team');
+  });
+
+  it('shows loading message while plans are loading', () => {
+    vi.mocked(usePlanCatalog).mockReturnValue({ plans: [], loading: true } as ReturnType<typeof usePlanCatalog>);
+    renderSection();
+    expect(screen.getByText(/Loading plans/)).toBeInTheDocument();
+    expect(screen.queryByTestId('plan-card')).not.toBeInTheDocument();
+  });
+
+  it('renders disclaimer when provided', () => {
+    renderSection({ ...baseConfig, disclaimer: 'Prices in USD. Cancel anytime.' });
+    expect(screen.getByText('Prices in USD. Cancel anytime.')).toBeInTheDocument();
+  });
+
+  it('does not render disclaimer when absent', () => {
+    renderSection();
+    expect(screen.queryByText(/Cancel anytime/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
@@ -1,26 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import type { LandingConfig } from '../../../../config/landing';
 import { PricingSection } from '../PricingSection';
 
 vi.mock('@beakerstack/billing', () => ({
   BillingProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   usePlanCatalog: vi.fn(),
 }));
-vi.mock('../../../lib/supabase', () => ({ supabase: {} }));
-vi.mock('../../../billing/beakerstackBillingConfig', () => ({
+vi.mock('../../../../lib/supabase', () => ({ supabase: {} }));
+vi.mock('../../../../billing/beakerstackBillingConfig', () => ({
   beakerstackBillingConfig: { plans: [] },
 }));
-vi.mock('../../billing/PlanCard.web', () => ({
+vi.mock('../../../billing/PlanCard.web', () => ({
   PlanCard: ({ plan }: { plan: { display_name: string } }) => (
     <div data-testid='plan-card'>{plan.display_name}</div>
   ),
 }));
-vi.mock('../../billing/CadenceToggle.web', () => ({
+vi.mock('../../../billing/CadenceToggle.web', () => ({
   CadenceToggle: () => <div data-testid='cadence-toggle'>Toggle</div>,
   getCadenceFromSearch: vi.fn(() => 'monthly'),
 }));
-vi.mock('../../../billing/billingSyncDisplay', () => ({
+vi.mock('../../../../billing/billingSyncDisplay', () => ({
   annualListCentsFromSync: vi.fn(() => 22800),
   planAnnualSavingsCopy: vi.fn(() => null),
   formatSavingsCalloutFromCopy: vi.fn(() => null),
@@ -34,12 +35,12 @@ const mockPlans = [
   { id: 'team', display_name: 'Team', price_cents: 4900, features: [] },
 ];
 
-const baseConfig = {
+const baseConfig: LandingConfig['pricing'] = {
   heading: 'Simple, transparent pricing',
   subhead: 'Start free. Scale as you grow.',
 };
 
-function renderSection(config = baseConfig) {
+function renderSection(config: LandingConfig['pricing'] = baseConfig) {
   return render(
     <MemoryRouter>
       <PricingSection config={config} />
@@ -49,7 +50,9 @@ function renderSection(config = baseConfig) {
 
 describe('PricingSection', () => {
   beforeEach(() => {
-    vi.mocked(usePlanCatalog).mockReturnValue({ plans: mockPlans, loading: false } as ReturnType<typeof usePlanCatalog>);
+    vi.mocked(usePlanCatalog).mockReturnValue(
+      { plans: mockPlans, loading: false } as unknown as ReturnType<typeof usePlanCatalog>
+    );
   });
 
   it('renders heading and subhead', () => {
@@ -75,7 +78,9 @@ describe('PricingSection', () => {
   });
 
   it('shows loading message while plans are loading', () => {
-    vi.mocked(usePlanCatalog).mockReturnValue({ plans: [], loading: true } as ReturnType<typeof usePlanCatalog>);
+    vi.mocked(usePlanCatalog).mockReturnValue(
+      { plans: [], loading: true } as unknown as ReturnType<typeof usePlanCatalog>
+    );
     renderSection();
     expect(screen.getByText(/Loading plans/)).toBeInTheDocument();
     expect(screen.queryByTestId('plan-card')).not.toBeInTheDocument();

--- a/apps/web/src/components/landing/sections/__tests__/SocialProof.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/SocialProof.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SocialProof } from '../SocialProof';
+
+describe('SocialProof', () => {
+  it('renders nothing when config is undefined', () => {
+    const { container } = render(<SocialProof />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders metrics section with metric values and labels', () => {
+    render(
+      <SocialProof
+        config={{
+          kind: 'metrics',
+          items: [
+            { metric: '10k+', label: 'Developers' },
+            { metric: '99.9%', label: 'Uptime' },
+            { metric: '< 5 min', label: 'Setup time' },
+          ],
+        }}
+      />
+    );
+    expect(screen.getByText('10k+')).toBeInTheDocument();
+    expect(screen.getByText('Developers')).toBeInTheDocument();
+    expect(screen.getByText('99.9%')).toBeInTheDocument();
+    expect(screen.getByText('< 5 min')).toBeInTheDocument();
+    expect(screen.getByText('Setup time')).toBeInTheDocument();
+  });
+
+  it('renders testimonials section with quotes and authors', () => {
+    render(
+      <SocialProof
+        config={{
+          kind: 'testimonials',
+          items: [
+            { quote: 'Best template I have used.', author: 'Alice', role: 'CTO' },
+            { quote: 'Saved us weeks of work.', author: 'Bob' },
+          ],
+        }}
+      />
+    );
+    expect(screen.getByText(/"Best template I have used\."/)).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText(', CTO')).toBeInTheDocument();
+    expect(screen.getByText(/"Saved us weeks of work\."/)).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('renders testimonials without role when role is absent', () => {
+    render(
+      <SocialProof
+        config={{
+          kind: 'testimonials',
+          items: [{ quote: 'Great product.', author: 'Carol' }],
+        }}
+      />
+    );
+    expect(screen.getByText('Carol')).toBeInTheDocument();
+    expect(screen.queryByText(/,/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/landing/sections/__tests__/SocialProof.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/SocialProof.test.tsx
@@ -59,4 +59,11 @@ describe('SocialProof', () => {
     expect(screen.getByText('Carol')).toBeInTheDocument();
     expect(screen.queryByText(/,/)).not.toBeInTheDocument();
   });
+
+  it('renders nothing for unsupported kind', () => {
+    const { container } = render(
+      <SocialProof config={{ kind: 'logos' as 'metrics', items: [] }} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
 });

--- a/packages/shared-tests/__tests__/config/legal.test.ts
+++ b/packages/shared-tests/__tests__/config/legal.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from '@jest/globals';
+import { LEGAL_CONFIG } from '@beakerstack/shared/config/legal';
+
+describe('LEGAL_CONFIG', () => {
+  it('has a non-empty brandName', () => {
+    expect(typeof LEGAL_CONFIG.brandName).toBe('string');
+    expect(LEGAL_CONFIG.brandName.length).toBeGreaterThan(0);
+  });
+
+  it('has a non-empty brandUrl', () => {
+    expect(typeof LEGAL_CONFIG.brandUrl).toBe('string');
+    expect(LEGAL_CONFIG.brandUrl.length).toBeGreaterThan(0);
+  });
+
+  it('has a non-empty legalEntityName', () => {
+    expect(typeof LEGAL_CONFIG.legalEntityName).toBe('string');
+    expect(LEGAL_CONFIG.legalEntityName.length).toBeGreaterThan(0);
+  });
+
+  it('has a valid contactEmail containing @', () => {
+    expect(LEGAL_CONFIG.contactEmail).toContain('@');
+    expect(LEGAL_CONFIG.contactEmail.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/shared-tests/__tests__/config/policies.test.ts
+++ b/packages/shared-tests/__tests__/config/policies.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from '@jest/globals';
+import { POLICIES } from '@beakerstack/shared/generated/policies';
+
+describe('POLICIES', () => {
+  it('exports terms, privacy, and refunds keys', () => {
+    expect(POLICIES).toHaveProperty('terms');
+    expect(POLICIES).toHaveProperty('privacy');
+    expect(POLICIES).toHaveProperty('refunds');
+  });
+
+  it('all policy values are non-empty strings', () => {
+    for (const key of ['terms', 'privacy', 'refunds'] as const) {
+      expect(typeof POLICIES[key]).toBe('string');
+      expect(POLICIES[key].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('all policy values contain HTML content', () => {
+    for (const key of ['terms', 'privacy', 'refunds'] as const) {
+      expect(POLICIES[key]).toMatch(/<h1>/);
+    }
+  });
+});

--- a/packages/shared/src/config/legal.ts
+++ b/packages/shared/src/config/legal.ts
@@ -1,4 +1,4 @@
-import { BRANDING } from './branding.js';
+import { BRANDING } from './branding';
 
 export const LEGAL_CONFIG = {
   brandName: BRANDING.pascalName,


### PR DESCRIPTION
## Summary

- **8 landing section test files** (`apps/web/src/components/landing/sections/__tests__/`) — replaces Diego's closed PR #61; covers all uncovered line ranges from issue #63
- **`packages/shared-tests/__tests__/config/legal.test.ts`** — structural validation of `LEGAL_CONFIG` fields
- **`packages/shared-tests/__tests__/config/policies.test.ts`** — validates `POLICIES` exports `terms`, `privacy`, `refunds` as non-empty HTML strings

## Coverage targets from issue #63

| File | Was | Tests added |
|------|-----|-------------|
| `FAQ.tsx` | 48% | heading, items, empty state |
| `FeatureGrid.tsx` | 44% | grid render, internal/external CTA |
| `FeatureRows.tsx` | 20% | rows render, link security attrs, lazy images |
| `FinalCTA.tsx` | 76% | primary CTA, optional secondary CTA |
| `Hero.tsx` | 78% | all optional fields (eyebrow, secondaryCta, trustStrip), eager image |
| `Nav.tsx` | 64% | mobile toggle, scroll shadow, mobile menu links |
| `PricingSection.tsx` | 49% | heading/subhead, plans, loading state, disclaimer |
| `SocialProof.tsx` | 5% | null config, metrics, testimonials (with/without role) |
| `legal.ts` | 0% | all 4 fields validated |
| `policies.ts` | 0% | all 3 keys validated as HTML |

## Notes

- `PricingSection` mocks `@beakerstack/billing`, `PlanCard`, `CadenceToggle`, and billing helpers — keeps tests isolated from Supabase
- `Nav` scroll test uses `Object.defineProperty(window, 'scrollY', ...)` + `window.dispatchEvent(new Event('scroll'))` to exercise the scroll shadow path
- `SocialProof` validates all three render branches (`null`, `'metrics'`, `'testimonials'`)
- Config tests assert structure rather than relying on coverage exclusions, per Brad's feedback on issue #63

## Test plan
- [ ] CI green (`npm run test:coverage`)
- [ ] All 10 new test files pass
- [ ] Coverage ≥ 95% total statements