### PR TITLE
Improve pricing demo copy: move explanation to subtitle

### DIFF
--- a/apps/web/src/config/landing.ts
+++ b/apps/web/src/config/landing.ts
@@ -240,9 +240,9 @@ export const landingConfig: LandingConfig = {
   },
   pricing: {
     heading: 'Simple, transparent pricing.',
-    subhead: 'Start free. Upgrade when you need more.',
-    disclaimer:
-      'BeakerStack itself is free and open-source (MIT) — clone it and ship your product at no cost. The plans below are a live demo of the billing system built into the template. Stripe is running in test mode for this preview; no real charges are made.',
+    subhead:
+      'BeakerStack itself is free and open-source (MIT) — clone it and ship your product at no cost. The plans below are a live demo of the billing system built into the template.',
+    disclaimer: 'Stripe is running in test mode for this preview; no real charges are made.',
   },
   faq: {
     heading: 'Frequently asked questions',


### PR DESCRIPTION
## Summary
- Moves the MIT/demo explanation from `disclaimer` to `subhead` so it appears prominently before the plans
- Shortens `disclaimer` to just the test-mode notice: "Stripe is running in test mode for this preview; no real charges are made."

Closes #66