### PR TITLE
feat(web): post-signup upgrade funnel — plan intent, billing redirect, OAuth/email storage

### DIFF
--- a/apps/web/src/auth/__tests__/planSignupBullets.test.ts
+++ b/apps/web/src/auth/__tests__/planSignupBullets.test.ts
@@ -2,18 +2,48 @@ import { describe, expect, it } from 'vitest';
 import { planSignupBullets } from '../planSignupBullets';
 
 describe('planSignupBullets', () => {
-  it('returns bullets for Pro', () => {
+  it('returns non-empty strings for known plans', () => {
     const b = planSignupBullets('beakerstack_pro');
     expect(b.length).toBeGreaterThan(0);
-    expect(b.some(x => /Feature A/i.test(x))).toBe(true);
+    expect(b.length).toBeLessThanOrEqual(3);
+    expect(b.every(x => typeof x === 'string' && x.length > 0)).toBe(true);
   });
 
-  it('includes trial copy for Max', () => {
+  it('includes trial copy when trial days > 0', () => {
     const b = planSignupBullets('beakerstack_max');
     expect(b.some(x => /trial/i.test(x))).toBe(true);
   });
 
   it('returns empty for unknown plan', () => {
     expect(planSignupBullets('unknown')).toEqual([]);
+  });
+
+  it('lists limited numeric features for Free plan', () => {
+    const b = planSignupBullets('beakerstack_free');
+    expect(b.some(x => /Up to 2 collections/i.test(x))).toBe(true);
+    expect(b.some(x => /Up to 3 items per collection/i.test(x))).toBe(true);
+    expect(b.some(x => /AI summarize/i.test(x))).toBe(true);
+    expect(b.length).toBeLessThanOrEqual(3);
+  });
+
+  it('includes unlimited collection copy when capped at -1', () => {
+    const b = planSignupBullets('beakerstack_pro');
+    expect(b.some(x => /Unlimited collections/i.test(x))).toBe(true);
+    expect(b.some(x => /Feature A/i.test(x))).toBe(true);
+  });
+
+  it('caps at three lines on Max (trial + booleans fill quota before meter)', () => {
+    const b = planSignupBullets('beakerstack_max');
+    expect(b.length).toBe(3);
+    expect(b.some(x => /trial/i.test(x))).toBe(true);
+    expect(b.some(x => /Feature A/i.test(x))).toBe(true);
+    expect(b.some(x => /Feature B/i.test(x))).toBe(true);
+  });
+
+  it('adds meter copy when feature rows leave room (Free)', () => {
+    const b = planSignupBullets('beakerstack_free');
+    expect(
+      b.some(x => /\d+\s+AI summarize\s+\/\s+billing period/i.test(x))
+    ).toBe(true);
   });
 });

--- a/apps/web/src/auth/__tests__/planSignupBullets.test.ts
+++ b/apps/web/src/auth/__tests__/planSignupBullets.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { planSignupBullets } from '../planSignupBullets';
+
+describe('planSignupBullets', () => {
+  it('returns bullets for Pro', () => {
+    const b = planSignupBullets('beakerstack_pro');
+    expect(b.length).toBeGreaterThan(0);
+    expect(b.some(x => /Feature A/i.test(x))).toBe(true);
+  });
+
+  it('includes trial copy for Max', () => {
+    const b = planSignupBullets('beakerstack_max');
+    expect(b.some(x => /trial/i.test(x))).toBe(true);
+  });
+
+  it('returns empty for unknown plan', () => {
+    expect(planSignupBullets('unknown')).toEqual([]);
+  });
+});

--- a/apps/web/src/auth/__tests__/postAuthRedirect.test.ts
+++ b/apps/web/src/auth/__tests__/postAuthRedirect.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseStoredPostAuthRedirect,
+  resolvePostAuthDestination,
+  serializePostAuthRedirectPayload,
+  validateInternalPostAuthPath,
+  POST_AUTH_REDIRECT_TTL_MS,
+} from '../postAuthRedirect';
+
+const ORIGIN = 'http://localhost:5173';
+
+describe('validateInternalPostAuthPath', () => {
+  it('accepts same-origin path + search', () => {
+    expect(validateInternalPostAuthPath('/billing/plans?plan=x', ORIGIN)).toBe(
+      '/billing/plans?plan=x'
+    );
+  });
+
+  it('rejects protocol-relative //evil.com', () => {
+    expect(
+      validateInternalPostAuthPath('//evil.com/path', ORIGIN)
+    ).toBeNull();
+  });
+
+  it('rejects https://evil.com path when resolved as absolute', () => {
+    expect(
+      validateInternalPostAuthPath('https://evil.com/path', ORIGIN)
+    ).toBeNull();
+  });
+
+  it('rejects bare strings without leading slash', () => {
+    expect(validateInternalPostAuthPath('evil.com', ORIGIN)).toBeNull();
+  });
+});
+
+describe('resolvePostAuthDestination', () => {
+  it('returns dashboard when plan missing', () => {
+    expect(resolvePostAuthDestination(new URLSearchParams())).toBe(
+      '/dashboard'
+    );
+  });
+
+  it('returns dashboard for unknown plan id', () => {
+    expect(
+      resolvePostAuthDestination(
+        new URLSearchParams({ plan: 'not_a_real_plan_id' })
+      )
+    ).toBe('/dashboard');
+  });
+
+  it('returns dashboard for free tier', () => {
+    expect(
+      resolvePostAuthDestination(
+        new URLSearchParams({ plan: 'beakerstack_free' })
+      )
+    ).toBe('/dashboard');
+  });
+
+  it('returns billing plans with welcome for paid Pro monthly', () => {
+    expect(
+      resolvePostAuthDestination(
+        new URLSearchParams({ plan: 'beakerstack_pro' })
+      )
+    ).toBe('/billing/plans?plan=beakerstack_pro&welcome=1');
+  });
+
+  it('includes cadence=annual when set', () => {
+    expect(
+      resolvePostAuthDestination(
+        new URLSearchParams({ plan: 'beakerstack_max', cadence: 'annual' })
+      )
+    ).toBe('/billing/plans?plan=beakerstack_max&welcome=1&cadence=annual');
+  });
+});
+
+describe('parseStoredPostAuthRedirect', () => {
+  it('parses valid JSON payload', () => {
+    const path = '/billing/plans?plan=beakerstack_pro&welcome=1';
+    const raw = serializePostAuthRedirectPayload(path);
+    expect(parseStoredPostAuthRedirect(raw, Date.now(), ORIGIN)).toBe(path);
+  });
+
+  it('returns null when TTL expired', () => {
+    const path = '/billing/plans?plan=beakerstack_pro&welcome=1';
+    const raw = JSON.stringify({
+      path,
+      ts: Date.now() - POST_AUTH_REDIRECT_TTL_MS - 1,
+    });
+    expect(parseStoredPostAuthRedirect(raw, Date.now(), ORIGIN)).toBeNull();
+  });
+});

--- a/apps/web/src/auth/__tests__/postAuthRedirect.test.ts
+++ b/apps/web/src/auth/__tests__/postAuthRedirect.test.ts
@@ -19,9 +19,7 @@ describe('validateInternalPostAuthPath', () => {
   });
 
   it('rejects protocol-relative //evil.com', () => {
-    expect(
-      validateInternalPostAuthPath('//evil.com/path', ORIGIN)
-    ).toBeNull();
+    expect(validateInternalPostAuthPath('//evil.com/path', ORIGIN)).toBeNull();
   });
 
   it('rejects https://evil.com path when resolved as absolute', () => {
@@ -92,7 +90,9 @@ describe('parseStoredPostAuthRedirect', () => {
   });
 
   it('returns null for invalid JSON (no legacy raw-path fallback)', () => {
-    expect(parseStoredPostAuthRedirect('not-json', Date.now(), ORIGIN)).toBeNull();
+    expect(
+      parseStoredPostAuthRedirect('not-json', Date.now(), ORIGIN)
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/auth/__tests__/postAuthRedirect.test.ts
+++ b/apps/web/src/auth/__tests__/postAuthRedirect.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import {
   parseStoredPostAuthRedirect,
+  POST_AUTH_REDIRECT_KEY,
+  readAndClearPostAuthRedirect,
   resolvePostAuthDestination,
   serializePostAuthRedirectPayload,
   validateInternalPostAuthPath,
@@ -87,5 +89,53 @@ describe('parseStoredPostAuthRedirect', () => {
       ts: Date.now() - POST_AUTH_REDIRECT_TTL_MS - 1,
     });
     expect(parseStoredPostAuthRedirect(raw, Date.now(), ORIGIN)).toBeNull();
+  });
+
+  it('returns null for invalid JSON (no legacy raw-path fallback)', () => {
+    expect(parseStoredPostAuthRedirect('not-json', Date.now(), ORIGIN)).toBeNull();
+  });
+});
+
+function storageMock(store: Record<string, string>) {
+  return {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => {
+      store[k] = v;
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+  };
+}
+
+describe('readAndClearPostAuthRedirect', () => {
+  let memS: Record<string, string>;
+  let memL: Record<string, string>;
+
+  beforeEach(() => {
+    memS = {};
+    memL = {};
+    vi.stubGlobal('sessionStorage', storageMock(memS));
+    vi.stubGlobal('localStorage', storageMock(memL));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns validated path and clears both stores', () => {
+    const path = '/billing/plans?plan=beakerstack_pro&welcome=1';
+    memS[POST_AUTH_REDIRECT_KEY] = serializePostAuthRedirectPayload(path);
+    expect(readAndClearPostAuthRedirect()).toBe(path);
+    expect(memS[POST_AUTH_REDIRECT_KEY]).toBeUndefined();
+    expect(memL[POST_AUTH_REDIRECT_KEY]).toBeUndefined();
+  });
+
+  it('uses sessionStorage when both are set', () => {
+    const a = '/billing/plans?plan=beakerstack_pro&welcome=1';
+    const b = '/dashboard';
+    memS[POST_AUTH_REDIRECT_KEY] = serializePostAuthRedirectPayload(a);
+    memL[POST_AUTH_REDIRECT_KEY] = serializePostAuthRedirectPayload(b);
+    expect(readAndClearPostAuthRedirect()).toBe(a);
   });
 });

--- a/apps/web/src/auth/planSignupBullets.ts
+++ b/apps/web/src/auth/planSignupBullets.ts
@@ -12,16 +12,17 @@ export function planSignupBullets(planId: string): string[] {
     );
   }
 
-  const feats = cfg.features as Record<string, number | boolean>;
+  const feats = cfg.features as Record<string, number | boolean | undefined>;
   for (const row of beakerstackBillingConfig.planFeatureRows) {
     if (out.length >= 3) break;
     const val = feats[row.featureKey];
     if (row.kind === 'boolean') {
       if (val === true) out.push(row.label);
     } else {
-      const n = val as number;
-      if (n === -1) out.push(row.unlimitedLabel);
-      else out.push(row.limitedLabelTemplate.replace('{count}', String(n)));
+      if (typeof val !== 'number') continue;
+      if (val === -1) out.push(row.unlimitedLabel);
+      else
+        out.push(row.limitedLabelTemplate.replace('{count}', String(val)));
     }
   }
 
@@ -39,5 +40,5 @@ export function planSignupBullets(planId: string): string[] {
     }
   }
 
-  return out.slice(0, 3);
+  return out;
 }

--- a/apps/web/src/auth/planSignupBullets.ts
+++ b/apps/web/src/auth/planSignupBullets.ts
@@ -1,0 +1,43 @@
+import { beakerstackBillingConfig } from '../billing/beakerstackBillingConfig';
+
+/** Up to 3 human-readable lines for signup plan context (from template billing config). */
+export function planSignupBullets(planId: string): string[] {
+  const cfg = beakerstackBillingConfig.plans.find(p => p.id === planId);
+  if (!cfg) return [];
+
+  const out: string[] = [];
+  if (cfg.trialPeriodDays > 0) {
+    out.push(
+      `Includes a ${cfg.trialPeriodDays}-day trial, then billed at this rate.`
+    );
+  }
+
+  const feats = cfg.features as Record<string, number | boolean>;
+  for (const row of beakerstackBillingConfig.planFeatureRows) {
+    if (out.length >= 3) break;
+    const val = feats[row.featureKey];
+    if (row.kind === 'boolean') {
+      if (val === true) out.push(row.label);
+    } else {
+      const n = val as number;
+      if (n === -1) out.push(row.unlimitedLabel);
+      else out.push(row.limitedLabelTemplate.replace('{count}', String(n)));
+    }
+  }
+
+  const ai = cfg.usageLimits?.ai_summarize;
+  if (out.length < 3 && typeof ai === 'number') {
+    const label = beakerstackBillingConfig.usageMeterCopy.ai_summarize?.label;
+    if (ai === -1) {
+      out.push(label ? `Unlimited ${label}` : 'Unlimited AI summarize');
+    } else {
+      out.push(
+        label
+          ? `${ai} ${label} / billing period`
+          : `${ai} AI summarize requests / billing period`
+      );
+    }
+  }
+
+  return out.slice(0, 3);
+}

--- a/apps/web/src/auth/planSignupBullets.ts
+++ b/apps/web/src/auth/planSignupBullets.ts
@@ -21,8 +21,7 @@ export function planSignupBullets(planId: string): string[] {
     } else {
       if (typeof val !== 'number') continue;
       if (val === -1) out.push(row.unlimitedLabel);
-      else
-        out.push(row.limitedLabelTemplate.replace('{count}', String(val)));
+      else out.push(row.limitedLabelTemplate.replace('{count}', String(val)));
     }
   }
 

--- a/apps/web/src/auth/postAuthRedirect.ts
+++ b/apps/web/src/auth/postAuthRedirect.ts
@@ -48,7 +48,7 @@ export function resolvePostAuthDestination(
   if (!planId || !PUBLIC_PLAN_IDS.has(planId)) return '/dashboard';
 
   const cfg = configPlanById(planId);
-  if (!cfg || !cfg.isPublic || cfg.priceCents === 0) return '/dashboard';
+  if (!cfg || cfg.priceCents === 0) return '/dashboard';
 
   const cadence =
     searchParams.get('cadence') === 'annual' ? 'annual' : 'monthly';
@@ -65,6 +65,7 @@ export function serializePostAuthRedirectPayload(path: string): string {
 
 /**
  * Parse stored JSON `{ path, ts }`, enforce TTL, validate path. Returns null if invalid/expired.
+ * Non-JSON or malformed payloads return null (TTL always enforced; no legacy raw-path fallback).
  */
 export function parseStoredPostAuthRedirect(
   raw: string | null,
@@ -80,8 +81,34 @@ export function parseStoredPostAuthRedirect(
     }
     return null;
   } catch {
-    return validateInternalPostAuthPath(raw, origin);
+    return null;
   }
+}
+
+/** Remove intent from both storages (after successful email auth or when clearing stale OAuth stash). */
+export function clearPostAuthRedirectKeys(): void {
+  if (typeof sessionStorage !== 'undefined') {
+    sessionStorage.removeItem(POST_AUTH_REDIRECT_KEY);
+  }
+  if (typeof localStorage !== 'undefined') {
+    localStorage.removeItem(POST_AUTH_REDIRECT_KEY);
+  }
+}
+
+/** Read intent once, clear both stores unconditionally, parse + TTL + validate. */
+export function readAndClearPostAuthRedirect(): string | null {
+  const rawS =
+    typeof sessionStorage !== 'undefined'
+      ? sessionStorage.getItem(POST_AUTH_REDIRECT_KEY)
+      : null;
+  const rawL =
+    typeof localStorage !== 'undefined'
+      ? localStorage.getItem(POST_AUTH_REDIRECT_KEY)
+      : null;
+  clearPostAuthRedirectKeys();
+  return (
+    parseStoredPostAuthRedirect(rawS) ?? parseStoredPostAuthRedirect(rawL)
+  );
 }
 
 export function hasPaidPlanIntent(searchParams: URLSearchParams): boolean {

--- a/apps/web/src/auth/postAuthRedirect.ts
+++ b/apps/web/src/auth/postAuthRedirect.ts
@@ -1,0 +1,89 @@
+import { beakerstackBillingConfig } from '../billing/beakerstackBillingConfig';
+
+/** Namespaced key — sessionStorage (OAuth) + localStorage (email confirmation). */
+export const POST_AUTH_REDIRECT_KEY = 'beakerstack:post_auth_redirect';
+
+export const POST_AUTH_REDIRECT_TTL_MS = 30 * 60 * 1000;
+
+const PUBLIC_PLAN_IDS: Set<string> = new Set(
+  beakerstackBillingConfig.plans
+    .filter(p => p.isPublic)
+    .map(p => p.id)
+);
+
+function configPlanById(planId: string) {
+  return beakerstackBillingConfig.plans.find(p => p.id === planId);
+}
+
+/**
+ * Returns pathname + search for an in-app redirect, or null if unsafe / external.
+ * Rejects protocol-relative URLs (e.g. //evil.com/...) and non-same-origin paths.
+ */
+export function validateInternalPostAuthPath(
+  path: string,
+  origin: string = typeof window !== 'undefined'
+    ? window.location.origin
+    : 'http://localhost'
+): string | null {
+  if (!path || typeof path !== 'string') return null;
+  const trimmed = path.trim();
+  if (!trimmed.startsWith('/') || trimmed.startsWith('//')) return null;
+  try {
+    const u = new URL(trimmed, origin);
+    if (u.origin !== new URL(origin).origin) return null;
+    return u.pathname + u.search;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Synchronous post-auth path from signup/login URL search params.
+ * Unknown or free plan → /dashboard; paid public plan → /billing/plans?…
+ */
+export function resolvePostAuthDestination(
+  searchParams: URLSearchParams
+): string {
+  const planId = searchParams.get('plan');
+  if (!planId || !PUBLIC_PLAN_IDS.has(planId)) return '/dashboard';
+
+  const cfg = configPlanById(planId);
+  if (!cfg || !cfg.isPublic || cfg.priceCents === 0) return '/dashboard';
+
+  const cadence =
+    searchParams.get('cadence') === 'annual' ? 'annual' : 'monthly';
+  const q = new URLSearchParams();
+  q.set('plan', planId);
+  q.set('welcome', '1');
+  if (cadence === 'annual') q.set('cadence', 'annual');
+  return `/billing/plans?${q.toString()}`;
+}
+
+export function serializePostAuthRedirectPayload(path: string): string {
+  return JSON.stringify({ path, ts: Date.now() });
+}
+
+/**
+ * Parse stored JSON `{ path, ts }`, enforce TTL, validate path. Returns null if invalid/expired.
+ */
+export function parseStoredPostAuthRedirect(
+  raw: string | null,
+  now: number = Date.now(),
+  origin?: string
+): string | null {
+  if (!raw) return null;
+  try {
+    const o = JSON.parse(raw) as { path?: string; ts?: number };
+    if (typeof o.path === 'string' && typeof o.ts === 'number') {
+      if (now - o.ts > POST_AUTH_REDIRECT_TTL_MS) return null;
+      return validateInternalPostAuthPath(o.path, origin);
+    }
+    return null;
+  } catch {
+    return validateInternalPostAuthPath(raw, origin);
+  }
+}
+
+export function hasPaidPlanIntent(searchParams: URLSearchParams): boolean {
+  return resolvePostAuthDestination(searchParams) !== '/dashboard';
+}

--- a/apps/web/src/auth/postAuthRedirect.ts
+++ b/apps/web/src/auth/postAuthRedirect.ts
@@ -6,9 +6,7 @@ export const POST_AUTH_REDIRECT_KEY = 'beakerstack:post_auth_redirect';
 export const POST_AUTH_REDIRECT_TTL_MS = 30 * 60 * 1000;
 
 const PUBLIC_PLAN_IDS: Set<string> = new Set(
-  beakerstackBillingConfig.plans
-    .filter(p => p.isPublic)
-    .map(p => p.id)
+  beakerstackBillingConfig.plans.filter(p => p.isPublic).map(p => p.id)
 );
 
 function configPlanById(planId: string) {
@@ -106,9 +104,7 @@ export function readAndClearPostAuthRedirect(): string | null {
       ? localStorage.getItem(POST_AUTH_REDIRECT_KEY)
       : null;
   clearPostAuthRedirectKeys();
-  return (
-    parseStoredPostAuthRedirect(rawS) ?? parseStoredPostAuthRedirect(rawL)
-  );
+  return parseStoredPostAuthRedirect(rawS) ?? parseStoredPostAuthRedirect(rawL);
 }
 
 export function hasPaidPlanIntent(searchParams: URLSearchParams): boolean {

--- a/apps/web/src/billing/BillingProviderLayout.tsx
+++ b/apps/web/src/billing/BillingProviderLayout.tsx
@@ -1,12 +1,8 @@
 import { BillingProvider } from '@beakerstack/billing';
 import { Outlet } from 'react-router-dom';
+import { appBasePath } from '../lib/appBasePath';
 import { supabase } from '../lib/supabase';
 import { beakerstackBillingConfig } from './beakerstackBillingConfig';
-
-function appBasePath(): string {
-  if (typeof window === 'undefined') return '';
-  return `${window.location.origin}${(import.meta.env.BASE_URL || '/').replace(/\/$/, '')}`;
-}
 
 /**
  * Wraps `/dashboard` and `/billing/*` with a single {@link BillingProvider} (shared subscription state).

--- a/apps/web/src/components/auth/SignupPlanSummary.tsx
+++ b/apps/web/src/components/auth/SignupPlanSummary.tsx
@@ -119,8 +119,8 @@ export function PlanIntentSummary({
       </div>
       {bullets.length > 0 ? (
         <ul className='mt-4 list-inside list-disc space-y-1 text-sm text-gray-700'>
-          {bullets.map(line => (
-            <li key={line}>{line}</li>
+          {bullets.map((line, i) => (
+            <li key={`${mode}-bullet-${i}`}>{line}</li>
           ))}
         </ul>
       ) : null}

--- a/apps/web/src/components/auth/SignupPlanSummary.tsx
+++ b/apps/web/src/components/auth/SignupPlanSummary.tsx
@@ -1,0 +1,137 @@
+import { usePlanCatalog } from '@beakerstack/billing';
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { beakerstackBillingConfig } from '../../billing/beakerstackBillingConfig';
+import {
+  annualListCentsFromSync,
+  formatSavingsCalloutFromCopy,
+  planAnnualSavingsCopy,
+} from '../../billing/billingSyncDisplay';
+import { getCadenceFromSearch } from '../billing/CadenceToggle.web';
+import { hasPaidPlanIntent } from '../../auth/postAuthRedirect';
+import { planSignupBullets } from '../../auth/planSignupBullets';
+
+type PlanIntentMode = 'signup' | 'login';
+
+/**
+ * Plan context when `?plan=` is a paid tier (Supabase catalog + config bullets).
+ * Login uses a compact variant; primary CTA wording stays on the page, not here.
+ */
+export function PlanIntentSummary({
+  mode = 'signup',
+}: {
+  mode?: PlanIntentMode;
+}): JSX.Element | null {
+  const [search] = useSearchParams();
+  const planId = search.get('plan');
+  const cadence = getCadenceFromSearch(search);
+  const { plans, loading } = usePlanCatalog<typeof beakerstackBillingConfig>();
+
+  const catalogPlan = useMemo(
+    () => (planId ? plans.find(p => p.id === planId) : undefined),
+    [plans, planId]
+  );
+
+  if (!planId || !hasPaidPlanIntent(search)) return null;
+
+  if (loading) {
+    return (
+      <div className='rounded-xl border border-gray-200 bg-white p-6 shadow-sm'>
+        <p className='text-sm text-gray-500'>Loading plan…</p>
+      </div>
+    );
+  }
+
+  if (!catalogPlan || catalogPlan.price_cents === 0) return null;
+
+  const isAnnual = cadence === 'annual' && catalogPlan.price_cents > 0;
+  const annualCents = isAnnual
+    ? annualListCentsFromSync(catalogPlan.id, catalogPlan.price_cents)
+    : null;
+
+  const fmt = (cents: number) =>
+    new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      maximumFractionDigits: 0,
+    }).format(cents / 100);
+
+  const priceHeadline =
+    isAnnual && annualCents != null
+      ? fmt(annualCents)
+      : fmt(catalogPlan.price_cents);
+
+  const priceSubline =
+    cadence === 'annual' ? 'per year, billed annually' : 'per month';
+
+  const savingsCopy = isAnnual
+    ? planAnnualSavingsCopy(catalogPlan.id, catalogPlan.price_cents)
+    : null;
+  const savingsCallout = savingsCopy
+    ? formatSavingsCalloutFromCopy(savingsCopy)
+    : null;
+
+  const bullets = planSignupBullets(catalogPlan.id).slice(
+    0,
+    mode === 'login' ? 2 : 3
+  );
+
+  return (
+    <div
+      className={
+        mode === 'login'
+          ? 'rounded-lg border border-gray-200 bg-white p-4 shadow-sm'
+          : 'rounded-xl border border-indigo-100 bg-indigo-50/80 p-6 shadow-sm ring-1 ring-indigo-100'
+      }
+    >
+      <p
+        className={
+          mode === 'login'
+            ? 'text-xs font-medium uppercase tracking-wide text-gray-500'
+            : 'text-xs font-semibold uppercase tracking-wide text-indigo-800'
+        }
+      >
+        {mode === 'login' ? 'Plan from pricing' : 'Your selection'}
+      </p>
+      <h3
+        className={
+          mode === 'login'
+            ? 'mt-1 text-lg font-semibold text-gray-900'
+            : 'mt-1 text-xl font-bold text-gray-900'
+        }
+      >
+        {catalogPlan.display_name}
+      </h3>
+      {savingsCallout ? (
+        <p className='mt-1 text-xs font-semibold text-amber-900'>{savingsCallout}</p>
+      ) : null}
+      <div className='mt-3'>
+        <p
+          className={
+            mode === 'login'
+              ? 'text-xl font-bold text-gray-900'
+              : 'text-2xl font-bold text-gray-900'
+          }
+        >
+          {priceHeadline}
+        </p>
+        <p className='text-sm text-gray-600'>{priceSubline}</p>
+      </div>
+      {bullets.length > 0 ? (
+        <ul className='mt-4 list-inside list-disc space-y-1 text-sm text-gray-700'>
+          {bullets.map(line => (
+            <li key={line}>{line}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+export function SignupPlanSummary() {
+  return <PlanIntentSummary mode='signup' />;
+}
+
+export function LoginPlanSummary() {
+  return <PlanIntentSummary mode='login' />;
+}

--- a/apps/web/src/components/auth/SignupPlanSummary.tsx
+++ b/apps/web/src/components/auth/SignupPlanSummary.tsx
@@ -103,7 +103,9 @@ export function PlanIntentSummary({
         {catalogPlan.display_name}
       </h3>
       {savingsCallout ? (
-        <p className='mt-1 text-xs font-semibold text-amber-900'>{savingsCallout}</p>
+        <p className='mt-1 text-xs font-semibold text-amber-900'>
+          {savingsCallout}
+        </p>
       ) : null}
       <div className='mt-3'>
         <p

--- a/apps/web/src/components/auth/__tests__/SignupPlanSummary.test.tsx
+++ b/apps/web/src/components/auth/__tests__/SignupPlanSummary.test.tsx
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { Plan } from '@beakerstack/billing';
+import type { PlanSavingsCopy } from '../../../billing/billingSyncDisplay';
+import {
+  LoginPlanSummary,
+  SignupPlanSummary,
+} from '../SignupPlanSummary';
+
+const proPlan: Plan = {
+  id: 'beakerstack_pro',
+  product_id: 'beakerstack',
+  display_name: 'Pro',
+  description: null,
+  price_cents: 1900,
+  billing_period: 'monthly',
+  stripe_price_id_monthly: null,
+  stripe_price_id_annual: null,
+  stripe_product_id: null,
+  features: {},
+  usage_limits: {},
+  trial_period_days: 0,
+  is_public: true,
+  display_order: 2,
+};
+
+vi.mock('@beakerstack/billing', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('@beakerstack/billing')>();
+  return {
+    ...actual,
+    usePlanCatalog: vi.fn(),
+  };
+});
+
+vi.mock('../../billing/CadenceToggle.web', () => ({
+  getCadenceFromSearch: vi.fn(() => 'monthly'),
+}));
+
+vi.mock('../../../billing/billingSyncDisplay', () => ({
+  annualListCentsFromSync: vi.fn(() => 22_800),
+  formatSavingsCalloutFromCopy: vi.fn((copy: PlanSavingsCopy) =>
+    copy.kind === 'percent' ? `(Save ~${copy.pct}%)` : ''
+  ),
+  planAnnualSavingsCopy: vi.fn(
+    (): PlanSavingsCopy => ({
+      kind: 'none',
+    })
+  ),
+}));
+
+import { usePlanCatalog } from '@beakerstack/billing';
+import { getCadenceFromSearch } from '../../billing/CadenceToggle.web';
+import * as billingSync from '../../../billing/billingSyncDisplay';
+
+describe('PlanIntentSummary', () => {
+  beforeEach(() => {
+    vi.mocked(usePlanCatalog).mockReturnValue({
+      plans: [proPlan],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+    vi.mocked(getCadenceFromSearch).mockReturnValue('monthly');
+    vi.mocked(billingSync.planAnnualSavingsCopy).mockReturnValue({
+      kind: 'none',
+    });
+  });
+
+  it('renders nothing when plan query is missing', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/signup']}>
+        <SignupPlanSummary />
+      </MemoryRouter>
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows loading placeholder while catalog loads', () => {
+    vi.mocked(usePlanCatalog).mockReturnValue({
+      plans: [],
+      loading: true,
+      error: null,
+      refresh: vi.fn(),
+    });
+    render(
+      <MemoryRouter initialEntries={['/signup?plan=beakerstack_pro']}>
+        <SignupPlanSummary />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Loading plan/i)).toBeInTheDocument();
+  });
+
+  it('renders signup selection card with pricing and bullets', () => {
+    render(
+      <MemoryRouter initialEntries={['/signup?plan=beakerstack_pro']}>
+        <SignupPlanSummary />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Your selection')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Pro' })).toBeInTheDocument();
+    expect(screen.getByText(/per month/i)).toBeInTheDocument();
+    expect(screen.getByText(/Feature A/i)).toBeInTheDocument();
+  });
+
+  it('shows savings callout when annual cadence and copy exists', () => {
+    vi.mocked(getCadenceFromSearch).mockReturnValue('annual');
+    vi.mocked(billingSync.planAnnualSavingsCopy).mockReturnValue({
+      kind: 'percent',
+      pct: 17,
+    });
+    render(
+      <MemoryRouter initialEntries={['/signup?plan=beakerstack_pro&cadence=annual']}>
+        <SignupPlanSummary />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/\(Save ~17%\)/)).toBeInTheDocument();
+    expect(screen.getByText(/per year, billed annually/i)).toBeInTheDocument();
+  });
+
+  it('returns null when catalog row is non-paid', () => {
+    vi.mocked(usePlanCatalog).mockReturnValue({
+      plans: [{ ...proPlan, price_cents: 0 }],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+    const { container } = render(
+      <MemoryRouter initialEntries={['/signup?plan=beakerstack_pro']}>
+        <SignupPlanSummary />
+      </MemoryRouter>
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('uses compact login styling and fewer bullets', () => {
+    render(
+      <MemoryRouter initialEntries={['/login?plan=beakerstack_pro']}>
+        <LoginPlanSummary />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Plan from pricing')).toBeInTheDocument();
+    const bullets = screen.getAllByRole('listitem');
+    expect(bullets.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/apps/web/src/components/auth/__tests__/SignupPlanSummary.test.tsx
+++ b/apps/web/src/components/auth/__tests__/SignupPlanSummary.test.tsx
@@ -3,10 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import type { Plan } from '@beakerstack/billing';
 import type { PlanSavingsCopy } from '../../../billing/billingSyncDisplay';
-import {
-  LoginPlanSummary,
-  SignupPlanSummary,
-} from '../SignupPlanSummary';
+import { LoginPlanSummary, SignupPlanSummary } from '../SignupPlanSummary';
 
 const proPlan: Plan = {
   id: 'beakerstack_pro',
@@ -26,8 +23,7 @@ const proPlan: Plan = {
 };
 
 vi.mock('@beakerstack/billing', async importOriginal => {
-  const actual =
-    await importOriginal<typeof import('@beakerstack/billing')>();
+  const actual = await importOriginal<typeof import('@beakerstack/billing')>();
   return {
     ...actual,
     usePlanCatalog: vi.fn(),
@@ -111,7 +107,9 @@ describe('PlanIntentSummary', () => {
       pct: 17,
     });
     render(
-      <MemoryRouter initialEntries={['/signup?plan=beakerstack_pro&cadence=annual']}>
+      <MemoryRouter
+        initialEntries={['/signup?plan=beakerstack_pro&cadence=annual']}
+      >
         <SignupPlanSummary />
       </MemoryRouter>
     );

--- a/apps/web/src/components/billing/PlanCard.web.tsx
+++ b/apps/web/src/components/billing/PlanCard.web.tsx
@@ -58,7 +58,10 @@ export function PlanCard({
     plan.description ??
     undefined;
   return (
-    <div className='flex h-full flex-col rounded-xl border border-gray-200 bg-white p-6 shadow-sm'>
+    <div
+      id={`plan-card-${plan.id}`}
+      className='flex h-full flex-col rounded-xl border border-gray-200 bg-white p-6 shadow-sm'
+    >
       <div className='flex flex-wrap items-center gap-2'>
         <h3 className='text-xl font-semibold text-gray-900'>
           {plan.display_name}

--- a/apps/web/src/components/billing/__tests__/CurrentPlanCard.web.test.tsx
+++ b/apps/web/src/components/billing/__tests__/CurrentPlanCard.web.test.tsx
@@ -14,8 +14,7 @@ const resolveCadenceMock = vi.hoisted(() =>
 );
 
 vi.mock('@beakerstack/billing', async importOriginal => {
-  const actual =
-    await importOriginal<typeof import('@beakerstack/billing')>();
+  const actual = await importOriginal<typeof import('@beakerstack/billing')>();
   return {
     ...actual,
     resolveCadence: (plan: Plan | null, sub: SubscriptionRow | null) =>

--- a/apps/web/src/components/billing/__tests__/CurrentPlanCard.web.test.tsx
+++ b/apps/web/src/components/billing/__tests__/CurrentPlanCard.web.test.tsx
@@ -1,11 +1,34 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import type { Plan, SubscriptionRow } from '@beakerstack/billing';
 import { CurrentPlanCard } from '../CurrentPlanCard.web';
 
+type BillingCadence = 'monthly' | 'annual';
+
+const resolveCadenceMock = vi.hoisted(() =>
+  vi.fn(
+    (_plan: Plan | null, _sub: SubscriptionRow | null): BillingCadence | null =>
+      'monthly'
+  )
+);
+
+vi.mock('@beakerstack/billing', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('@beakerstack/billing')>();
+  return {
+    ...actual,
+    resolveCadence: (plan: Plan | null, sub: SubscriptionRow | null) =>
+      resolveCadenceMock(plan, sub),
+  };
+});
+
 vi.mock('@beakerstack/billing/web', () => ({
   SubscriptionStatusBadge: () => <span>badge</span>,
+}));
+
+vi.mock('../../../billing/billingSyncDisplay', () => ({
+  annualListCentsFromSync: vi.fn(() => 22_800),
 }));
 
 const plan: Plan = {
@@ -44,6 +67,10 @@ const subscription: SubscriptionRow = {
 };
 
 describe('CurrentPlanCard', () => {
+  beforeEach(() => {
+    resolveCadenceMock.mockReturnValue('monthly');
+  });
+
   it('returns null when plan is missing', () => {
     const { container } = render(
       <MemoryRouter>
@@ -106,5 +133,86 @@ describe('CurrentPlanCard', () => {
     expect(
       screen.queryByRole('button', { name: /Manage payment/i })
     ).not.toBeInTheDocument();
+  });
+
+  it('shows annual price when cadence resolves to annual', () => {
+    resolveCadenceMock.mockReturnValue('annual');
+    render(
+      <MemoryRouter>
+        <CurrentPlanCard
+          plan={plan}
+          subscription={subscription}
+          isFree={false}
+          onManagePayment={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/\$228\.00\/year/i)).toBeInTheDocument();
+  });
+
+  it('renders periodSubcopy when provided for paid subscription', () => {
+    render(
+      <MemoryRouter>
+        <CurrentPlanCard
+          plan={plan}
+          subscription={subscription}
+          isFree={false}
+          onManagePayment={vi.fn()}
+          periodSubcopy='Downgrade scheduled — ends Aug 1'
+        />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByText('Downgrade scheduled — ends Aug 1')
+    ).toBeInTheDocument();
+  });
+
+  it('shows Ends on when cancel_at_period_end', () => {
+    render(
+      <MemoryRouter>
+        <CurrentPlanCard
+          plan={plan}
+          subscription={{
+            ...subscription,
+            cancel_at_period_end: true,
+          }}
+          isFree={false}
+          onManagePayment={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/^Ends on /)).toBeInTheDocument();
+  });
+
+  it('shows Trial copy when status is trialing', () => {
+    render(
+      <MemoryRouter>
+        <CurrentPlanCard
+          plan={plan}
+          subscription={{
+            ...subscription,
+            status: 'trialing',
+            trial_end: new Date(Date.now() + 864e5 * 5).toISOString(),
+          }}
+          isFree={false}
+          onManagePayment={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/^Trial — ends /)).toBeInTheDocument();
+  });
+
+  it('shows Renews on by default for active paid subscription', () => {
+    render(
+      <MemoryRouter>
+        <CurrentPlanCard
+          plan={plan}
+          subscription={subscription}
+          isFree={false}
+          onManagePayment={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/^Renews on /)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/billing/__tests__/InvoiceTable.web.test.tsx
+++ b/apps/web/src/components/billing/__tests__/InvoiceTable.web.test.tsx
@@ -39,12 +39,7 @@ describe('InvoiceTable', () => {
 
   it('shows skeleton when loading with no items', () => {
     const { container } = renderTable(
-      <InvoiceTable
-        items={[]}
-        loading
-        hasMore={false}
-        onLoadMore={vi.fn()}
-      />
+      <InvoiceTable items={[]} loading hasMore={false} onLoadMore={vi.fn()} />
     );
     expect(container.querySelector('.animate-pulse')).toBeTruthy();
   });

--- a/apps/web/src/components/billing/__tests__/InvoiceTable.web.test.tsx
+++ b/apps/web/src/components/billing/__tests__/InvoiceTable.web.test.tsx
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import type { BillingInvoiceRow } from '@beakerstack/billing';
+import type { ReactElement } from 'react';
+import { InvoiceTable } from '../InvoiceTable.web';
+
+function renderTable(ui: ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+vi.mock('../../../billing/formatters', () => ({
+  formatDate: (iso: string) => `D:${iso.slice(0, 10)}`,
+  formatMoneyCents: (cents: number, currency?: string) =>
+    `${currency ?? 'usd'}:${cents}`,
+}));
+
+describe('InvoiceTable', () => {
+  const baseRow = (): BillingInvoiceRow => ({
+    id: 'inv_1',
+    user_id: 'u1',
+    stripe_invoice_id: 'in_1',
+    stripe_customer_id: 'cus_1',
+    stripe_subscription_id: 'sub_1',
+    amount_due: 0,
+    amount_paid: 1000,
+    currency: 'usd',
+    status: 'paid',
+    description: 'Subscription',
+    hosted_invoice_url: 'https://stripe.example/i',
+    invoice_pdf_url: 'https://stripe.example/p.pdf',
+    period_start: null,
+    period_end: null,
+    created_at: '2026-01-15T12:00:00Z',
+    finalized_at: null,
+    paid_at: null,
+  });
+
+  it('shows skeleton when loading with no items', () => {
+    const { container } = renderTable(
+      <InvoiceTable
+        items={[]}
+        loading
+        hasMore={false}
+        onLoadMore={vi.fn()}
+      />
+    );
+    expect(container.querySelector('.animate-pulse')).toBeTruthy();
+  });
+
+  it('shows empty state when not loading and no items', () => {
+    renderTable(
+      <InvoiceTable
+        items={[]}
+        loading={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/No invoices yet/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /View plans/i })).toHaveAttribute(
+      'href',
+      '/billing/plans'
+    );
+  });
+
+  it('renders rows with links when urls exist', () => {
+    renderTable(
+      <InvoiceTable
+        items={[baseRow()]}
+        loading={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Subscription')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View' })).toHaveAttribute(
+      'href',
+      'https://stripe.example/i'
+    );
+    expect(screen.getByRole('link', { name: 'PDF' })).toHaveAttribute(
+      'href',
+      'https://stripe.example/p.pdf'
+    );
+  });
+
+  it('uses amount_due when amount_paid is zero', () => {
+    renderTable(
+      <InvoiceTable
+        items={[
+          {
+            ...baseRow(),
+            amount_paid: 0,
+            amount_due: 2500,
+          },
+        ]}
+        loading={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+      />
+    );
+    expect(screen.getByText('usd:2500')).toBeInTheDocument();
+  });
+
+  it('shows em dash when description is missing', () => {
+    renderTable(
+      <InvoiceTable
+        items={[{ ...baseRow(), description: null }]}
+        loading={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+      />
+    );
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('calls onLoadMore when Load more is pressed', async () => {
+    const user = userEvent.setup();
+    const onLoadMore = vi.fn();
+    renderTable(
+      <InvoiceTable
+        items={[baseRow()]}
+        loading={false}
+        hasMore
+        onLoadMore={onLoadMore}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /Load more/i }));
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/landing/sections/FeatureGrid.tsx
+++ b/apps/web/src/components/landing/sections/FeatureGrid.tsx
@@ -6,7 +6,10 @@ interface FeatureGridProps {
 
 export function FeatureGrid({ config }: FeatureGridProps) {
   return (
-    <section id='features' className='py-20 md:py-24 bg-gray-50 dark:bg-gray-900'>
+    <section
+      id='features'
+      className='py-20 md:py-24 bg-gray-50 dark:bg-gray-900'
+    >
       <div className='max-w-[1200px] mx-auto px-6'>
         <div className='text-center mb-12'>
           <h2 className='text-3xl font-bold text-gray-900 dark:text-white mb-3'>

--- a/apps/web/src/components/landing/sections/FeatureRows.tsx
+++ b/apps/web/src/components/landing/sections/FeatureRows.tsx
@@ -17,7 +17,9 @@ export function FeatureRows({ config }: FeatureRowsProps) {
               className='grid md:grid-cols-2 gap-12 items-center'
             >
               {/* On mobile: image always first */}
-              <div className={`order-1 ${imageFirst ? 'md:order-1' : 'md:order-2'}`}>
+              <div
+                className={`order-1 ${imageFirst ? 'md:order-1' : 'md:order-2'}`}
+              >
                 <div className='rounded-xl overflow-hidden border border-gray-200 dark:border-gray-800 shadow-md bg-gray-100 dark:bg-gray-900 aspect-video flex items-center justify-center'>
                   <img
                     src={row.mediaSrc}
@@ -30,7 +32,9 @@ export function FeatureRows({ config }: FeatureRowsProps) {
                   />
                 </div>
               </div>
-              <div className={`order-2 ${imageFirst ? 'md:order-2' : 'md:order-1'}`}>
+              <div
+                className={`order-2 ${imageFirst ? 'md:order-2' : 'md:order-1'}`}
+              >
                 <h2 className='text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-4'>
                   {row.title}
                 </h2>

--- a/apps/web/src/components/landing/sections/Nav.tsx
+++ b/apps/web/src/components/landing/sections/Nav.tsx
@@ -27,7 +27,9 @@ export function Nav({ config }: NavProps) {
   return (
     <header
       className={`sticky top-0 z-50 bg-white dark:bg-gray-950 transition-shadow ${
-        scrolled ? 'border-b border-gray-200 dark:border-gray-800 shadow-sm' : ''
+        scrolled
+          ? 'border-b border-gray-200 dark:border-gray-800 shadow-sm'
+          : ''
       }`}
     >
       <div className='max-w-[1200px] mx-auto px-6 flex items-center justify-between h-16'>
@@ -79,7 +81,11 @@ export function Nav({ config }: NavProps) {
                 stroke='currentColor'
                 strokeWidth={2}
               >
-                <path strokeLinecap='round' strokeLinejoin='round' d='M6 18L18 6M6 6l12 12' />
+                <path
+                  strokeLinecap='round'
+                  strokeLinejoin='round'
+                  d='M6 18L18 6M6 6l12 12'
+                />
               </svg>
             ) : (
               <svg
@@ -90,7 +96,11 @@ export function Nav({ config }: NavProps) {
                 stroke='currentColor'
                 strokeWidth={2}
               >
-                <path strokeLinecap='round' strokeLinejoin='round' d='M4 6h16M4 12h16M4 18h16' />
+                <path
+                  strokeLinecap='round'
+                  strokeLinejoin='round'
+                  d='M4 6h16M4 12h16M4 18h16'
+                />
               </svg>
             )}
           </button>

--- a/apps/web/src/components/landing/sections/PricingSection.tsx
+++ b/apps/web/src/components/landing/sections/PricingSection.tsx
@@ -3,7 +3,10 @@ import { BillingProvider, usePlanCatalog } from '@beakerstack/billing';
 import { supabase } from '../../../lib/supabase';
 import { beakerstackBillingConfig } from '../../../billing/beakerstackBillingConfig';
 import { PlanCard } from '../../billing/PlanCard.web';
-import { CadenceToggle, getCadenceFromSearch } from '../../billing/CadenceToggle.web';
+import {
+  CadenceToggle,
+  getCadenceFromSearch,
+} from '../../billing/CadenceToggle.web';
 import {
   annualListCentsFromSync,
   planAnnualSavingsCopy,
@@ -27,7 +30,9 @@ function LandingPricingTable() {
   const { plans, loading } = usePlanCatalog<typeof beakerstackBillingConfig>();
 
   if (loading) {
-    return <p className='mt-8 text-center text-sm text-gray-500'>Loading plans…</p>;
+    return (
+      <p className='mt-8 text-center text-sm text-gray-500'>Loading plans…</p>
+    );
   }
 
   return (
@@ -53,15 +58,15 @@ function LandingPricingTable() {
             plan.price_cents === 0
               ? 'US$0'
               : isAnnual && annualCents != null
-              ? fmt(annualCents)
-              : fmt(plan.price_cents);
+                ? fmt(annualCents)
+                : fmt(plan.price_cents);
 
           const priceSubline =
             plan.price_cents === 0
               ? 'Free forever'
               : isAnnual
-              ? 'per year'
-              : 'per month';
+                ? 'per year'
+                : 'per month';
 
           const savingsCopy = isAnnual
             ? planAnnualSavingsCopy(plan.id, plan.price_cents)
@@ -101,13 +106,18 @@ export function PricingSection({ config }: PricingSectionProps) {
   const base = appBasePath();
 
   return (
-    <section id='pricing' className='py-20 md:py-24 bg-gray-50 dark:bg-gray-900'>
+    <section
+      id='pricing'
+      className='py-20 md:py-24 bg-gray-50 dark:bg-gray-900'
+    >
       <div className='max-w-[1200px] mx-auto px-6'>
         <div className='text-center mb-12'>
           <h2 className='text-3xl font-bold text-gray-900 dark:text-white mb-3'>
             {config.heading}
           </h2>
-          <p className='text-lg text-gray-600 dark:text-gray-400'>{config.subhead}</p>
+          <p className='text-lg text-gray-600 dark:text-gray-400'>
+            {config.subhead}
+          </p>
         </div>
         <BillingProvider<typeof beakerstackBillingConfig>
           supabase={supabase}

--- a/apps/web/src/components/landing/sections/SocialProof.tsx
+++ b/apps/web/src/components/landing/sections/SocialProof.tsx
@@ -17,7 +17,9 @@ export function SocialProof({ config }: SocialProofProps) {
                 <p className='text-3xl font-bold text-gray-900 dark:text-white mb-1'>
                   {item.metric}
                 </p>
-                <p className='text-sm text-gray-500 dark:text-gray-400'>{item.label}</p>
+                <p className='text-sm text-gray-500 dark:text-gray-400'>
+                  {item.label}
+                </p>
               </div>
             ))}
           </div>
@@ -40,9 +42,13 @@ export function SocialProof({ config }: SocialProofProps) {
                   "{item.quote}"
                 </p>
                 <footer className='text-sm'>
-                  <span className='font-semibold text-gray-900 dark:text-white'>{item.author}</span>
+                  <span className='font-semibold text-gray-900 dark:text-white'>
+                    {item.author}
+                  </span>
                   {item.role && (
-                    <span className='text-gray-500 dark:text-gray-400'>, {item.role}</span>
+                    <span className='text-gray-500 dark:text-gray-400'>
+                      , {item.role}
+                    </span>
                   )}
                 </footer>
               </blockquote>

--- a/apps/web/src/components/landing/sections/__tests__/FAQ.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/FAQ.test.tsx
@@ -26,7 +26,9 @@ describe('FAQ', () => {
 
   it('renders all FAQ answers', () => {
     render(<FAQ config={faqConfig} />);
-    expect(screen.getByText('An open-source SaaS template.')).toBeInTheDocument();
+    expect(
+      screen.getByText('An open-source SaaS template.')
+    ).toBeInTheDocument();
     expect(screen.getByText('Yes, MIT licensed.')).toBeInTheDocument();
     expect(screen.getByText('Yes, React Native included.')).toBeInTheDocument();
   });

--- a/apps/web/src/components/landing/sections/__tests__/FeatureGrid.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/FeatureGrid.test.tsx
@@ -28,16 +28,24 @@ const config = {
 describe('FeatureGrid', () => {
   it('renders the section heading and subhead', () => {
     render(<FeatureGrid config={config} />);
-    expect(screen.getByRole('heading', { name: 'Everything you need' })).toBeInTheDocument();
-    expect(screen.getByText('A complete toolkit for modern SaaS.')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Everything you need' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('A complete toolkit for modern SaaS.')
+    ).toBeInTheDocument();
   });
 
   it('renders all feature item titles and bodies', () => {
     render(<FeatureGrid config={config} />);
     expect(screen.getByText('Auth')).toBeInTheDocument();
-    expect(screen.getByText('Secure authentication out of the box.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Secure authentication out of the box.')
+    ).toBeInTheDocument();
     expect(screen.getByText('Billing')).toBeInTheDocument();
-    expect(screen.getByText('Stripe-powered subscriptions.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Stripe-powered subscriptions.')
+    ).toBeInTheDocument();
   });
 
   it('renders internal CTA link without target or rel', () => {

--- a/apps/web/src/components/landing/sections/__tests__/FeatureRows.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/FeatureRows.test.tsx
@@ -16,7 +16,8 @@ const rows = [
     title: 'Set up in minutes.',
     body: 'A single npm run setup provisions your local environment.',
     ctaLabel: 'Read the architecture',
-    ctaHref: 'https://github.com/Artificer-Innovations/BeakerStack/blob/main/ARCHITECTURE.md',
+    ctaHref:
+      'https://github.com/Artificer-Innovations/BeakerStack/blob/main/ARCHITECTURE.md',
     mediaSrc: 'https://placehold.co/560x315?text=Setup',
     mediaAlt: 'Setup screenshot',
     mediaSide: 'left' as const,
@@ -30,7 +31,9 @@ describe('FeatureRows', () => {
       screen.getByRole('heading', { name: 'Web and mobile from one codebase.' })
     ).toBeInTheDocument();
     expect(
-      screen.getByText('Shared auth, billing, and business rules across platforms.')
+      screen.getByText(
+        'Shared auth, billing, and business rules across platforms.'
+      )
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: 'Set up in minutes.' })

--- a/apps/web/src/components/landing/sections/__tests__/FinalCTA.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/FinalCTA.test.tsx
@@ -20,7 +20,9 @@ describe('FinalCTA', () => {
     expect(
       screen.getByRole('heading', { name: 'Ready to ship faster?' })
     ).toBeInTheDocument();
-    expect(screen.getByText('Start building your SaaS today.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Start building your SaaS today.')
+    ).toBeInTheDocument();
   });
 
   it('renders the primary CTA link', () => {
@@ -29,13 +31,18 @@ describe('FinalCTA', () => {
         <FinalCTA config={baseConfig} />
       </MemoryRouter>
     );
-    expect(screen.getByRole('link', { name: 'Get started free' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Get started free' })
+    ).toBeInTheDocument();
   });
 
   it('renders secondary CTA with target="_blank" and rel="noopener noreferrer"', () => {
     const config = {
       ...baseConfig,
-      secondaryCta: { label: 'View on GitHub', href: 'https://github.com/Artificer-Innovations/BeakerStack' },
+      secondaryCta: {
+        label: 'View on GitHub',
+        href: 'https://github.com/Artificer-Innovations/BeakerStack',
+      },
     };
     render(
       <MemoryRouter>
@@ -43,7 +50,10 @@ describe('FinalCTA', () => {
       </MemoryRouter>
     );
     const secondary = screen.getByRole('link', { name: 'View on GitHub' });
-    expect(secondary).toHaveAttribute('href', 'https://github.com/Artificer-Innovations/BeakerStack');
+    expect(secondary).toHaveAttribute(
+      'href',
+      'https://github.com/Artificer-Innovations/BeakerStack'
+    );
     expect(secondary).toHaveAttribute('target', '_blank');
     expect(secondary).toHaveAttribute('rel', 'noopener noreferrer');
   });

--- a/apps/web/src/components/landing/sections/__tests__/Hero.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/Hero.test.tsx
@@ -19,7 +19,9 @@ describe('Hero', () => {
       </MemoryRouter>
     );
     expect(
-      screen.getByRole('heading', { name: 'Build the full stack. Not the scaffolding.' })
+      screen.getByRole('heading', {
+        name: 'Build the full stack. Not the scaffolding.',
+      })
     ).toBeInTheDocument();
     expect(
       screen.getByText('BeakerStack ships with everything a SaaS needs.')
@@ -32,7 +34,9 @@ describe('Hero', () => {
         <Hero config={baseConfig} />
       </MemoryRouter>
     );
-    expect(screen.getByRole('link', { name: 'Get started free' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Get started free' })
+    ).toBeInTheDocument();
   });
 
   it('renders the hero image with eager loading', () => {
@@ -42,14 +46,19 @@ describe('Hero', () => {
       </MemoryRouter>
     );
     const img = screen.getByRole('img', { name: 'Dashboard preview' });
-    expect(img).toHaveAttribute('src', 'https://placehold.co/600x338?text=Dashboard');
+    expect(img).toHaveAttribute(
+      'src',
+      'https://placehold.co/600x338?text=Dashboard'
+    );
     expect(img).toHaveAttribute('loading', 'eager');
   });
 
   it('renders eyebrow text when provided', () => {
     render(
       <MemoryRouter>
-        <Hero config={{ ...baseConfig, eyebrow: 'Open source SaaS template' }} />
+        <Hero
+          config={{ ...baseConfig, eyebrow: 'Open source SaaS template' }}
+        />
       </MemoryRouter>
     );
     expect(screen.getByText('Open source SaaS template')).toBeInTheDocument();
@@ -61,7 +70,9 @@ describe('Hero', () => {
         <Hero config={baseConfig} />
       </MemoryRouter>
     );
-    expect(screen.queryByText('Open source SaaS template')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Open source SaaS template')
+    ).not.toBeInTheDocument();
   });
 
   it('renders secondary CTA when provided', () => {
@@ -70,12 +81,17 @@ describe('Hero', () => {
         <Hero
           config={{
             ...baseConfig,
-            secondaryCta: { label: 'View on GitHub', href: 'https://github.com/Artificer-Innovations/BeakerStack' },
+            secondaryCta: {
+              label: 'View on GitHub',
+              href: 'https://github.com/Artificer-Innovations/BeakerStack',
+            },
           }}
         />
       </MemoryRouter>
     );
-    expect(screen.getByRole('link', { name: 'View on GitHub' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'View on GitHub' })
+    ).toBeInTheDocument();
   });
 
   it('does not render secondary CTA when absent', () => {
@@ -90,10 +106,17 @@ describe('Hero', () => {
   it('renders trust strip when provided', () => {
     render(
       <MemoryRouter>
-        <Hero config={{ ...baseConfig, trustStrip: 'MIT licensed · No vendor lock-in' }} />
+        <Hero
+          config={{
+            ...baseConfig,
+            trustStrip: 'MIT licensed · No vendor lock-in',
+          }}
+        />
       </MemoryRouter>
     );
-    expect(screen.getByText('MIT licensed · No vendor lock-in')).toBeInTheDocument();
+    expect(
+      screen.getByText('MIT licensed · No vendor lock-in')
+    ).toBeInTheDocument();
   });
 
   it('does not render trust strip when absent', () => {

--- a/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
@@ -4,7 +4,11 @@ import { MemoryRouter } from 'react-router-dom';
 import { Nav } from '../Nav';
 
 const config = {
-  brand: { name: 'BeakerStack', tagline: 'Ship your SaaS faster.', logoSrc: '/logo.svg' },
+  brand: {
+    name: 'BeakerStack',
+    tagline: 'Ship your SaaS faster.',
+    logoSrc: '/logo.svg',
+  },
   links: [
     { href: '#features', label: 'Features' },
     { href: '#pricing', label: 'Pricing' },
@@ -29,7 +33,9 @@ describe('Nav', () => {
 
   it('renders desktop navigation links', () => {
     renderNav();
-    expect(screen.getByRole('navigation', { name: 'Main' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('navigation', { name: 'Main' })
+    ).toBeInTheDocument();
     const mainNav = screen.getByRole('navigation', { name: 'Main' });
     expect(mainNav).toHaveTextContent('Features');
     expect(mainNav).toHaveTextContent('Pricing');
@@ -38,7 +44,9 @@ describe('Nav', () => {
   it('renders Sign in and Get started buttons', () => {
     renderNav();
     expect(screen.getByRole('link', { name: 'Sign in' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Get started' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Get started' })
+    ).toBeInTheDocument();
   });
 
   it('mobile menu toggle starts with aria-expanded false', () => {
@@ -52,7 +60,9 @@ describe('Nav', () => {
     const toggle = screen.getByRole('button', { name: 'Toggle menu' });
     fireEvent.click(toggle);
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
-    expect(screen.getByRole('navigation', { name: 'Mobile' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('navigation', { name: 'Mobile' })
+    ).toBeInTheDocument();
   });
 
   it('mobile menu shows nav links and sign in', () => {
@@ -69,7 +79,9 @@ describe('Nav', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Toggle menu' }));
     const mobileNav = screen.getByRole('navigation', { name: 'Mobile' });
     fireEvent.click(within(mobileNav).getByRole('link', { name: 'Features' }));
-    expect(screen.queryByRole('navigation', { name: 'Mobile' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('navigation', { name: 'Mobile' })
+    ).not.toBeInTheDocument();
   });
 
   it('adds shadow class after scrolling past threshold', () => {
@@ -78,7 +90,11 @@ describe('Nav', () => {
     expect(header.className).not.toContain('shadow-sm');
 
     act(() => {
-      Object.defineProperty(window, 'scrollY', { value: 50, writable: true, configurable: true });
+      Object.defineProperty(window, 'scrollY', {
+        value: 50,
+        writable: true,
+        configurable: true,
+      });
       window.dispatchEvent(new Event('scroll'));
     });
 
@@ -90,13 +106,21 @@ describe('Nav', () => {
     const header = screen.getByRole('banner');
 
     act(() => {
-      Object.defineProperty(window, 'scrollY', { value: 50, writable: true, configurable: true });
+      Object.defineProperty(window, 'scrollY', {
+        value: 50,
+        writable: true,
+        configurable: true,
+      });
       window.dispatchEvent(new Event('scroll'));
     });
     expect(header.className).toContain('shadow-sm');
 
     act(() => {
-      Object.defineProperty(window, 'scrollY', { value: 0, writable: true, configurable: true });
+      Object.defineProperty(window, 'scrollY', {
+        value: 0,
+        writable: true,
+        configurable: true,
+      });
       window.dispatchEvent(new Event('scroll'));
     });
     expect(header.className).not.toContain('shadow-sm');

--- a/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
@@ -1,8 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import type { LandingConfig } from '../../../../config/landing';
 import { PricingSection } from '../PricingSection';
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+const getCadenceFromSearchMock = vi.hoisted(() =>
+  vi.fn((_search: URLSearchParams): 'monthly' | 'annual' => 'monthly')
+);
+
+vi.mock('react-router-dom', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 vi.mock('@beakerstack/billing', () => ({
   BillingProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -13,13 +28,26 @@ vi.mock('../../../../billing/beakerstackBillingConfig', () => ({
   beakerstackBillingConfig: { plans: [] },
 }));
 vi.mock('../../../billing/PlanCard.web', () => ({
-  PlanCard: ({ plan }: { plan: { display_name: string } }) => (
-    <div data-testid='plan-card'>{plan.display_name}</div>
+  PlanCard: ({
+    plan,
+    primary,
+  }: {
+    plan: { id: string; display_name: string };
+    primary: { label: string; onClick: () => void };
+  }) => (
+    <button
+      type='button'
+      data-testid={`plan-card-${plan.id}`}
+      onClick={primary.onClick}
+    >
+      {plan.display_name}
+    </button>
   ),
 }));
 vi.mock('../../../billing/CadenceToggle.web', () => ({
   CadenceToggle: () => <div data-testid='cadence-toggle'>Toggle</div>,
-  getCadenceFromSearch: vi.fn(() => 'monthly'),
+  getCadenceFromSearch: (search: URLSearchParams) =>
+    getCadenceFromSearchMock(search),
 }));
 vi.mock('../../../../billing/billingSyncDisplay', () => ({
   annualListCentsFromSync: vi.fn(() => 22800),
@@ -50,6 +78,8 @@ function renderSection(config: LandingConfig['pricing'] = baseConfig) {
 
 describe('PricingSection', () => {
   beforeEach(() => {
+    mockNavigate.mockClear();
+    getCadenceFromSearchMock.mockReturnValue('monthly');
     vi.mocked(usePlanCatalog).mockReturnValue(
       { plans: mockPlans, loading: false } as unknown as ReturnType<typeof usePlanCatalog>
     );
@@ -70,11 +100,24 @@ describe('PricingSection', () => {
 
   it('renders a plan card for each plan', () => {
     renderSection();
-    const cards = screen.getAllByTestId('plan-card');
-    expect(cards).toHaveLength(3);
-    expect(cards[0]).toHaveTextContent('Free');
-    expect(cards[1]).toHaveTextContent('Pro');
-    expect(cards[2]).toHaveTextContent('Team');
+    expect(screen.getByTestId('plan-card-free')).toHaveTextContent('Free');
+    expect(screen.getByTestId('plan-card-pro')).toHaveTextContent('Pro');
+    expect(screen.getByTestId('plan-card-team')).toHaveTextContent('Team');
+  });
+
+  it('navigates to signup with encoded plan id', async () => {
+    const user = userEvent.setup();
+    renderSection();
+    await user.click(screen.getByTestId('plan-card-pro'));
+    expect(mockNavigate).toHaveBeenCalledWith('/signup?plan=pro');
+  });
+
+  it('appends cadence=annual when annual pricing is selected', async () => {
+    const user = userEvent.setup();
+    getCadenceFromSearchMock.mockReturnValue('annual');
+    renderSection();
+    await user.click(screen.getByTestId('plan-card-pro'));
+    expect(mockNavigate).toHaveBeenCalledWith('/signup?plan=pro&cadence=annual');
   });
 
   it('shows loading message while plans are loading', () => {
@@ -83,7 +126,7 @@ describe('PricingSection', () => {
     );
     renderSection();
     expect(screen.getByText(/Loading plans/)).toBeInTheDocument();
-    expect(screen.queryByTestId('plan-card')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('plan-card-free')).not.toBeInTheDocument();
   });
 
   it('renders disclaimer when provided', () => {

--- a/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
@@ -11,8 +11,7 @@ const getCadenceFromSearchMock = vi.hoisted(() =>
 );
 
 vi.mock('react-router-dom', async importOriginal => {
-  const actual =
-    await importOriginal<typeof import('react-router-dom')>();
+  const actual = await importOriginal<typeof import('react-router-dom')>();
   return {
     ...actual,
     useNavigate: () => mockNavigate,
@@ -20,7 +19,9 @@ vi.mock('react-router-dom', async importOriginal => {
 });
 
 vi.mock('@beakerstack/billing', () => ({
-  BillingProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  BillingProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
   usePlanCatalog: vi.fn(),
 }));
 vi.mock('../../../../lib/supabase', () => ({ supabase: {} }));
@@ -80,9 +81,10 @@ describe('PricingSection', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
     getCadenceFromSearchMock.mockReturnValue('monthly');
-    vi.mocked(usePlanCatalog).mockReturnValue(
-      { plans: mockPlans, loading: false } as unknown as ReturnType<typeof usePlanCatalog>
-    );
+    vi.mocked(usePlanCatalog).mockReturnValue({
+      plans: mockPlans,
+      loading: false,
+    } as unknown as ReturnType<typeof usePlanCatalog>);
   });
 
   it('renders heading and subhead', () => {
@@ -90,7 +92,9 @@ describe('PricingSection', () => {
     expect(
       screen.getByRole('heading', { name: 'Simple, transparent pricing' })
     ).toBeInTheDocument();
-    expect(screen.getByText('Start free. Scale as you grow.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Start free. Scale as you grow.')
+    ).toBeInTheDocument();
   });
 
   it('renders the cadence toggle', () => {
@@ -117,21 +121,29 @@ describe('PricingSection', () => {
     getCadenceFromSearchMock.mockReturnValue('annual');
     renderSection();
     await user.click(screen.getByTestId('plan-card-pro'));
-    expect(mockNavigate).toHaveBeenCalledWith('/signup?plan=pro&cadence=annual');
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/signup?plan=pro&cadence=annual'
+    );
   });
 
   it('shows loading message while plans are loading', () => {
-    vi.mocked(usePlanCatalog).mockReturnValue(
-      { plans: [], loading: true } as unknown as ReturnType<typeof usePlanCatalog>
-    );
+    vi.mocked(usePlanCatalog).mockReturnValue({
+      plans: [],
+      loading: true,
+    } as unknown as ReturnType<typeof usePlanCatalog>);
     renderSection();
     expect(screen.getByText(/Loading plans/)).toBeInTheDocument();
     expect(screen.queryByTestId('plan-card-free')).not.toBeInTheDocument();
   });
 
   it('renders disclaimer when provided', () => {
-    renderSection({ ...baseConfig, disclaimer: 'Prices in USD. Cancel anytime.' });
-    expect(screen.getByText('Prices in USD. Cancel anytime.')).toBeInTheDocument();
+    renderSection({
+      ...baseConfig,
+      disclaimer: 'Prices in USD. Cancel anytime.',
+    });
+    expect(
+      screen.getByText('Prices in USD. Cancel anytime.')
+    ).toBeInTheDocument();
   });
 
   it('does not render disclaimer when absent', () => {

--- a/apps/web/src/components/landing/sections/__tests__/SocialProof.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/SocialProof.test.tsx
@@ -34,13 +34,19 @@ describe('SocialProof', () => {
         config={{
           kind: 'testimonials',
           items: [
-            { quote: 'Best template I have used.', author: 'Alice', role: 'CTO' },
+            {
+              quote: 'Best template I have used.',
+              author: 'Alice',
+              role: 'CTO',
+            },
             { quote: 'Saved us weeks of work.', author: 'Bob' },
           ],
         }}
       />
     );
-    expect(screen.getByText(/"Best template I have used\."/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/"Best template I have used\."/)
+    ).toBeInTheDocument();
     expect(screen.getByText('Alice')).toBeInTheDocument();
     expect(screen.getByText(', CTO')).toBeInTheDocument();
     expect(screen.getByText(/"Saved us weeks of work\."/)).toBeInTheDocument();

--- a/apps/web/src/config/landing.example.alt.ts
+++ b/apps/web/src/config/landing.example.alt.ts
@@ -17,7 +17,8 @@ export const altLandingConfig: LandingConfig = {
   },
   hero: {
     headline: 'Build your SaaS without the boilerplate.',
-    subhead: 'LaunchPad is the fastest way to go from idea to paying customers — auth, billing, and mobile included.',
+    subhead:
+      'LaunchPad is the fastest way to go from idea to paying customers — auth, billing, and mobile included.',
     primaryCta: { label: 'Start building', href: '/signup' },
     secondaryCta: { label: 'See how it works', href: '#features' },
     mediaSrc: '/landing/placeholder-hero.png',
@@ -25,14 +26,39 @@ export const altLandingConfig: LandingConfig = {
   },
   featureGrid: {
     heading: 'Everything you need. Nothing you do not.',
-    subhead: 'Stop wiring libraries together and start building your actual product.',
+    subhead:
+      'Stop wiring libraries together and start building your actual product.',
     items: [
-      { icon: Rocket, title: 'Ship in hours', body: 'Clone, configure, and deploy. Your MVP is live the same day.' },
-      { icon: Lock, title: 'Auth included', body: 'Email and OAuth logins via Supabase, secured with row-level policies.' },
-      { icon: TrendingUp, title: 'Grow with billing', body: 'Stripe subscriptions and usage metering ready on day one.' },
-      { icon: Globe, title: 'Web and mobile', body: 'React and React Native sharing the same business logic.' },
-      { icon: Layers, title: 'Clean architecture', body: 'Monorepo with clear package boundaries — easy to extend.' },
-      { icon: Users, title: 'Multi-tenant ready', body: 'Data isolation built in. Add your users and go.' },
+      {
+        icon: Rocket,
+        title: 'Ship in hours',
+        body: 'Clone, configure, and deploy. Your MVP is live the same day.',
+      },
+      {
+        icon: Lock,
+        title: 'Auth included',
+        body: 'Email and OAuth logins via Supabase, secured with row-level policies.',
+      },
+      {
+        icon: TrendingUp,
+        title: 'Grow with billing',
+        body: 'Stripe subscriptions and usage metering ready on day one.',
+      },
+      {
+        icon: Globe,
+        title: 'Web and mobile',
+        body: 'React and React Native sharing the same business logic.',
+      },
+      {
+        icon: Layers,
+        title: 'Clean architecture',
+        body: 'Monorepo with clear package boundaries — easy to extend.',
+      },
+      {
+        icon: Users,
+        title: 'Multi-tenant ready',
+        body: 'Data isolation built in. Add your users and go.',
+      },
     ],
   },
   featureRows: [
@@ -53,9 +79,15 @@ export const altLandingConfig: LandingConfig = {
   faq: {
     heading: 'Questions',
     items: [
-      { q: 'What is LaunchPad?', a: 'LaunchPad is a full-stack SaaS starter built on React, Supabase, and Stripe.' },
+      {
+        q: 'What is LaunchPad?',
+        a: 'LaunchPad is a full-stack SaaS starter built on React, Supabase, and Stripe.',
+      },
       { q: 'Can I use it commercially?', a: 'Yes — MIT licensed.' },
-      { q: 'How long does setup take?', a: 'Under five minutes to run locally. Under an hour to deploy.' },
+      {
+        q: 'How long does setup take?',
+        a: 'Under five minutes to run locally. Under an hour to deploy.',
+      },
     ],
   },
   finalCta: {
@@ -66,11 +98,32 @@ export const altLandingConfig: LandingConfig = {
   },
   footer: {
     columns: [
-      { heading: 'Product', links: [{ label: 'Features', href: '#features' }, { label: 'Pricing', href: '#pricing' }] },
-      { heading: 'Company', links: [{ label: 'About', href: '#' }, { label: 'GitHub', href: '#' }] },
-      { heading: 'Legal', links: [{ label: 'Terms', href: '/terms' }, { label: 'Privacy', href: '/privacy' }] },
+      {
+        heading: 'Product',
+        links: [
+          { label: 'Features', href: '#features' },
+          { label: 'Pricing', href: '#pricing' },
+        ],
+      },
+      {
+        heading: 'Company',
+        links: [
+          { label: 'About', href: '#' },
+          { label: 'GitHub', href: '#' },
+        ],
+      },
+      {
+        heading: 'Legal',
+        links: [
+          { label: 'Terms', href: '/terms' },
+          { label: 'Privacy', href: '/privacy' },
+        ],
+      },
     ],
-    legalLinks: [{ label: 'Terms', href: '/terms' }, { label: 'Privacy', href: '/privacy' }],
+    legalLinks: [
+      { label: 'Terms', href: '/terms' },
+      { label: 'Privacy', href: '/privacy' },
+    ],
     copyright: `© ${new Date().getFullYear()} LaunchPad Corp. All rights reserved.`,
   },
 };

--- a/apps/web/src/config/landing.ts
+++ b/apps/web/src/config/landing.ts
@@ -141,7 +141,8 @@ export const landingConfig: LandingConfig = {
   },
   featureGrid: {
     heading: 'Everything wired. Nothing hidden.',
-    subhead: 'Stop stitching libraries together. BeakerStack ships the hard parts pre-integrated.',
+    subhead:
+      'Stop stitching libraries together. BeakerStack ships the hard parts pre-integrated.',
     items: [
       {
         icon: Zap,
@@ -215,7 +216,8 @@ export const landingConfig: LandingConfig = {
       title: 'Environments that match your shipping workflow.',
       body: 'Three Supabase databases—local Docker, shared PR testing, and staging—mirror your branching model. Migrations are validated before they touch production. PR previews deploy automatically to path-based S3/CloudFront URLs. EAS Update channels give mobile the same preview → staging → production flow.',
       ctaLabel: 'Read the architecture docs',
-      ctaHref: 'https://github.com/Artificer-Innovations/BeakerStack/blob/main/ARCHITECTURE.md',
+      ctaHref:
+        'https://github.com/Artificer-Innovations/BeakerStack/blob/main/ARCHITECTURE.md',
       mediaSrc: 'https://placehold.co/560x315?text=Environments',
       mediaAlt: 'Three-environment pipeline diagram',
       mediaSide: 'right',
@@ -224,7 +226,8 @@ export const landingConfig: LandingConfig = {
       title: 'Set up in minutes. Documented for the long haul.',
       body: 'Run `npm run setup` to provision your local environment in one step. QUICKSTART, ARCHITECTURE, and focused guides (OAuth, Stripe, testing) explain key decisions. Env vars and secrets use a consistent layout that maps directly to GitHub Actions.',
       ctaLabel: 'Read the quickstart',
-      ctaHref: 'https://github.com/Artificer-Innovations/BeakerStack/blob/main/QUICKSTART.md',
+      ctaHref:
+        'https://github.com/Artificer-Innovations/BeakerStack/blob/main/QUICKSTART.md',
       mediaSrc: 'https://placehold.co/560x315?text=Setup',
       mediaAlt: 'Setup guide screenshot',
       mediaSide: 'left',
@@ -234,7 +237,10 @@ export const landingConfig: LandingConfig = {
     kind: 'metrics',
     items: [
       { metric: '40–60%', label: 'Code shared between web and mobile' },
-      { metric: '3 environments', label: 'PR preview, staging, and production' },
+      {
+        metric: '3 environments',
+        label: 'PR preview, staging, and production',
+      },
       { metric: 'MIT licensed', label: '100% open source, no vendor lock-in' },
     ],
   },
@@ -242,7 +248,8 @@ export const landingConfig: LandingConfig = {
     heading: 'Simple, transparent pricing.',
     subhead:
       'BeakerStack itself is free and open-source (MIT) — clone it and ship your product at no cost. The plans below are a live demo of the billing system built into the template.',
-    disclaimer: 'Stripe is running in test mode for this preview; no real charges are made.',
+    disclaimer:
+      'Stripe is running in test mode for this preview; no real charges are made.',
   },
   faq: {
     heading: 'Frequently asked questions',
@@ -303,7 +310,10 @@ export const landingConfig: LandingConfig = {
         links: [
           { label: 'About', href: '#' },
           { label: 'Blog', href: '#' },
-          { label: 'GitHub', href: 'https://github.com/Artificer-Innovations/BeakerStack' },
+          {
+            label: 'GitHub',
+            href: 'https://github.com/Artificer-Innovations/BeakerStack',
+          },
         ],
       },
       {

--- a/apps/web/src/lib/appBasePath.ts
+++ b/apps/web/src/lib/appBasePath.ts
@@ -1,0 +1,5 @@
+/** Origin + router basename (no trailing slash), for BillingProvider checkout URLs. */
+export function appBasePath(): string {
+  if (typeof window === 'undefined') return '';
+  return `${window.location.origin}${(import.meta.env.BASE_URL || '/').replace(/\/$/, '')}`;
+}

--- a/apps/web/src/pages/AuthCallbackPage.tsx
+++ b/apps/web/src/pages/AuthCallbackPage.tsx
@@ -1,19 +1,23 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
+import {
+  POST_AUTH_REDIRECT_KEY,
+  parseStoredPostAuthRedirect,
+} from '../auth/postAuthRedirect';
 
 export default function AuthCallbackPage() {
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
   const auth = useAuthContext();
+  const navigatedRef = useRef(false);
+  const authRef = useRef(auth);
+  authRef.current = auth;
 
   useEffect(() => {
-    // Supabase OAuth callbacks can come as hash fragments (#access_token=...) or query params (?error=...)
-    // Check hash fragment first (successful OAuth)
-    const hashParams = new URLSearchParams(window.location.hash.substring(1));
-    const accessToken = hashParams.get('access_token');
+    if (navigatedRef.current) return;
 
-    // Check query params for errors
+    const hashParams = new URLSearchParams(window.location.hash.substring(1));
     const queryParams = new URLSearchParams(window.location.search);
     const errorParam = queryParams.get('error') || hashParams.get('error');
     const errorDescription =
@@ -22,39 +26,58 @@ export default function AuthCallbackPage() {
 
     if (errorParam) {
       setError(errorDescription || 'Authentication failed. Please try again.');
-      // Redirect to login after showing error
-      setTimeout(() => {
+      const t = setTimeout(() => {
+        navigatedRef.current = true;
         navigate('/login', { replace: true });
       }, 3000);
+      return () => clearTimeout(t);
+    }
+
+    if (auth.loading) return;
+
+    if (auth.user) {
+      navigatedRef.current = true;
+      const rawS = sessionStorage.getItem(POST_AUTH_REDIRECT_KEY);
+      const rawL = localStorage.getItem(POST_AUTH_REDIRECT_KEY);
+      sessionStorage.removeItem(POST_AUTH_REDIRECT_KEY);
+      localStorage.removeItem(POST_AUTH_REDIRECT_KEY);
+      const stored =
+        parseStoredPostAuthRedirect(rawS) ?? parseStoredPostAuthRedirect(rawL);
+      navigate(stored ?? '/dashboard', { replace: true });
       return;
     }
 
-    // If we have an access token in the hash, Supabase client will pick it up automatically
-    // Wait for auth state to update, then redirect
-    if (accessToken) {
-      // Give Supabase client time to process the token
-      const timer = setTimeout(() => {
-        if (auth.user && !auth.loading) {
-          navigate('/dashboard', { replace: true });
-        } else if (!auth.loading) {
-          // If we got a token but no user after loading completes, there might be an issue
-          setError(
-            'Authentication completed but session not established. Please try again.'
-          );
-          setTimeout(() => {
-            navigate('/login', { replace: true });
-          }, 3000);
-        }
-      }, 1000);
-
-      return () => clearTimeout(timer);
+    const accessToken =
+      hashParams.get('access_token') || queryParams.get('access_token');
+    if (!accessToken) {
+      return;
     }
 
-    // If user is already authenticated (OAuth callback completed)
-    if (auth.user && !auth.loading) {
-      // Successful OAuth login, redirect to dashboard
-      navigate('/dashboard', { replace: true });
-    }
+    const timer = setTimeout(() => {
+      if (navigatedRef.current) return;
+      const a = authRef.current;
+      if (a.user && !a.loading) {
+        navigatedRef.current = true;
+        const rawS = sessionStorage.getItem(POST_AUTH_REDIRECT_KEY);
+        const rawL = localStorage.getItem(POST_AUTH_REDIRECT_KEY);
+        sessionStorage.removeItem(POST_AUTH_REDIRECT_KEY);
+        localStorage.removeItem(POST_AUTH_REDIRECT_KEY);
+        const stored =
+          parseStoredPostAuthRedirect(rawS) ??
+          parseStoredPostAuthRedirect(rawL);
+        navigate(stored ?? '/dashboard', { replace: true });
+      } else if (!a.loading) {
+        setError(
+          'Authentication completed but session not established. Please try again.'
+        );
+        setTimeout(() => {
+          navigatedRef.current = true;
+          navigate('/login', { replace: true });
+        }, 3000);
+      }
+    }, 1200);
+
+    return () => clearTimeout(timer);
   }, [auth.user, auth.loading, navigate]);
 
   if (error) {

--- a/apps/web/src/pages/AuthCallbackPage.tsx
+++ b/apps/web/src/pages/AuthCallbackPage.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
-import {
-  POST_AUTH_REDIRECT_KEY,
-  parseStoredPostAuthRedirect,
-} from '../auth/postAuthRedirect';
+import { readAndClearPostAuthRedirect } from '../auth/postAuthRedirect';
 
 export default function AuthCallbackPage() {
   const [error, setError] = useState<string | null>(null);
@@ -13,6 +10,9 @@ export default function AuthCallbackPage() {
   const navigatedRef = useRef(false);
   const authRef = useRef(auth);
   authRef.current = auth;
+  const delayedLoginTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
 
   useEffect(() => {
     if (navigatedRef.current) return;
@@ -37,12 +37,7 @@ export default function AuthCallbackPage() {
 
     if (auth.user) {
       navigatedRef.current = true;
-      const rawS = sessionStorage.getItem(POST_AUTH_REDIRECT_KEY);
-      const rawL = localStorage.getItem(POST_AUTH_REDIRECT_KEY);
-      sessionStorage.removeItem(POST_AUTH_REDIRECT_KEY);
-      localStorage.removeItem(POST_AUTH_REDIRECT_KEY);
-      const stored =
-        parseStoredPostAuthRedirect(rawS) ?? parseStoredPostAuthRedirect(rawL);
+      const stored = readAndClearPostAuthRedirect();
       navigate(stored ?? '/dashboard', { replace: true });
       return;
     }
@@ -58,26 +53,26 @@ export default function AuthCallbackPage() {
       const a = authRef.current;
       if (a.user && !a.loading) {
         navigatedRef.current = true;
-        const rawS = sessionStorage.getItem(POST_AUTH_REDIRECT_KEY);
-        const rawL = localStorage.getItem(POST_AUTH_REDIRECT_KEY);
-        sessionStorage.removeItem(POST_AUTH_REDIRECT_KEY);
-        localStorage.removeItem(POST_AUTH_REDIRECT_KEY);
-        const stored =
-          parseStoredPostAuthRedirect(rawS) ??
-          parseStoredPostAuthRedirect(rawL);
+        const stored = readAndClearPostAuthRedirect();
         navigate(stored ?? '/dashboard', { replace: true });
       } else if (!a.loading) {
         setError(
           'Authentication completed but session not established. Please try again.'
         );
-        setTimeout(() => {
+        delayedLoginTimerRef.current = setTimeout(() => {
           navigatedRef.current = true;
           navigate('/login', { replace: true });
         }, 3000);
       }
     }, 1200);
 
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      if (delayedLoginTimerRef.current) {
+        clearTimeout(delayedLoginTimerRef.current);
+        delayedLoginTimerRef.current = null;
+      }
+    };
   }, [auth.user, auth.loading, navigate]);
 
   if (error) {

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -85,7 +85,11 @@ function LoginPageContent() {
               : 'w-full space-y-8'
           }
         >
-          <div className={showPlanAside ? 'order-2 md:order-1 space-y-8' : 'space-y-8'}>
+          <div
+            className={
+              showPlanAside ? 'order-2 md:order-1 space-y-8' : 'space-y-8'
+            }
+          >
             <div>
               <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900 md:mt-0 md:text-left'>
                 Sign in to your account

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -8,15 +8,12 @@ import { SocialLoginButton } from '../components/SocialLoginButton';
 import { LoginPlanSummary } from '../components/auth/SignupPlanSummary';
 import { beakerstackBillingConfig } from '../billing/beakerstackBillingConfig';
 import {
+  clearPostAuthRedirectKeys,
   POST_AUTH_REDIRECT_KEY,
   resolvePostAuthDestination,
   serializePostAuthRedirectPayload,
 } from '../auth/postAuthRedirect';
-
-function appBasePath(): string {
-  if (typeof window === 'undefined') return '';
-  return `${window.location.origin}${(import.meta.env.BASE_URL || '/').replace(/\/$/, '')}`;
-}
+import { appBasePath } from '../lib/appBasePath';
 
 function LoginPageContent() {
   const [email, setEmail] = useState('');
@@ -53,7 +50,7 @@ function LoginPageContent() {
 
     try {
       await auth.signIn(email, password);
-      localStorage.removeItem(POST_AUTH_REDIRECT_KEY);
+      clearPostAuthRedirectKeys();
       navigate(postAuthPath, { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to sign in');
@@ -68,6 +65,7 @@ function LoginPageContent() {
       stashOAuthIntent();
       await auth.signInWithGoogle();
     } catch (err) {
+      sessionStorage.removeItem(POST_AUTH_REDIRECT_KEY);
       setError(
         err instanceof Error ? err.message : 'Failed to sign in with Google'
       );

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,17 +1,44 @@
+import { BillingProvider } from '@beakerstack/billing';
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
 import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
 import { supabase } from '@/lib/supabase';
 import { SocialLoginButton } from '../components/SocialLoginButton';
+import { LoginPlanSummary } from '../components/auth/SignupPlanSummary';
+import { beakerstackBillingConfig } from '../billing/beakerstackBillingConfig';
+import {
+  POST_AUTH_REDIRECT_KEY,
+  resolvePostAuthDestination,
+  serializePostAuthRedirectPayload,
+} from '../auth/postAuthRedirect';
 
-export default function LoginPage() {
+function appBasePath(): string {
+  if (typeof window === 'undefined') return '';
+  return `${window.location.origin}${(import.meta.env.BASE_URL || '/').replace(/\/$/, '')}`;
+}
+
+function LoginPageContent() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const auth = useAuthContext();
+
+  const postAuthPath = resolvePostAuthDestination(searchParams);
+  const signupSearch = searchParams.toString();
+  const signupTo = signupSearch ? `/signup?${signupSearch}` : '/signup';
+
+  const stashOAuthIntent = () => {
+    if (postAuthPath !== '/dashboard') {
+      sessionStorage.setItem(
+        POST_AUTH_REDIRECT_KEY,
+        serializePostAuthRedirectPayload(postAuthPath)
+      );
+    }
+  };
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -26,7 +53,8 @@ export default function LoginPage() {
 
     try {
       await auth.signIn(email, password);
-      navigate('/dashboard');
+      localStorage.removeItem(POST_AUTH_REDIRECT_KEY);
+      navigate(postAuthPath, { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to sign in');
     } finally {
@@ -37,6 +65,7 @@ export default function LoginPage() {
   const handleGoogleLogin = async () => {
     setError(null);
     try {
+      stashOAuthIntent();
       await auth.signInWithGoogle();
     } catch (err) {
       setError(
@@ -45,104 +74,128 @@ export default function LoginPage() {
     }
   };
 
+  const showPlanAside = postAuthPath !== '/dashboard';
+
   return (
     <div className='min-h-screen bg-gray-50'>
       <AppHeader supabaseClient={supabase} />
       <div className='max-w-[1024px] mx-auto py-12 px-4 sm:px-6 lg:px-8'>
-        <div className='w-full space-y-8'>
-          <div>
-            <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900'>
-              Sign in to your account
-            </h2>
-          </div>
-
-          {/* OAuth Buttons */}
-          <div className='space-y-3'>
-            <SocialLoginButton onPress={handleGoogleLogin} mode='signin' />
-          </div>
-
-          {/* Divider */}
-          <div className='relative'>
-            <div className='absolute inset-0 flex items-center'>
-              <div className='w-full border-t border-gray-300' />
+        <div
+          className={
+            showPlanAside
+              ? 'grid w-full gap-10 md:grid-cols-2 md:items-start'
+              : 'w-full space-y-8'
+          }
+        >
+          <div className={showPlanAside ? 'order-2 md:order-1 space-y-8' : 'space-y-8'}>
+            <div>
+              <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900 md:mt-0 md:text-left'>
+                Sign in to your account
+              </h2>
             </div>
-            <div className='relative flex justify-center text-sm'>
-              <span className='px-2 bg-gray-50 text-gray-500'>
-                Or continue with email
-              </span>
-            </div>
-          </div>
 
-          {/* Error Message */}
-          {error && (
-            <div className='rounded-md bg-red-50 p-4'>
-              <div className='flex'>
-                <div className='ml-3'>
-                  <h3 className='text-sm font-medium text-red-800'>{error}</h3>
+            <div className='space-y-3'>
+              <SocialLoginButton onPress={handleGoogleLogin} mode='signin' />
+            </div>
+
+            <div className='relative'>
+              <div className='absolute inset-0 flex items-center'>
+                <div className='w-full border-t border-gray-300' />
+              </div>
+              <div className='relative flex justify-center text-sm'>
+                <span className='px-2 bg-gray-50 text-gray-500'>
+                  Or continue with email
+                </span>
+              </div>
+            </div>
+
+            {error && (
+              <div className='rounded-md bg-red-50 p-4'>
+                <h3 className='text-sm font-medium text-red-800'>{error}</h3>
+              </div>
+            )}
+
+            <form className='mt-8 space-y-6' onSubmit={handleLogin}>
+              <div className='rounded-md shadow-sm -space-y-px'>
+                <div>
+                  <label htmlFor='email' className='sr-only'>
+                    Email address
+                  </label>
+                  <input
+                    id='email'
+                    name='email'
+                    type='email'
+                    autoComplete='email'
+                    required
+                    value={email}
+                    onChange={e => setEmail(e.target.value)}
+                    disabled={isLoading}
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    placeholder='Email address'
+                  />
+                </div>
+                <div>
+                  <label htmlFor='password' className='sr-only'>
+                    Password
+                  </label>
+                  <input
+                    id='password'
+                    name='password'
+                    type='password'
+                    autoComplete='current-password'
+                    required
+                    value={password}
+                    onChange={e => setPassword(e.target.value)}
+                    disabled={isLoading}
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    placeholder='Password'
+                  />
                 </div>
               </div>
-            </div>
-          )}
 
-          <form className='mt-8 space-y-6' onSubmit={handleLogin}>
-            <div className='rounded-md shadow-sm -space-y-px'>
               <div>
-                <label htmlFor='email' className='sr-only'>
-                  Email address
-                </label>
-                <input
-                  id='email'
-                  name='email'
-                  type='email'
-                  autoComplete='email'
-                  required
-                  value={email}
-                  onChange={e => setEmail(e.target.value)}
+                <button
+                  type='submit'
                   disabled={isLoading}
-                  className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
-                  placeholder='Email address'
-                />
+                  className='group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed'
+                >
+                  {isLoading ? 'Signing in...' : 'Sign in'}
+                </button>
               </div>
-              <div>
-                <label htmlFor='password' className='sr-only'>
-                  Password
-                </label>
-                <input
-                  id='password'
-                  name='password'
-                  type='password'
-                  autoComplete='current-password'
-                  required
-                  value={password}
-                  onChange={e => setPassword(e.target.value)}
-                  disabled={isLoading}
-                  className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
-                  placeholder='Password'
-                />
+
+              <div className='text-center md:text-left'>
+                <Link
+                  to={signupTo}
+                  className='font-medium text-primary-600 hover:text-primary-500'
+                >
+                  Don&apos;t have an account? Sign up
+                </Link>
               </div>
-            </div>
+            </form>
+          </div>
 
-            <div>
-              <button
-                type='submit'
-                disabled={isLoading}
-                className='group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed'
-              >
-                {isLoading ? 'Signing in...' : 'Sign in'}
-              </button>
+          {showPlanAside ? (
+            <div className='order-1 md:order-2'>
+              <LoginPlanSummary />
             </div>
-
-            <div className='text-center'>
-              <Link
-                to='/signup'
-                className='font-medium text-primary-600 hover:text-primary-500'
-              >
-                Don't have an account? Sign up
-              </Link>
-            </div>
-          </form>
+          ) : null}
         </div>
       </div>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  const base = appBasePath();
+  return (
+    <BillingProvider<typeof beakerstackBillingConfig>
+      supabase={supabase}
+      config={beakerstackBillingConfig}
+      checkoutSuccessUrl={`${base}/billing?checkout=success`}
+      checkoutCancelUrl={`${base}/billing/plans?checkout=cancel`}
+      portalReturnUrl={`${base}/billing`}
+    >
+      <LoginPageContent />
+    </BillingProvider>
   );
 }

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -59,7 +59,9 @@ function SignupPageContent() {
 
     try {
       await auth.signUp(email, password);
-      const { data: { session } } = await supabase.auth.getSession();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
 
       if (session) {
         clearPostAuthRedirectKeys();

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -1,18 +1,48 @@
+import { BillingProvider } from '@beakerstack/billing';
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
 import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
 import { supabase } from '@/lib/supabase';
 import { SocialLoginButton } from '../components/SocialLoginButton';
+import { SignupPlanSummary } from '../components/auth/SignupPlanSummary';
+import { beakerstackBillingConfig } from '../billing/beakerstackBillingConfig';
+import {
+  hasPaidPlanIntent,
+  POST_AUTH_REDIRECT_KEY,
+  resolvePostAuthDestination,
+  serializePostAuthRedirectPayload,
+} from '../auth/postAuthRedirect';
 
-export default function SignupPage() {
+function appBasePath(): string {
+  if (typeof window === 'undefined') return '';
+  return `${window.location.origin}${(import.meta.env.BASE_URL || '/').replace(/\/$/, '')}`;
+}
+
+function SignupPageContent() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [awaitingEmail, setAwaitingEmail] = useState(false);
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const auth = useAuthContext();
+
+  const paidIntent = hasPaidPlanIntent(searchParams);
+  const postAuthPath = resolvePostAuthDestination(searchParams);
+  const loginSearch = searchParams.toString();
+  const loginTo = loginSearch ? `/login?${loginSearch}` : '/login';
+
+  const stashOAuthIntent = () => {
+    if (postAuthPath !== '/dashboard') {
+      sessionStorage.setItem(
+        POST_AUTH_REDIRECT_KEY,
+        serializePostAuthRedirectPayload(postAuthPath)
+      );
+    }
+  };
 
   const handleSignup = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -32,7 +62,20 @@ export default function SignupPage() {
 
     try {
       await auth.signUp(email, password);
-      navigate('/dashboard');
+      const { data: { session } } = await supabase.auth.getSession();
+
+      if (session) {
+        localStorage.removeItem(POST_AUTH_REDIRECT_KEY);
+        navigate(postAuthPath, { replace: true });
+      } else if (paidIntent && postAuthPath !== '/dashboard') {
+        localStorage.setItem(
+          POST_AUTH_REDIRECT_KEY,
+          serializePostAuthRedirectPayload(postAuthPath)
+        );
+        setAwaitingEmail(true);
+      } else {
+        navigate('/dashboard', { replace: true });
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create account');
     } finally {
@@ -43,6 +86,7 @@ export default function SignupPage() {
   const handleGoogleSignup = async () => {
     setError(null);
     try {
+      stashOAuthIntent();
       await auth.signInWithGoogle();
     } catch (err) {
       setError(
@@ -51,121 +95,177 @@ export default function SignupPage() {
     }
   };
 
+  const displayName =
+    beakerstackBillingConfig.plans.find(p => p.id === searchParams.get('plan'))
+      ?.displayName ?? 'this plan';
+  const submitLabel = isLoading
+    ? 'Creating account...'
+    : paidIntent && postAuthPath !== '/dashboard'
+      ? `Continue with ${displayName}`
+      : 'Create account';
+
+  if (awaitingEmail) {
+    return (
+      <div className='min-h-screen bg-gray-50'>
+        <AppHeader supabaseClient={supabase} />
+        <div className='max-w-[1024px] mx-auto py-12 px-4 sm:px-6 lg:px-8'>
+          <div className='mx-auto max-w-md rounded-lg border border-gray-200 bg-white p-8 shadow-sm'>
+            <h2 className='text-xl font-semibold text-gray-900'>
+              Check your email
+            </h2>
+            <p className='mt-3 text-sm text-gray-600'>
+              We sent a confirmation link to <strong>{email}</strong>. Click the
+              link in that email to finish creating your account — we&apos;ll
+              take you to billing to complete your plan when you&apos;re signed
+              in.
+            </p>
+            <p className='mt-4 text-sm text-gray-500'>
+              <Link to={loginTo} className='font-medium text-primary-600'>
+                Already confirmed? Sign in
+              </Link>
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className='min-h-screen bg-gray-50'>
       <AppHeader supabaseClient={supabase} />
       <div className='max-w-[1024px] mx-auto py-12 px-4 sm:px-6 lg:px-8'>
-        <div className='w-full space-y-8'>
-          <div>
-            <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900'>
-              Create your account
-            </h2>
-          </div>
-
-          {/* OAuth Buttons */}
-          <div className='space-y-3'>
-            <SocialLoginButton onPress={handleGoogleSignup} mode='signup' />
-          </div>
-
-          {/* Divider */}
-          <div className='relative'>
-            <div className='absolute inset-0 flex items-center'>
-              <div className='w-full border-t border-gray-300' />
+        <div className='grid w-full gap-10 md:grid-cols-2 md:items-start'>
+          <div className='order-2 md:order-1 space-y-8'>
+            <div>
+              <h2 className='mt-0 text-center text-3xl font-extrabold text-gray-900 md:text-left'>
+                {paidIntent && postAuthPath !== '/dashboard'
+                  ? `Create your account to continue with ${displayName}`
+                  : 'Create your account'}
+              </h2>
+              {paidIntent && postAuthPath !== '/dashboard' ? (
+                <p className='mt-2 text-center text-sm text-gray-600 md:text-left'>
+                  No charge until you finish checkout on the next step.
+                </p>
+              ) : null}
             </div>
-            <div className='relative flex justify-center text-sm'>
-              <span className='px-2 bg-gray-50 text-gray-500'>
-                Or continue with email
-              </span>
-            </div>
-          </div>
 
-          {/* Error Message */}
-          {error && (
-            <div className='rounded-md bg-red-50 p-4'>
-              <div className='flex'>
-                <div className='ml-3'>
-                  <h3 className='text-sm font-medium text-red-800'>{error}</h3>
+            <div className='space-y-3'>
+              <SocialLoginButton onPress={handleGoogleSignup} mode='signup' />
+            </div>
+
+            <div className='relative'>
+              <div className='absolute inset-0 flex items-center'>
+                <div className='w-full border-t border-gray-300' />
+              </div>
+              <div className='relative flex justify-center text-sm'>
+                <span className='px-2 bg-gray-50 text-gray-500'>
+                  Or continue with email
+                </span>
+              </div>
+            </div>
+
+            {error && (
+              <div className='rounded-md bg-red-50 p-4'>
+                <h3 className='text-sm font-medium text-red-800'>{error}</h3>
+              </div>
+            )}
+
+            <form className='mt-8 space-y-6' onSubmit={handleSignup}>
+              <div className='rounded-md shadow-sm -space-y-px'>
+                <div>
+                  <label htmlFor='email' className='sr-only'>
+                    Email address
+                  </label>
+                  <input
+                    id='email'
+                    name='email'
+                    type='email'
+                    autoComplete='email'
+                    required
+                    value={email}
+                    onChange={e => setEmail(e.target.value)}
+                    disabled={isLoading}
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    placeholder='Email address'
+                  />
+                </div>
+                <div>
+                  <label htmlFor='password' className='sr-only'>
+                    Password
+                  </label>
+                  <input
+                    id='password'
+                    name='password'
+                    type='password'
+                    autoComplete='new-password'
+                    required
+                    value={password}
+                    onChange={e => setPassword(e.target.value)}
+                    disabled={isLoading}
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    placeholder='Password'
+                  />
+                </div>
+                <div>
+                  <label htmlFor='confirm-password' className='sr-only'>
+                    Confirm Password
+                  </label>
+                  <input
+                    id='confirm-password'
+                    name='confirm-password'
+                    type='password'
+                    autoComplete='new-password'
+                    required
+                    value={confirmPassword}
+                    onChange={e => setConfirmPassword(e.target.value)}
+                    disabled={isLoading}
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    placeholder='Confirm password'
+                  />
                 </div>
               </div>
-            </div>
-          )}
 
-          <form className='mt-8 space-y-6' onSubmit={handleSignup}>
-            <div className='rounded-md shadow-sm -space-y-px'>
               <div>
-                <label htmlFor='email' className='sr-only'>
-                  Email address
-                </label>
-                <input
-                  id='email'
-                  name='email'
-                  type='email'
-                  autoComplete='email'
-                  required
-                  value={email}
-                  onChange={e => setEmail(e.target.value)}
+                <button
+                  type='submit'
                   disabled={isLoading}
-                  className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
-                  placeholder='Email address'
-                />
+                  className='group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed'
+                >
+                  {submitLabel}
+                </button>
               </div>
-              <div>
-                <label htmlFor='password' className='sr-only'>
-                  Password
-                </label>
-                <input
-                  id='password'
-                  name='password'
-                  type='password'
-                  autoComplete='new-password'
-                  required
-                  value={password}
-                  onChange={e => setPassword(e.target.value)}
-                  disabled={isLoading}
-                  className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
-                  placeholder='Password'
-                />
-              </div>
-              <div>
-                <label htmlFor='confirm-password' className='sr-only'>
-                  Confirm Password
-                </label>
-                <input
-                  id='confirm-password'
-                  name='confirm-password'
-                  type='password'
-                  autoComplete='new-password'
-                  required
-                  value={confirmPassword}
-                  onChange={e => setConfirmPassword(e.target.value)}
-                  disabled={isLoading}
-                  className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
-                  placeholder='Confirm password'
-                />
-              </div>
-            </div>
 
-            <div>
-              <button
-                type='submit'
-                disabled={isLoading}
-                className='group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed'
-              >
-                {isLoading ? 'Creating account...' : 'Create account'}
-              </button>
-            </div>
+              <div className='text-center md:text-left'>
+                <Link
+                  to={loginTo}
+                  className='font-medium text-primary-600 hover:text-primary-500'
+                >
+                  Already have an account? Sign in
+                </Link>
+              </div>
+            </form>
+          </div>
 
-            <div className='text-center'>
-              <Link
-                to='/login'
-                className='font-medium text-primary-600 hover:text-primary-500'
-              >
-                Already have an account? Sign in
-              </Link>
-            </div>
-          </form>
+          <div className='order-1 md:order-2'>
+            <SignupPlanSummary />
+          </div>
         </div>
       </div>
     </div>
+  );
+}
+
+export default function SignupPage() {
+  const base = appBasePath();
+  return (
+    <BillingProvider<typeof beakerstackBillingConfig>
+      supabase={supabase}
+      config={beakerstackBillingConfig}
+      checkoutSuccessUrl={`${base}/billing?checkout=success`}
+      checkoutCancelUrl={`${base}/billing/plans?checkout=cancel`}
+      portalReturnUrl={`${base}/billing`}
+    >
+      <SignupPageContent />
+    </BillingProvider>
   );
 }

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -8,16 +8,13 @@ import { SocialLoginButton } from '../components/SocialLoginButton';
 import { SignupPlanSummary } from '../components/auth/SignupPlanSummary';
 import { beakerstackBillingConfig } from '../billing/beakerstackBillingConfig';
 import {
+  clearPostAuthRedirectKeys,
   hasPaidPlanIntent,
   POST_AUTH_REDIRECT_KEY,
   resolvePostAuthDestination,
   serializePostAuthRedirectPayload,
 } from '../auth/postAuthRedirect';
-
-function appBasePath(): string {
-  if (typeof window === 'undefined') return '';
-  return `${window.location.origin}${(import.meta.env.BASE_URL || '/').replace(/\/$/, '')}`;
-}
+import { appBasePath } from '../lib/appBasePath';
 
 function SignupPageContent() {
   const [email, setEmail] = useState('');
@@ -65,7 +62,7 @@ function SignupPageContent() {
       const { data: { session } } = await supabase.auth.getSession();
 
       if (session) {
-        localStorage.removeItem(POST_AUTH_REDIRECT_KEY);
+        clearPostAuthRedirectKeys();
         navigate(postAuthPath, { replace: true });
       } else if (paidIntent && postAuthPath !== '/dashboard') {
         localStorage.setItem(
@@ -89,6 +86,7 @@ function SignupPageContent() {
       stashOAuthIntent();
       await auth.signInWithGoogle();
     } catch (err) {
+      sessionStorage.removeItem(POST_AUTH_REDIRECT_KEY);
       setError(
         err instanceof Error ? err.message : 'Failed to sign up with Google'
       );
@@ -103,6 +101,8 @@ function SignupPageContent() {
     : paidIntent && postAuthPath !== '/dashboard'
       ? `Continue with ${displayName}`
       : 'Create account';
+
+  const showPlanAside = paidIntent && postAuthPath !== '/dashboard';
 
   if (awaitingEmail) {
     return (
@@ -134,8 +134,18 @@ function SignupPageContent() {
     <div className='min-h-screen bg-gray-50'>
       <AppHeader supabaseClient={supabase} />
       <div className='max-w-[1024px] mx-auto py-12 px-4 sm:px-6 lg:px-8'>
-        <div className='grid w-full gap-10 md:grid-cols-2 md:items-start'>
-          <div className='order-2 md:order-1 space-y-8'>
+        <div
+          className={
+            showPlanAside
+              ? 'grid w-full gap-10 md:grid-cols-2 md:items-start'
+              : 'w-full space-y-8'
+          }
+        >
+          <div
+            className={
+              showPlanAside ? 'order-2 md:order-1 space-y-8' : 'space-y-8'
+            }
+          >
             <div>
               <h2 className='mt-0 text-center text-3xl font-extrabold text-gray-900 md:text-left'>
                 {paidIntent && postAuthPath !== '/dashboard'
@@ -246,9 +256,11 @@ function SignupPageContent() {
             </form>
           </div>
 
-          <div className='order-1 md:order-2'>
-            <SignupPlanSummary />
-          </div>
+          {showPlanAside ? (
+            <div className='order-1 md:order-2'>
+              <SignupPlanSummary />
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/apps/web/src/pages/__tests__/AuthCallbackPage.coverage.test.tsx
+++ b/apps/web/src/pages/__tests__/AuthCallbackPage.coverage.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import {
+  POST_AUTH_REDIRECT_KEY,
+  serializePostAuthRedirectPayload,
+} from '../../auth/postAuthRedirect';
 import AuthCallbackPage from '../AuthCallbackPage';
 
 const mockNavigate = vi.fn();
@@ -36,27 +40,28 @@ vi.mock('@beakerstack/shared/contexts/AuthContext', () => ({
 
 describe('AuthCallbackPage (URL + auth branches)', () => {
   const original = window.location;
-  const memStore: Record<string, string> = {};
+  const memSession: Record<string, string> = {};
+  const memLocal: Record<string, string> = {};
 
-  const storageMock = {
-    getItem: (k: string) => (k in memStore ? memStore[k] : null),
-    setItem: (k: string, v: string) => {
-      memStore[k] = v;
-    },
-    removeItem: (k: string) => {
-      delete memStore[k];
-    },
-    clear: () => {
-      for (const k of Object.keys(memStore)) delete memStore[k];
-    },
-  };
+  function storageMock(mem: Record<string, string>) {
+    return {
+      getItem: (k: string) => (k in mem ? mem[k] : null),
+      setItem: (k: string, v: string) => {
+        mem[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete mem[k];
+      },
+    };
+  }
 
   beforeEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
-    Object.keys(memStore).forEach(k => delete memStore[k]);
-    vi.stubGlobal('sessionStorage', storageMock);
-    vi.stubGlobal('localStorage', storageMock);
+    Object.keys(memSession).forEach(k => delete memSession[k]);
+    Object.keys(memLocal).forEach(k => delete memLocal[k]);
+    vi.stubGlobal('sessionStorage', storageMock(memSession));
+    vi.stubGlobal('localStorage', storageMock(memLocal));
     auth.user = null;
     auth.loading = true;
     Object.defineProperty(window, 'location', {
@@ -220,5 +225,42 @@ describe('AuthCallbackPage (URL + auth branches)', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
       replace: true,
     });
+  });
+
+  it('redirects to stored post-auth path when session is ready', () => {
+    const dest =
+      '/billing/plans?plan=beakerstack_pro&welcome=1';
+    memSession[POST_AUTH_REDIRECT_KEY] =
+      serializePostAuthRedirectPayload(dest);
+    auth.loading = false;
+    auth.user = { id: 'u1' };
+
+    render(
+      <MemoryRouter>
+        <AuthCallbackPage />
+      </MemoryRouter>
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(dest, { replace: true });
+    expect(memSession[POST_AUTH_REDIRECT_KEY]).toBeUndefined();
+    expect(memLocal[POST_AUTH_REDIRECT_KEY]).toBeUndefined();
+  });
+
+  it('reads localStorage when sessionStorage is empty', () => {
+    const dest =
+      '/billing/plans?plan=beakerstack_max&welcome=1';
+    memLocal[POST_AUTH_REDIRECT_KEY] =
+      serializePostAuthRedirectPayload(dest);
+    auth.loading = false;
+    auth.user = { id: 'u1' };
+
+    render(
+      <MemoryRouter>
+        <AuthCallbackPage />
+      </MemoryRouter>
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(dest, { replace: true });
+    expect(memLocal[POST_AUTH_REDIRECT_KEY]).toBeUndefined();
   });
 });

--- a/apps/web/src/pages/__tests__/AuthCallbackPage.coverage.test.tsx
+++ b/apps/web/src/pages/__tests__/AuthCallbackPage.coverage.test.tsx
@@ -36,10 +36,27 @@ vi.mock('@beakerstack/shared/contexts/AuthContext', () => ({
 
 describe('AuthCallbackPage (URL + auth branches)', () => {
   const original = window.location;
+  const memStore: Record<string, string> = {};
+
+  const storageMock = {
+    getItem: (k: string) => (k in memStore ? memStore[k] : null),
+    setItem: (k: string, v: string) => {
+      memStore[k] = v;
+    },
+    removeItem: (k: string) => {
+      delete memStore[k];
+    },
+    clear: () => {
+      for (const k of Object.keys(memStore)) delete memStore[k];
+    },
+  };
 
   beforeEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+    Object.keys(memStore).forEach(k => delete memStore[k]);
+    vi.stubGlobal('sessionStorage', storageMock);
+    vi.stubGlobal('localStorage', storageMock);
     auth.user = null;
     auth.loading = true;
     Object.defineProperty(window, 'location', {
@@ -54,6 +71,7 @@ describe('AuthCallbackPage (URL + auth branches)', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: original,
@@ -150,9 +168,6 @@ describe('AuthCallbackPage (URL + auth branches)', () => {
       );
     });
 
-    await act(async () => {
-      vi.advanceTimersByTime(1000);
-    });
     expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
       replace: true,
     });
@@ -181,7 +196,7 @@ describe('AuthCallbackPage (URL + auth branches)', () => {
     });
 
     await act(async () => {
-      vi.advanceTimersByTime(1000);
+      vi.advanceTimersByTime(1200);
     });
     expect(screen.getByText(/session not established/i)).toBeInTheDocument();
 

--- a/apps/web/src/pages/__tests__/AuthCallbackPage.coverage.test.tsx
+++ b/apps/web/src/pages/__tests__/AuthCallbackPage.coverage.test.tsx
@@ -228,10 +228,8 @@ describe('AuthCallbackPage (URL + auth branches)', () => {
   });
 
   it('redirects to stored post-auth path when session is ready', () => {
-    const dest =
-      '/billing/plans?plan=beakerstack_pro&welcome=1';
-    memSession[POST_AUTH_REDIRECT_KEY] =
-      serializePostAuthRedirectPayload(dest);
+    const dest = '/billing/plans?plan=beakerstack_pro&welcome=1';
+    memSession[POST_AUTH_REDIRECT_KEY] = serializePostAuthRedirectPayload(dest);
     auth.loading = false;
     auth.user = { id: 'u1' };
 
@@ -247,10 +245,8 @@ describe('AuthCallbackPage (URL + auth branches)', () => {
   });
 
   it('reads localStorage when sessionStorage is empty', () => {
-    const dest =
-      '/billing/plans?plan=beakerstack_max&welcome=1';
-    memLocal[POST_AUTH_REDIRECT_KEY] =
-      serializePostAuthRedirectPayload(dest);
+    const dest = '/billing/plans?plan=beakerstack_max&welcome=1';
+    memLocal[POST_AUTH_REDIRECT_KEY] = serializePostAuthRedirectPayload(dest);
     auth.loading = false;
     auth.user = { id: 'u1' };
 

--- a/apps/web/src/pages/__tests__/HomePage.test.tsx
+++ b/apps/web/src/pages/__tests__/HomePage.test.tsx
@@ -120,7 +120,10 @@ describe('HomePage', () => {
           screen.queryByText('Dashboard')
       ).toBeTruthy()
     );
-    return result!;
+    if (result === null) {
+      throw new Error('Expected render to assign result');
+    }
+    return result;
   };
 
   describe('when user is not authenticated', () => {

--- a/apps/web/src/pages/__tests__/HomePage.test.tsx
+++ b/apps/web/src/pages/__tests__/HomePage.test.tsx
@@ -22,7 +22,10 @@ vi.mock('@/lib/supabase', () => ({
     }),
     channel: vi.fn().mockReturnValue({
       on: vi.fn().mockReturnThis(),
-      subscribe: vi.fn(cb => { cb('SUBSCRIBED'); return { unsubscribe: vi.fn().mockResolvedValue(undefined) }; }),
+      subscribe: vi.fn(cb => {
+        cb('SUBSCRIBED');
+        return { unsubscribe: vi.fn().mockResolvedValue(undefined) };
+      }),
     }),
     removeChannel: vi.fn().mockResolvedValue({ status: 'ok', error: null }),
   },
@@ -33,10 +36,14 @@ vi.mock('@beakerstack/billing', async importOriginal => {
   return {
     ...actual,
     BillingProvider: ({ children }: { children: ReactNode }) => children,
-    usePlanCatalog: () => ({ plans: [], loading: false, error: null, refresh: async () => {} }),
+    usePlanCatalog: () => ({
+      plans: [],
+      loading: false,
+      error: null,
+      refresh: async () => {},
+    }),
   };
 });
-
 
 // Stub the landing config so tests don't depend on placehold.co or Lucide icons
 vi.mock('../../config/landing', () => ({
@@ -54,12 +61,21 @@ vi.mock('../../config/landing', () => ({
     featureRows: [],
     pricing: { heading: 'Pricing', subhead: '' },
     faq: { heading: 'FAQ', items: [] },
-    finalCta: { headline: 'Ready?', subhead: '', ctaLabel: 'Start', ctaHref: '/signup' },
+    finalCta: {
+      headline: 'Ready?',
+      subhead: '',
+      ctaLabel: 'Start',
+      ctaHref: '/signup',
+    },
   },
 }));
 
 vi.mock('../../../billing/beakerstackBillingConfig', () => ({
-  beakerstackBillingConfig: { plans: [], productId: 'test', displayName: 'Test' },
+  beakerstackBillingConfig: {
+    plans: [],
+    productId: 'test',
+    displayName: 'Test',
+  },
 }));
 
 describe('HomePage', () => {
@@ -84,7 +100,10 @@ describe('HomePage', () => {
       }),
       channel: vi.fn().mockReturnValue({
         on: vi.fn().mockReturnThis(),
-        subscribe: vi.fn(cb => { cb('SUBSCRIBED'); return { unsubscribe: vi.fn().mockResolvedValue(undefined) }; }),
+        subscribe: vi.fn(cb => {
+          cb('SUBSCRIBED');
+          return { unsubscribe: vi.fn().mockResolvedValue(undefined) };
+        }),
       }),
       removeChannel: vi.fn().mockResolvedValue({ status: 'ok', error: null }),
     } as unknown as SupabaseClient;
@@ -92,7 +111,9 @@ describe('HomePage', () => {
 
   const renderWithAuth = async (authenticated = false) => {
     if (authenticated) {
-      (mockSupabaseClient.auth.getSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      (
+        mockSupabaseClient.auth.getSession as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({
         data: {
           session: { user: { id: 'test-user-id', email: 'test@example.com' } },
         },
@@ -150,8 +171,12 @@ describe('HomePage', () => {
 
     it('renders the pricing cadence toggle with Monthly and Annually buttons', async () => {
       await renderWithAuth(false);
-      expect(screen.getByRole('button', { name: /monthly/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /annually/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /monthly/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /annually/i })
+      ).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/pages/__tests__/LoginPage.test.tsx
+++ b/apps/web/src/pages/__tests__/LoginPage.test.tsx
@@ -30,8 +30,7 @@ const mockCatalogPlans = vi.hoisted(() => {
 });
 
 vi.mock('@beakerstack/billing', async importOriginal => {
-  const actual =
-    await importOriginal<typeof import('@beakerstack/billing')>();
+  const actual = await importOriginal<typeof import('@beakerstack/billing')>();
   return {
     ...actual,
     BillingProvider: ({ children }: { children: React.ReactNode }) => (

--- a/apps/web/src/pages/__tests__/LoginPage.test.tsx
+++ b/apps/web/src/pages/__tests__/LoginPage.test.tsx
@@ -2,11 +2,49 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+import type { Plan } from '@beakerstack/billing';
 import LoginPage from '../LoginPage';
 import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
 import type { SupabaseClient } from '@supabase/supabase-js';
+
+const mockCatalogPlans = vi.hoisted(() => {
+  const pro: Plan = {
+    id: 'beakerstack_pro',
+    product_id: 'beakerstack',
+    display_name: 'Pro',
+    description: null,
+    price_cents: 1900,
+    billing_period: 'monthly',
+    stripe_price_id_monthly: null,
+    stripe_price_id_annual: null,
+    stripe_product_id: null,
+    features: {},
+    usage_limits: {},
+    trial_period_days: 0,
+    is_public: true,
+    display_order: 2,
+  };
+  return { pro };
+});
+
+vi.mock('@beakerstack/billing', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('@beakerstack/billing')>();
+  return {
+    ...actual,
+    BillingProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    usePlanCatalog: () => ({
+      plans: [mockCatalogPlans.pro],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    }),
+  };
+});
 
 // Mock the supabase client
 vi.mock('@/lib/supabase', () => ({
@@ -39,17 +77,30 @@ const createMockSupabaseClient = (): SupabaseClient => {
   } as unknown as SupabaseClient;
 };
 
-const renderWithProviders = (component: React.ReactElement) => {
+const renderWithProviders = (
+  component: React.ReactElement,
+  options?: { initialEntries?: string[] }
+) => {
   const mockClient = createMockSupabaseClient();
-  return render(
-    <BrowserRouter>
-      <AuthProvider supabaseClient={mockClient}>
-        <ProfileProvider supabaseClient={mockClient}>
-          {component}
-        </ProfileProvider>
-      </AuthProvider>
-    </BrowserRouter>
-  );
+  const router =
+    options?.initialEntries != null ? (
+      <MemoryRouter initialEntries={options.initialEntries}>
+        <AuthProvider supabaseClient={mockClient}>
+          <ProfileProvider supabaseClient={mockClient}>
+            {component}
+          </ProfileProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    ) : (
+      <BrowserRouter>
+        <AuthProvider supabaseClient={mockClient}>
+          <ProfileProvider supabaseClient={mockClient}>
+            {component}
+          </ProfileProvider>
+        </AuthProvider>
+      </BrowserRouter>
+    );
+  return render(router);
 };
 
 describe('LoginPage', () => {
@@ -159,6 +210,18 @@ describe('LoginPage', () => {
     const signupLink = screen.getByText("Don't have an account? Sign up");
     expect(signupLink).toBeInTheDocument();
     expect(signupLink.closest('a')).toHaveAttribute('href', '/signup');
+  });
+
+  it('shows plan summary aside when arriving with paid plan query', () => {
+    renderWithProviders(<LoginPage />, {
+      initialEntries: ['/login?plan=beakerstack_pro'],
+    });
+    expect(screen.getByText('Plan from pricing')).toBeInTheDocument();
+  });
+
+  it('does not show plan aside on plain /login', () => {
+    renderWithProviders(<LoginPage />);
+    expect(screen.queryByText('Plan from pricing')).not.toBeInTheDocument();
   });
 
   it.skip('disables form inputs when loading', async () => {

--- a/apps/web/src/pages/__tests__/SignupPage.test.tsx
+++ b/apps/web/src/pages/__tests__/SignupPage.test.tsx
@@ -1,20 +1,77 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+import type { Plan } from '@beakerstack/billing';
 import SignupPage from '../SignupPage';
 import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { POST_AUTH_REDIRECT_KEY } from '../../auth/postAuthRedirect';
 
-// Mock the supabase client
+const mockCatalogPlans = vi.hoisted(() => {
+  const pro: Plan = {
+    id: 'beakerstack_pro',
+    product_id: 'beakerstack',
+    display_name: 'Pro',
+    description: null,
+    price_cents: 1900,
+    billing_period: 'monthly',
+    stripe_price_id_monthly: null,
+    stripe_price_id_annual: null,
+    stripe_product_id: null,
+    features: {},
+    usage_limits: {},
+    trial_period_days: 0,
+    is_public: true,
+    display_order: 2,
+  };
+  return { pro };
+});
+
+vi.mock('@beakerstack/billing', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('@beakerstack/billing')>();
+  return {
+    ...actual,
+    BillingProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    usePlanCatalog: () => ({
+      plans: [mockCatalogPlans.pro],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    }),
+  };
+});
+
+const webSupabaseAuth = vi.hoisted(() => ({
+  getSession: vi.fn(),
+}));
+
+const authClientMocks = vi.hoisted(() => ({
+  signUp: vi.fn(),
+  signInWithOAuth: vi.fn(),
+}));
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// Mock the supabase client (SignupPage calls getSession on this module)
 vi.mock('@/lib/supabase', () => ({
   supabase: {
     auth: {
-      getSession: vi
-        .fn()
-        .mockResolvedValue({ data: { session: null }, error: null }),
+      getSession: (...args: unknown[]) => webSupabaseAuth.getSession(...args),
       onAuthStateChange: vi.fn(() => ({
         data: { subscription: { unsubscribe: vi.fn() } },
       })),
@@ -32,29 +89,131 @@ const createMockSupabaseClient = (): SupabaseClient => {
         data: { subscription: { unsubscribe: vi.fn() } },
       })),
       signInWithPassword: vi.fn(),
-      signUp: vi.fn(),
+      signUp: (...args: unknown[]) => authClientMocks.signUp(...args),
       signOut: vi.fn(),
-      signInWithOAuth: vi.fn(),
+      signInWithOAuth: (...args: unknown[]) =>
+        authClientMocks.signInWithOAuth(...args),
     },
   } as unknown as SupabaseClient;
 };
 
-const renderWithProviders = (component: React.ReactElement) => {
+const renderWithProviders = (
+  component: React.ReactElement,
+  options?: { initialEntries?: string[] }
+) => {
   const mockClient = createMockSupabaseClient();
-  return render(
-    <BrowserRouter>
-      <AuthProvider supabaseClient={mockClient}>
-        <ProfileProvider supabaseClient={mockClient}>
-          {component}
-        </ProfileProvider>
-      </AuthProvider>
-    </BrowserRouter>
-  );
+  const router =
+    options?.initialEntries != null ? (
+      <MemoryRouter initialEntries={options.initialEntries}>
+        <AuthProvider supabaseClient={mockClient}>
+          <ProfileProvider supabaseClient={mockClient}>
+            {component}
+          </ProfileProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    ) : (
+      <BrowserRouter>
+        <AuthProvider supabaseClient={mockClient}>
+          <ProfileProvider supabaseClient={mockClient}>
+            {component}
+          </ProfileProvider>
+        </AuthProvider>
+      </BrowserRouter>
+    );
+  return render(router);
 };
+
+/** Avoid flaky jsdom `Storage` after prototype spies / Supabase auth touching storage. */
+function installMemoryWebStorage() {
+  const make = (): Storage => {
+    const map = new Map<string, string>();
+    return {
+      get length() {
+        return map.size;
+      },
+      clear: () => {
+        map.clear();
+      },
+      getItem: (key: string) => {
+        const v = map.get(key);
+        return v === undefined ? null : v;
+      },
+      key: (index: number) => [...map.keys()][index] ?? null,
+      removeItem: (key: string) => {
+        map.delete(key);
+      },
+      setItem: (key: string, value: string) => {
+        map.set(key, value);
+      },
+    } as Storage;
+  };
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: make(),
+    writable: true,
+  });
+  Object.defineProperty(window, 'sessionStorage', {
+    configurable: true,
+    value: make(),
+    writable: true,
+  });
+}
+
+/**
+ * BillingProvider calls `getSession` before submit; return a session only after email `signUp`.
+ */
+function mockGetSessionForAuthFlow(options: {
+  sessionAfterSignup: boolean;
+}) {
+  webSupabaseAuth.getSession.mockImplementation(async () => {
+    if (!options.sessionAfterSignup) {
+      return { data: { session: null }, error: null };
+    }
+    const afterEmailSignup = authClientMocks.signUp.mock.calls.length > 0;
+    if (!afterEmailSignup) {
+      return { data: { session: null }, error: null };
+    }
+    return {
+      data: {
+        session: {
+          access_token: 'at',
+          refresh_token: 'rt',
+          expires_in: 3600,
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+          token_type: 'bearer' as const,
+          user: {
+            id: 'u1',
+            aud: 'authenticated',
+            role: 'authenticated',
+            email: 'a@b.com',
+            app_metadata: {},
+            user_metadata: {},
+            created_at: '',
+          },
+        },
+      },
+      error: null,
+    };
+  });
+}
 
 describe('SignupPage', () => {
   beforeEach(() => {
+    installMemoryWebStorage();
     vi.clearAllMocks();
+    mockNavigate.mockClear();
+    webSupabaseAuth.getSession.mockImplementation(async () => ({
+      data: { session: null },
+      error: null,
+    }));
+    authClientMocks.signUp.mockResolvedValue({
+      data: { user: { id: 'new-user' } },
+      error: null,
+    });
+    authClientMocks.signInWithOAuth.mockResolvedValue({
+      data: { provider: 'google', url: null },
+      error: null,
+    });
   });
 
   it('renders signup form', () => {
@@ -73,18 +232,14 @@ describe('SignupPage', () => {
     expect(screen.getByText('Sign up with Google')).toBeInTheDocument();
   });
 
-  it.skip('shows error when fields are empty', async () => {
-    const user = userEvent.setup();
+  it('shows error when fields are empty', async () => {
     renderWithProviders(<SignupPage />);
 
     const form = screen.getByPlaceholderText('Email address').closest('form');
-    const submitButton = form?.querySelector(
-      'button[type="submit"]'
-    ) as HTMLButtonElement;
-    expect(submitButton).toBeInTheDocument();
-    if (submitButton) {
-      await user.click(submitButton);
+    if (!(form instanceof HTMLFormElement)) {
+      throw new Error('Expected signup form');
     }
+    fireEvent.submit(form);
 
     await waitFor(() => {
       expect(screen.getByText('Please fill in all fields')).toBeInTheDocument();
@@ -161,6 +316,11 @@ describe('SignupPage', () => {
 
   it('displays error message on signup failure', async () => {
     const user = userEvent.setup();
+    authClientMocks.signUp.mockResolvedValueOnce({
+      data: { user: null },
+      error: { message: 'User already registered', name: 'AuthApiError', status: 422 },
+    });
+
     renderWithProviders(<SignupPage />);
 
     const emailInput = screen.getByPlaceholderText('Email address');
@@ -179,11 +339,113 @@ describe('SignupPage', () => {
       await user.click(submitButton);
     }
 
-    // The form should attempt submission - error handling is tested via integration tests
-    // This test verifies the form can be filled and submitted
-    expect(emailInput).toHaveValue('existing@example.com');
-    expect(passwordInput).toHaveValue('password123');
-    expect(confirmPasswordInput).toHaveValue('password123');
+    await waitFor(() => {
+      expect(screen.getByText('User already registered')).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to billing plans after signup when session exists and plan intent is paid', async () => {
+    const user = userEvent.setup();
+    mockGetSessionForAuthFlow({ sessionAfterSignup: true });
+
+    renderWithProviders(<SignupPage />, {
+      initialEntries: ['/signup?plan=beakerstack_pro'],
+    });
+
+    await user.type(screen.getByPlaceholderText('Email address'), 'new@example.com');
+    await user.type(screen.getByPlaceholderText('Password'), 'password123');
+    await user.type(screen.getByPlaceholderText('Confirm password'), 'password123');
+    await user.click(screen.getByRole('button', { name: /Continue with Pro/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/billing/plans?plan=beakerstack_pro&welcome=1',
+        { replace: true }
+      );
+    });
+  });
+
+  it('navigates to dashboard after signup when session exists and there is no paid plan intent', async () => {
+    const user = userEvent.setup();
+    mockGetSessionForAuthFlow({ sessionAfterSignup: true });
+
+    renderWithProviders(<SignupPage />, { initialEntries: ['/signup'] });
+
+    await user.type(screen.getByPlaceholderText('Email address'), 'new@example.com');
+    await user.type(screen.getByPlaceholderText('Password'), 'password123');
+    await user.type(screen.getByPlaceholderText('Confirm password'), 'password123');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
+    });
+  });
+
+  it('shows check your email and stores redirect when signup succeeds without session and paid plan intent', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<SignupPage />, {
+      initialEntries: ['/signup?plan=beakerstack_pro'],
+    });
+
+    await user.type(screen.getByPlaceholderText('Email address'), 'pending@example.com');
+    await user.type(screen.getByPlaceholderText('Password'), 'password123');
+    await user.type(screen.getByPlaceholderText('Confirm password'), 'password123');
+    await user.click(screen.getByRole('button', { name: /Continue with Pro/i }));
+
+    await waitFor(() => expect(authClientMocks.signUp).toHaveBeenCalled());
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(screen.getByText('Check your email')).toBeInTheDocument();
+      expect(screen.getByText(/pending@example.com/)).toBeInTheDocument();
+    });
+
+    const raw = window.localStorage.getItem(POST_AUTH_REDIRECT_KEY);
+    expect(raw).toBeTruthy();
+    expect(raw).toContain('/billing/plans');
+  });
+
+  it('navigates to dashboard after signup when no session and no paid plan intent', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SignupPage />, { initialEntries: ['/signup'] });
+
+    await user.type(screen.getByPlaceholderText('Email address'), 'confirm@example.com');
+    await user.type(screen.getByPlaceholderText('Password'), 'password123');
+    await user.type(screen.getByPlaceholderText('Confirm password'), 'password123');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
+    });
+  });
+
+  it('clears OAuth stash and shows error when Google signup fails', async () => {
+    const user = userEvent.setup();
+    authClientMocks.signInWithOAuth.mockResolvedValueOnce({
+      data: { provider: 'google', url: null },
+      error: {
+        message: 'OAuth provider unavailable',
+        name: 'AuthApiError',
+        status: 503,
+      },
+    });
+
+    const removeSpy = vi.spyOn(window.sessionStorage, 'removeItem');
+
+    renderWithProviders(<SignupPage />, {
+      initialEntries: ['/signup?plan=beakerstack_pro'],
+    });
+
+    await user.click(screen.getByRole('button', { name: /Sign up with Google/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('OAuth provider unavailable')).toBeInTheDocument();
+    });
+
+    expect(authClientMocks.signInWithOAuth).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalledWith(POST_AUTH_REDIRECT_KEY);
+    removeSpy.mockRestore();
   });
 
   it('has link to login page', () => {
@@ -191,6 +453,21 @@ describe('SignupPage', () => {
     const loginLink = screen.getByText('Already have an account? Sign in');
     expect(loginLink).toBeInTheDocument();
     expect(loginLink.closest('a')).toHaveAttribute('href', '/login');
+  });
+
+  it('shows paid funnel CTA when arriving from pricing with Pro plan', () => {
+    renderWithProviders(<SignupPage />, {
+      initialEntries: ['/signup?plan=beakerstack_pro'],
+    });
+    expect(
+      screen.getByRole('button', { name: /Continue with Pro/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Your selection')).toBeInTheDocument();
+  });
+
+  it('does not show plan aside copy on plain /signup', () => {
+    renderWithProviders(<SignupPage />);
+    expect(screen.queryByText('Your selection')).not.toBeInTheDocument();
   });
 
   it.skip('disables form inputs when loading', async () => {

--- a/apps/web/src/pages/__tests__/SignupPage.test.tsx
+++ b/apps/web/src/pages/__tests__/SignupPage.test.tsx
@@ -31,8 +31,7 @@ const mockCatalogPlans = vi.hoisted(() => {
 });
 
 vi.mock('@beakerstack/billing', async importOriginal => {
-  const actual =
-    await importOriginal<typeof import('@beakerstack/billing')>();
+  const actual = await importOriginal<typeof import('@beakerstack/billing')>();
   return {
     ...actual,
     BillingProvider: ({ children }: { children: React.ReactNode }) => (
@@ -59,8 +58,7 @@ const authClientMocks = vi.hoisted(() => ({
 const mockNavigate = vi.fn();
 
 vi.mock('react-router-dom', async importOriginal => {
-  const actual =
-    await importOriginal<typeof import('react-router-dom')>();
+  const actual = await importOriginal<typeof import('react-router-dom')>();
   return {
     ...actual,
     useNavigate: () => mockNavigate,
@@ -162,9 +160,7 @@ function installMemoryWebStorage() {
 /**
  * BillingProvider calls `getSession` before submit; return a session only after email `signUp`.
  */
-function mockGetSessionForAuthFlow(options: {
-  sessionAfterSignup: boolean;
-}) {
+function mockGetSessionForAuthFlow(options: { sessionAfterSignup: boolean }) {
   webSupabaseAuth.getSession.mockImplementation(async () => {
     if (!options.sessionAfterSignup) {
       return { data: { session: null }, error: null };
@@ -318,7 +314,11 @@ describe('SignupPage', () => {
     const user = userEvent.setup();
     authClientMocks.signUp.mockResolvedValueOnce({
       data: { user: null },
-      error: { message: 'User already registered', name: 'AuthApiError', status: 422 },
+      error: {
+        message: 'User already registered',
+        name: 'AuthApiError',
+        status: 422,
+      },
     });
 
     renderWithProviders(<SignupPage />);
@@ -352,10 +352,18 @@ describe('SignupPage', () => {
       initialEntries: ['/signup?plan=beakerstack_pro'],
     });
 
-    await user.type(screen.getByPlaceholderText('Email address'), 'new@example.com');
+    await user.type(
+      screen.getByPlaceholderText('Email address'),
+      'new@example.com'
+    );
     await user.type(screen.getByPlaceholderText('Password'), 'password123');
-    await user.type(screen.getByPlaceholderText('Confirm password'), 'password123');
-    await user.click(screen.getByRole('button', { name: /Continue with Pro/i }));
+    await user.type(
+      screen.getByPlaceholderText('Confirm password'),
+      'password123'
+    );
+    await user.click(
+      screen.getByRole('button', { name: /Continue with Pro/i })
+    );
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
@@ -371,13 +379,21 @@ describe('SignupPage', () => {
 
     renderWithProviders(<SignupPage />, { initialEntries: ['/signup'] });
 
-    await user.type(screen.getByPlaceholderText('Email address'), 'new@example.com');
+    await user.type(
+      screen.getByPlaceholderText('Email address'),
+      'new@example.com'
+    );
     await user.type(screen.getByPlaceholderText('Password'), 'password123');
-    await user.type(screen.getByPlaceholderText('Confirm password'), 'password123');
+    await user.type(
+      screen.getByPlaceholderText('Confirm password'),
+      'password123'
+    );
     await user.click(screen.getByRole('button', { name: /create account/i }));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
+        replace: true,
+      });
     });
   });
 
@@ -388,10 +404,18 @@ describe('SignupPage', () => {
       initialEntries: ['/signup?plan=beakerstack_pro'],
     });
 
-    await user.type(screen.getByPlaceholderText('Email address'), 'pending@example.com');
+    await user.type(
+      screen.getByPlaceholderText('Email address'),
+      'pending@example.com'
+    );
     await user.type(screen.getByPlaceholderText('Password'), 'password123');
-    await user.type(screen.getByPlaceholderText('Confirm password'), 'password123');
-    await user.click(screen.getByRole('button', { name: /Continue with Pro/i }));
+    await user.type(
+      screen.getByPlaceholderText('Confirm password'),
+      'password123'
+    );
+    await user.click(
+      screen.getByRole('button', { name: /Continue with Pro/i })
+    );
 
     await waitFor(() => expect(authClientMocks.signUp).toHaveBeenCalled());
     expect(mockNavigate).not.toHaveBeenCalled();
@@ -410,13 +434,21 @@ describe('SignupPage', () => {
     const user = userEvent.setup();
     renderWithProviders(<SignupPage />, { initialEntries: ['/signup'] });
 
-    await user.type(screen.getByPlaceholderText('Email address'), 'confirm@example.com');
+    await user.type(
+      screen.getByPlaceholderText('Email address'),
+      'confirm@example.com'
+    );
     await user.type(screen.getByPlaceholderText('Password'), 'password123');
-    await user.type(screen.getByPlaceholderText('Confirm password'), 'password123');
+    await user.type(
+      screen.getByPlaceholderText('Confirm password'),
+      'password123'
+    );
     await user.click(screen.getByRole('button', { name: /create account/i }));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
+        replace: true,
+      });
     });
   });
 
@@ -437,10 +469,14 @@ describe('SignupPage', () => {
       initialEntries: ['/signup?plan=beakerstack_pro'],
     });
 
-    await user.click(screen.getByRole('button', { name: /Sign up with Google/i }));
+    await user.click(
+      screen.getByRole('button', { name: /Sign up with Google/i })
+    );
 
     await waitFor(() => {
-      expect(screen.getByText('OAuth provider unavailable')).toBeInTheDocument();
+      expect(
+        screen.getByText('OAuth provider unavailable')
+      ).toBeInTheDocument();
     });
 
     expect(authClientMocks.signInWithOAuth).toHaveBeenCalled();

--- a/apps/web/src/pages/billing/BillingPlansPage.tsx
+++ b/apps/web/src/pages/billing/BillingPlansPage.tsx
@@ -85,14 +85,11 @@ export default function BillingPlansPage() {
   useEffect(() => {
     const sp = new URLSearchParams(searchKey);
     if (sp.get('welcome') !== '1' || !welcomePlanId || catLoad) return;
-    const raf = requestAnimationFrame(() => {
-      document
-        .getElementById(`plan-card-${welcomePlanId}`)
-        ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    });
+    document
+      .getElementById(`plan-card-${welcomePlanId}`)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
     sp.delete('welcome');
     setSearchParams(sp, { replace: true });
-    return () => cancelAnimationFrame(raf);
   }, [searchKey, setSearchParams, welcomePlanId, catLoad]);
 
   const welcomePlanMeta = useMemo(

--- a/apps/web/src/pages/billing/BillingPlansPage.tsx
+++ b/apps/web/src/pages/billing/BillingPlansPage.tsx
@@ -46,8 +46,7 @@ export default function BillingPlansPage() {
   const [search, setSearchParams] = useSearchParams();
   const cadence = getCadenceFromSearch(search);
   const [welcomeSnapshot] = useState(() => ({
-    showBanner:
-      search.get('welcome') === '1' && Boolean(search.get('plan')),
+    showBanner: search.get('welcome') === '1' && Boolean(search.get('plan')),
     planId: search.get('plan'),
   }));
   const { plans, loading: catLoad } =

--- a/apps/web/src/pages/billing/BillingPlansPage.tsx
+++ b/apps/web/src/pages/billing/BillingPlansPage.tsx
@@ -9,7 +9,7 @@ import {
   useSubscription,
   useUsage,
 } from '@beakerstack/billing';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   beakerstackBillingConfig,
@@ -43,8 +43,13 @@ type Primary = {
 };
 
 export default function BillingPlansPage() {
-  const [search] = useSearchParams();
+  const [search, setSearchParams] = useSearchParams();
   const cadence = getCadenceFromSearch(search);
+  const [welcomeSnapshot] = useState(() => ({
+    showBanner:
+      search.get('welcome') === '1' && Boolean(search.get('plan')),
+    planId: search.get('plan'),
+  }));
   const { plans, loading: catLoad } =
     usePlanCatalog<typeof beakerstackBillingConfig>();
   const { data: current } = usePlan<typeof beakerstackBillingConfig>();
@@ -68,6 +73,32 @@ export default function BillingPlansPage() {
 
   const [modal, setModal] = useState(false);
   const pending = checkoutPend || actionPend;
+
+  const welcomePlanId = welcomeSnapshot.planId;
+  const welcomeFromPricing =
+    welcomeSnapshot.showBanner &&
+    Boolean(welcomePlanId) &&
+    plans.some(p => p.id === welcomePlanId);
+
+  const searchKey = search.toString();
+
+  useEffect(() => {
+    const sp = new URLSearchParams(searchKey);
+    if (sp.get('welcome') !== '1' || !welcomePlanId || catLoad) return;
+    const raf = requestAnimationFrame(() => {
+      document
+        .getElementById(`plan-card-${welcomePlanId}`)
+        ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+    sp.delete('welcome');
+    setSearchParams(sp, { replace: true });
+    return () => cancelAnimationFrame(raf);
+  }, [searchKey, setSearchParams, welcomePlanId, catLoad]);
+
+  const welcomePlanMeta = useMemo(
+    () => (welcomePlanId ? plans.find(p => p.id === welcomePlanId) : undefined),
+    [plans, welcomePlanId]
+  );
 
   const currentCadence = useMemo(
     () =>
@@ -249,6 +280,22 @@ export default function BillingPlansPage() {
       <div className='mt-6'>
         <CadenceToggle />
       </div>
+      {welcomeFromPricing && welcomePlanMeta ? (
+        <div
+          role='status'
+          className='mt-6 rounded-lg border border-indigo-200 bg-indigo-50 px-4 py-3 text-sm text-indigo-950'
+        >
+          <p className='font-medium'>
+            You&apos;re almost there — finish checkout for{' '}
+            {welcomePlanMeta.display_name}
+          </p>
+          <p className='mt-1 text-indigo-900/90'>
+            {cadence === 'annual'
+              ? 'Annual billing is selected below. Use Upgrade to start checkout when you are ready.'
+              : 'Monthly billing is selected below. Use Upgrade to start checkout when you are ready.'}
+          </p>
+        </div>
+      ) : null}
       {catLoad ? (
         <p className='mt-8 text-sm text-gray-500'>Loading plans…</p>
       ) : (

--- a/apps/web/src/pages/billing/__tests__/BillingInvoicesPage.test.tsx
+++ b/apps/web/src/pages/billing/__tests__/BillingInvoicesPage.test.tsx
@@ -1,20 +1,30 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
+import type { BillingInvoiceRow } from '@beakerstack/billing';
 import BillingInvoicesPage from '../BillingInvoicesPage';
 
 const loadMore = vi.fn();
 
+const invoicesHook = vi.hoisted(() => ({
+  items: [] as BillingInvoiceRow[],
+  loading: false,
+  hasMore: false,
+  error: null as Error | string | null,
+}));
+
 vi.mock('@beakerstack/billing', async importOriginal => {
-  const actual = await importOriginal<typeof import('@beakerstack/billing')>();
+  const actual =
+    await importOriginal<typeof import('@beakerstack/billing')>();
   return {
     ...actual,
     useInvoices: () => ({
-      items: [],
-      loading: false,
-      hasMore: false,
+      items: invoicesHook.items,
+      loading: invoicesHook.loading,
+      hasMore: invoicesHook.hasMore,
       loadMore,
-      error: null,
+      error: invoicesHook.error,
       refresh: vi.fn(),
     }),
   };
@@ -26,7 +36,35 @@ vi.mock('@/components/billing/BillingPageShell.web', () => ({
   ),
 }));
 
+const sampleInvoice = (): BillingInvoiceRow => ({
+  id: 'inv_1',
+  user_id: 'u1',
+  stripe_invoice_id: 'in_1',
+  stripe_customer_id: 'cus_1',
+  stripe_subscription_id: 'sub_1',
+  amount_due: 0,
+  amount_paid: 1200,
+  currency: 'usd',
+  status: 'paid',
+  description: 'Invoice',
+  hosted_invoice_url: null,
+  invoice_pdf_url: null,
+  period_start: null,
+  period_end: null,
+  created_at: '2026-02-01T00:00:00Z',
+  finalized_at: null,
+  paid_at: null,
+});
+
 describe('BillingInvoicesPage', () => {
+  beforeEach(() => {
+    invoicesHook.items = [];
+    invoicesHook.loading = false;
+    invoicesHook.hasMore = false;
+    invoicesHook.error = null;
+    loadMore.mockClear();
+  });
+
   it('renders invoices heading and empty-state hint', () => {
     render(
       <MemoryRouter>
@@ -37,5 +75,39 @@ describe('BillingInvoicesPage', () => {
       screen.getByRole('heading', { name: 'Invoices' })
     ).toBeInTheDocument();
     expect(screen.getByText(/Explore plans/i)).toBeInTheDocument();
+  });
+
+  it('shows invoice hook error in an alert', () => {
+    invoicesHook.error = new Error('Stripe unavailable');
+    render(
+      <MemoryRouter>
+        <BillingInvoicesPage />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Stripe unavailable');
+  });
+
+  it('lists invoice rows when data is present', () => {
+    invoicesHook.items = [sampleInvoice()];
+    render(
+      <MemoryRouter>
+        <BillingInvoicesPage />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Invoice')).toBeInTheDocument();
+    expect(screen.queryByText(/Explore plans/i)).not.toBeInTheDocument();
+  });
+
+  it('invokes loadMore from InvoiceTable when there are more pages', async () => {
+    const user = userEvent.setup();
+    invoicesHook.items = [sampleInvoice()];
+    invoicesHook.hasMore = true;
+    render(
+      <MemoryRouter>
+        <BillingInvoicesPage />
+      </MemoryRouter>
+    );
+    await user.click(screen.getByRole('button', { name: /Load more/i }));
+    expect(loadMore).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/pages/billing/__tests__/BillingInvoicesPage.test.tsx
+++ b/apps/web/src/pages/billing/__tests__/BillingInvoicesPage.test.tsx
@@ -15,8 +15,7 @@ const invoicesHook = vi.hoisted(() => ({
 }));
 
 vi.mock('@beakerstack/billing', async importOriginal => {
-  const actual =
-    await importOriginal<typeof import('@beakerstack/billing')>();
+  const actual = await importOriginal<typeof import('@beakerstack/billing')>();
   return {
     ...actual,
     useInvoices: () => ({

--- a/apps/web/src/pages/billing/__tests__/BillingPlansPage.test.tsx
+++ b/apps/web/src/pages/billing/__tests__/BillingPlansPage.test.tsx
@@ -175,6 +175,7 @@ describe('BillingPlansPage', () => {
     );
 
   beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
     plansState.catLoading = false;
     plansState.currentNull = false;
     checkoutSpies.startCheckout.mockReset();
@@ -412,5 +413,18 @@ describe('BillingPlansPage', () => {
     const dots = screen.getAllByRole('button', { name: '…' });
     expect(dots.length).toBeGreaterThan(0);
     expect(dots[0]).toBeDisabled();
+  });
+
+  it('exposes plan-card-{id} anchors for scroll targeting', () => {
+    renderPage();
+    expect(document.getElementById('plan-card-beakerstack_pro')).toBeTruthy();
+    expect(document.getElementById('plan-card-beakerstack_max')).toBeTruthy();
+  });
+
+  it('shows post-signup funnel banner when welcome=1 and plan is in catalog', async () => {
+    renderPage('/billing/plans?plan=beakerstack_pro&welcome=1');
+    expect(
+      await screen.findByText(/You.*re almost there/i)
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/billing/__tests__/BillingPlansPage.test.tsx
+++ b/apps/web/src/pages/billing/__tests__/BillingPlansPage.test.tsx
@@ -427,4 +427,11 @@ describe('BillingPlansPage', () => {
       await screen.findByText(/You.*re almost there/i)
     ).toBeInTheDocument();
   });
+
+  it('welcome banner copy reflects annual cadence when selected', async () => {
+    renderPage('/billing/plans?plan=beakerstack_pro&welcome=1&cadence=annual');
+    expect(
+      await screen.findByText(/Annual billing is selected below/i)
+    ).toBeInTheDocument();
+  });
 });

--- a/packages/billing/src/components/PricingTable.web.tsx
+++ b/packages/billing/src/components/PricingTable.web.tsx
@@ -38,9 +38,7 @@ export function PricingTable<P extends ProductBillingConfig>({
               <li
                 key={p.id}
                 style={{
-                  border: isCurrent
-                    ? '2px solid #3b82f6'
-                    : '1px solid #e5e7eb',
+                  border: isCurrent ? '2px solid #3b82f6' : '1px solid #e5e7eb',
                   padding: 12,
                   marginBottom: 8,
                   borderRadius: 8,
@@ -50,10 +48,7 @@ export function PricingTable<P extends ProductBillingConfig>({
                 {(p.price_cents / 100).toFixed(2)} USD / {p.billing_period}
                 {onPlanChosen ? (
                   <div style={{ marginTop: 8 }}>
-                    <button
-                      type='button'
-                      onClick={() => onPlanChosen(p.id)}
-                    >
+                    <button type='button' onClick={() => onPlanChosen(p.id)}>
                       {isAuthenticated ? 'Select' : 'Get started'}
                     </button>
                   </div>

--- a/packages/billing/src/components/__tests__/PricingTable.web.test.tsx
+++ b/packages/billing/src/components/__tests__/PricingTable.web.test.tsx
@@ -6,8 +6,18 @@ import { PricingTable } from '../PricingTable.web';
 vi.mock('../../hooks/usePlanCatalog.js', () => ({
   usePlanCatalog: () => ({
     plans: [
-      { id: 'plan_free', display_name: 'Free', price_cents: 0, billing_period: 'free' },
-      { id: 'plan_pro', display_name: 'Pro', price_cents: 1900, billing_period: 'monthly' },
+      {
+        id: 'plan_free',
+        display_name: 'Free',
+        price_cents: 0,
+        billing_period: 'free',
+      },
+      {
+        id: 'plan_pro',
+        display_name: 'Pro',
+        price_cents: 1900,
+        billing_period: 'monthly',
+      },
     ],
     loading: false,
   }),
@@ -25,13 +35,19 @@ describe('PricingTable', () => {
 
   it('shows "Get started" buttons when unauthenticated', () => {
     render(<PricingTable isAuthenticated={false} onCheckout={() => {}} />);
-    expect(screen.getAllByRole('button', { name: 'Get started' })).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: 'Get started' })).toHaveLength(
+      2
+    );
     expect(screen.queryByRole('button', { name: 'Select' })).toBeNull();
   });
 
   it('suppresses current-plan highlight when unauthenticated', () => {
     const { container } = render(
-      <PricingTable isAuthenticated={false} highlightCurrent={true} onCheckout={() => {}} />
+      <PricingTable
+        isAuthenticated={false}
+        highlightCurrent={true}
+        onCheckout={() => {}}
+      />
     );
     const items = container.querySelectorAll('li');
     items.forEach(li => {
@@ -42,7 +58,9 @@ describe('PricingTable', () => {
   it('fires onCheckout with planId when Get started is clicked', async () => {
     const onCheckout = vi.fn();
     render(<PricingTable isAuthenticated={false} onCheckout={onCheckout} />);
-    await userEvent.click(screen.getAllByRole('button', { name: 'Get started' })[1]);
+    await userEvent.click(
+      screen.getAllByRole('button', { name: 'Get started' })[1]
+    );
     expect(onCheckout).toHaveBeenCalledWith('plan_pro');
   });
 });


### PR DESCRIPTION
Closes #68 

## Summary

Implements the **post-pricing signup funnel**: preserve plan intent from landing pricing through signup/login, route paid-intent users to **`/billing/plans`** after authentication (with welcome UX), and show **plan context on signup** using the same Supabase-backed catalog as the home page.

## What changed

- **`resolvePostAuthDestination`** + **`validateInternalPostAuthPath`** — synchronous resolver against `beakerstackBillingConfig`; unknown/free → `/dashboard`; paid public → `/billing/plans?plan=…&welcome=1` (+ cadence); rejects protocol-relative and external URLs.
- **`beakerstack:post_auth_redirect`** — JSON payload `{ path, ts }` with **30-minute TTL** in **`sessionStorage`** (Google OAuth) and **`localStorage`** (email confirmation when signup returns no session).
- **`AuthCallbackPage`** — read both stores, **unconditionally `removeItem` both**, parse/TTL/validate, then `navigate(..., { replace: true })`.
- **`SignupPage` / `LoginPage`** — `BillingProvider` + plan summary; preserve query between signup ↔ login; clear stale `localStorage` on successful email auth; Google stashes intent before OAuth.
- **`BillingPlansPage`** — welcome banner, scroll to **`plan-card-{plan.id}`**, strip **`welcome`** from URL with **`replace: true`**.
- Tests for redirect helper, callback coverage, billing welcome, plan bullets.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactoring
- [ ] Other

## Merge strategy (targets `develop`)

Use **Squash and merge** when merging into `develop`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code (only where needed)
- [ ] Documentation updated (if needed)
- [x] No new warnings generated (address any CI findings)
- [x] Tests added/updated
- [x] All tests pass locally (`apps/web` vitest, `tsc --noEmit`)

## Testing

- `cd apps/web && npm test`
- `cd apps/web && npx tsc --noEmit`

## Related

Closes / implements **[#68 — Post-pricing signup: preserve plan intent, contextual signup UI, and route paid signups to billing checkout](https://github.com/Artificer-Innovations/BeakerStack/issues/68)** (if that matches scope—adjust if not).
