### PR TITLE
feat(web): pre-render marketing home page for SEO and social sharing

### DIFF
--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -103,7 +103,8 @@ jobs:
             --domain "${PREVIEW_DOMAIN}" \
             --hosted-zone-id "${PREVIEW_HOSTED_ZONE_ID}" \
             --certificate-arn "${PREVIEW_CERTIFICATE_ARN}" \
-            --preview-prefix "${PREVIEW_PREFIX_VALUE}"
+            --preview-prefix "${PREVIEW_PREFIX_VALUE}" \
+            --skip-cloudfront-function-publish
 
       - name: Prepare Supabase preview database
         id: supabase
@@ -191,6 +192,25 @@ jobs:
             --environment preview \
             --preview-prefix "${PREVIEW_PREFIX_VALUE}" \
             --region "${AWS_REGION_VALUE}"
+
+      # Publish edge routing only after a successful web build so a failed deploy cannot
+      # replace live CloudFront function code while leaving stale or missing S3 assets.
+      - name: Publish PR path router (CloudFront)
+        if: steps.web.outcome == 'success'
+        shell: bash
+        run: |
+          set -euo pipefail
+          STACK_NAME="${PREVIEW_STACK_NAME:-beakerstack-pr-preview}"
+          AWS_REGION_VALUE="${PREVIEW_AWS_REGION:-us-east-1}"
+          PREVIEW_PREFIX_VALUE="${PREVIEW_PREFIX:-pr-}"
+          ./scripts/pr-preview/bootstrap-aws-stack.sh \
+            --stack-name "${STACK_NAME}" \
+            --region "${AWS_REGION_VALUE}" \
+            --domain "${PREVIEW_DOMAIN}" \
+            --hosted-zone-id "${PREVIEW_HOSTED_ZONE_ID}" \
+            --certificate-arn "${PREVIEW_CERTIFICATE_ARN}" \
+            --preview-prefix "${PREVIEW_PREFIX_VALUE}" \
+            --if-stack-exists refresh-outputs
 
       - name: Check for native code changes
         id: native-changes

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -12,11 +12,12 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="BeakerStack — Ship your SaaS faster." />
     <meta property="og:description" content="Everything you need to ship a real product. Auth, billing, and cross-platform React with a production CI/CD pipeline." />
-    <meta property="og:image" content="https://beakerstack.com/og-image.png" />
+    <!-- Shipped icon until a dedicated 1200×630 og-image asset exists. -->
+    <meta property="og:image" content="https://beakerstack.com/android-chrome-512x512.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="BeakerStack — Ship your SaaS faster." />
     <meta name="twitter:description" content="Everything you need to ship a real product." />
-    <meta name="twitter:image" content="https://beakerstack.com/og-image.png" />
+    <meta name="twitter:image" content="https://beakerstack.com/android-chrome-512x512.png" />
 
     <!-- Favicons for all browsers -->
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,20 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>%APP_TITLE%</title>
-    
+
+    <!-- Site-wide meta — canonical and og:url are home-only and are injected into
+         prerender-home.html by scripts/prerender-home.ts; adding them here would
+         incorrectly set home-page values on /dashboard, /login, etc. -->
+    <meta name="description" content="BeakerStack gives you auth, billing, and a cross-platform React foundation — ready to ship your SaaS." />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="BeakerStack — Ship your SaaS faster." />
+    <meta property="og:description" content="Everything you need to ship a real product. Auth, billing, and cross-platform React with a production CI/CD pipeline." />
+    <meta property="og:image" content="https://beakerstack.com/og-image.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="BeakerStack — Ship your SaaS faster." />
+    <meta name="twitter:description" content="Everything you need to ship a real product." />
+    <meta name="twitter:image" content="https://beakerstack.com/og-image.png" />
+
     <!-- Favicons for all browsers -->
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && vite-node scripts/prerender-home.ts",
     "preview": "vite preview",
     "test": "vitest --run",
     "test:watch": "vitest --watch",
@@ -46,6 +46,7 @@
     "tailwindcss": "^3.3.0",
     "typescript": "^5.3.0",
     "vite": "^6.4.2",
+    "vite-node": "^3.2.4",
     "vitest": "^3.2.4"
   }
 }

--- a/apps/web/scripts/prerender-home.ts
+++ b/apps/web/scripts/prerender-home.ts
@@ -39,10 +39,14 @@ const publicHomeUrl = `${siteOrigin}${homePath === '/' ? '/' : homePath}`;
 const routerBasename =
   basePath === '' || basePath === '/' ? undefined : basePath;
 
+// MemoryRouter matches locations against basename: with basename "/pr-N", "/" does not
+// match (RR warns and renders nothing). Use the same pathname as publicHomeUrl path.
+const initialEntries = [homePath];
+
 const html = renderToStaticMarkup(
   createElement(
     MemoryRouter,
-    { basename: routerBasename, initialEntries: ['/'] },
+    { basename: routerBasename, initialEntries },
     createElement(LandingPage)
   )
 );

--- a/apps/web/scripts/prerender-home.ts
+++ b/apps/web/scripts/prerender-home.ts
@@ -1,10 +1,24 @@
-import { createElement } from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
-import { StaticRouter } from 'react-router-dom/server';
-import { LandingPage } from '../src/components/landing/LandingPage';
 import { readFileSync, writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { join, dirname } from 'path';
+
+// Shim WebSocket for Node < 22 before any app module loads.
+// supabase-js checks globalThis.WebSocket at createClient() time (module load, not runtime).
+// renderToStaticMarkup never opens a socket, but the check throws on Node 20 without this.
+// Dynamic imports below ensure this assignment runs first (static imports are hoisted).
+if (typeof globalThis.WebSocket === 'undefined') {
+  (globalThis as any).WebSocket = class WebSocket {
+    constructor(_url: string) {}
+    close() {}
+    addEventListener() {}
+    removeEventListener() {}
+  };
+}
+
+const { createElement } = await import('react');
+const { renderToStaticMarkup } = await import('react-dom/server');
+const { StaticRouter } = await import('react-router-dom/server');
+const { LandingPage } = await import('../src/components/landing/LandingPage');
 
 const webRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 

--- a/apps/web/scripts/prerender-home.ts
+++ b/apps/web/scripts/prerender-home.ts
@@ -1,0 +1,47 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { StaticRouter } from 'react-router-dom/server';
+import { LandingPage } from '../src/components/landing/LandingPage';
+import { readFileSync, writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { join, dirname } from 'path';
+
+const webRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const html = renderToStaticMarkup(
+  createElement(
+    StaticRouter,
+    { location: '/' },
+    createElement(LandingPage)
+  )
+);
+
+// Structural smoke check — catches a broken render without hardcoding copy text.
+// Fails the build if LandingPage produced no heading element.
+if (!html.includes('<h1')) {
+  console.error(
+    'pre-render smoke check: no <h1> in output — LandingPage did not render'
+  );
+  process.exit(1);
+}
+
+const template = readFileSync(join(webRoot, 'dist', 'index.html'), 'utf8');
+
+// canonical and og:url are home-only; inject here rather than in the base
+// template which is also served as the SPA fallback for all other routes.
+const withHomeMeta = template.replace(
+  '</head>',
+  [
+    '  <link rel="canonical" href="https://beakerstack.com/" />',
+    '  <meta property="og:url" content="https://beakerstack.com/" />',
+    '  </head>',
+  ].join('\n')
+);
+
+const out = withHomeMeta.replace(
+  '<div id="root"></div>',
+  `<div id="root">${html}</div>`
+);
+
+writeFileSync(join(webRoot, 'dist', 'prerender-home.html'), out);
+console.log(`pre-render complete — ${html.length} chars`);

--- a/apps/web/scripts/prerender-home.ts
+++ b/apps/web/scripts/prerender-home.ts
@@ -17,15 +17,19 @@ if (typeof globalThis.WebSocket === 'undefined') {
 
 const { createElement } = await import('react');
 const { renderToStaticMarkup } = await import('react-dom/server');
-const { StaticRouter } = await import('react-router-dom/server');
+// MemoryRouter comes from the same react-router-dom instance as <Link> and other
+// router-aware components in LandingPage, so they share the same NavigationContext.
+// StaticRouter (from react-router-dom/server) is a separate sub-package with its
+// own bundled context, causing a null-context mismatch in vite-node's module graph.
+const { MemoryRouter } = await import('react-router-dom');
 const { LandingPage } = await import('../src/components/landing/LandingPage');
 
 const webRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 const html = renderToStaticMarkup(
   createElement(
-    StaticRouter,
-    { location: '/' },
+    MemoryRouter,
+    { initialEntries: ['/'] },
     createElement(LandingPage)
   )
 );

--- a/apps/web/scripts/prerender-home.ts
+++ b/apps/web/scripts/prerender-home.ts
@@ -26,10 +26,23 @@ const { LandingPage } = await import('../src/components/landing/LandingPage');
 
 const webRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
+// Public home URL for canonical / og:url (set by deploy-web.sh per environment).
+const siteOrigin = (
+  process.env.VITE_PUBLIC_SITE_ORIGIN ?? 'https://beakerstack.com'
+).replace(/\/$/, '');
+let basePath = process.env.VITE_BASE_PATH ?? '/';
+if (!basePath.startsWith('/')) basePath = `/${basePath}`;
+basePath = basePath.replace(/\/+$/, '');
+const homePath = basePath === '' ? '/' : `${basePath}/`;
+const publicHomeUrl = `${siteOrigin}${homePath === '/' ? '/' : homePath}`;
+
+const routerBasename =
+  basePath === '' || basePath === '/' ? undefined : basePath;
+
 const html = renderToStaticMarkup(
   createElement(
     MemoryRouter,
-    { initialEntries: ['/'] },
+    { basename: routerBasename, initialEntries: ['/'] },
     createElement(LandingPage)
   )
 );
@@ -50,11 +63,22 @@ const template = readFileSync(join(webRoot, 'dist', 'index.html'), 'utf8');
 const withHomeMeta = template.replace(
   '</head>',
   [
-    '  <link rel="canonical" href="https://beakerstack.com/" />',
-    '  <meta property="og:url" content="https://beakerstack.com/" />',
+    `  <link rel="canonical" href="${publicHomeUrl}" />`,
+    `  <meta property="og:url" content="${publicHomeUrl}" />`,
     '  </head>',
   ].join('\n')
 );
+
+if (
+  withHomeMeta === template ||
+  !withHomeMeta.includes('rel="canonical"') ||
+  !withHomeMeta.includes('property="og:url"')
+) {
+  console.error(
+    'pre-render smoke check: </head> injection failed — dist/index.html may be missing </head> or markup changed'
+  );
+  process.exit(1);
+}
 
 const out = withHomeMeta.replace(
   '<div id="root"></div>',

--- a/apps/web/scripts/prerender-home.ts
+++ b/apps/web/scripts/prerender-home.ts
@@ -61,5 +61,14 @@ const out = withHomeMeta.replace(
   `<div id="root">${html}</div>`
 );
 
+// Verify the mount-point injection landed — catches a silent no-op if the
+// root div markup ever changes (e.g. id renamed from "root" to "app").
+if (out.includes('<div id="root"></div>')) {
+  console.error(
+    'pre-render smoke check: mount point injection failed — <div id="root"></div> still empty in output'
+  );
+  process.exit(1);
+}
+
 writeFileSync(join(webRoot, 'dist', 'prerender-home.html'), out);
 console.log(`pre-render complete — ${html.length} chars`);

--- a/apps/web/src/lib/__tests__/supabase-env-throws.test.ts
+++ b/apps/web/src/lib/__tests__/supabase-env-throws.test.ts
@@ -8,6 +8,7 @@ describe('supabase module env guards', () => {
   });
 
   it('throws when VITE_SUPABASE_URL is missing', async () => {
+    vi.stubGlobal('window', globalThis);
     vi.stubEnv('VITE_SUPABASE_URL', '');
     vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'test-anon-key');
     await expect(import('../supabase')).rejects.toThrow(
@@ -16,6 +17,7 @@ describe('supabase module env guards', () => {
   });
 
   it('throws when VITE_SUPABASE_ANON_KEY is missing', async () => {
+    vi.stubGlobal('window', globalThis);
     vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co');
     vi.stubEnv('VITE_SUPABASE_ANON_KEY', '');
     await expect(import('../supabase')).rejects.toThrow(

--- a/apps/web/src/lib/__tests__/supabase-env-throws.test.ts
+++ b/apps/web/src/lib/__tests__/supabase-env-throws.test.ts
@@ -11,7 +11,7 @@ describe('supabase module env guards', () => {
     vi.stubEnv('VITE_SUPABASE_URL', '');
     vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'test-anon-key');
     await expect(import('../supabase')).rejects.toThrow(
-      /Missing VITE_SUPABASE_URL/
+      /VITE_SUPABASE_URL.*is not set/
     );
   });
 
@@ -19,7 +19,7 @@ describe('supabase module env guards', () => {
     vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co');
     vi.stubEnv('VITE_SUPABASE_ANON_KEY', '');
     await expect(import('../supabase')).rejects.toThrow(
-      /Missing VITE_SUPABASE_ANON_KEY/
+      /VITE_SUPABASE_ANON_KEY.*is not set/
     );
   });
 });

--- a/apps/web/src/lib/supabase.ts
+++ b/apps/web/src/lib/supabase.ts
@@ -2,18 +2,20 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@beakerstack/shared/types/database';
 import { Logger } from '@beakerstack/shared/utils/logger';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
-if (!supabaseUrl) {
-  throw new Error('Missing VITE_SUPABASE_URL environment variable');
-}
-
-if (!supabaseAnonKey) {
-  throw new Error('Missing VITE_SUPABASE_ANON_KEY environment variable');
-}
+// Defensive fallback allows the module to load in the vite-node pre-render
+// context where env vars may be absent. No Supabase calls are made during
+// renderToStaticMarkup, so placeholder values are safe.
+const supabaseUrl =
+  import.meta.env.VITE_SUPABASE_URL ?? 'https://placeholder.supabase.co';
+const supabaseAnonKey =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ?? 'placeholder-anon-key';
 
 if (import.meta.env.DEV) {
+  if (!import.meta.env.VITE_SUPABASE_URL) {
+    Logger.warn(
+      '[web.supabase] VITE_SUPABASE_URL not set — using placeholder (pre-render only)'
+    );
+  }
   const realtimeUrl = supabaseUrl.replace(
     /^http(s?)/,
     (_: string, secure: string) => (secure ? 'wss' : 'ws')

--- a/apps/web/src/lib/supabase.ts
+++ b/apps/web/src/lib/supabase.ts
@@ -25,6 +25,11 @@ if (import.meta.env.DEV) {
       '[web.supabase] VITE_SUPABASE_URL not set — using placeholder (pre-render only)'
     );
   }
+  if (isNode && !import.meta.env.VITE_SUPABASE_ANON_KEY) {
+    Logger.warn(
+      '[web.supabase] VITE_SUPABASE_ANON_KEY not set — using placeholder (pre-render only)'
+    );
+  }
   const realtimeUrl = supabaseUrl.replace(
     /^http(s?)/,
     (_: string, secure: string) => (secure ? 'wss' : 'ws')

--- a/apps/web/src/lib/supabase.ts
+++ b/apps/web/src/lib/supabase.ts
@@ -2,16 +2,25 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@beakerstack/shared/types/database';
 import { Logger } from '@beakerstack/shared/utils/logger';
 
-// Defensive fallback allows the module to load in the vite-node pre-render
-// context where env vars may be absent. No Supabase calls are made during
-// renderToStaticMarkup, so placeholder values are safe.
+// In the Node/vite-node pre-render path, env vars may be absent and no Supabase
+// calls happen during renderToStaticMarkup, so placeholder values are safe.
+// In browser context a missing env var is a build misconfiguration — throw loudly.
+const isNode = typeof window === 'undefined';
+
+if (!isNode) {
+  if (!import.meta.env.VITE_SUPABASE_URL)
+    throw new Error('[web.supabase] VITE_SUPABASE_URL is not set');
+  if (!import.meta.env.VITE_SUPABASE_ANON_KEY)
+    throw new Error('[web.supabase] VITE_SUPABASE_ANON_KEY is not set');
+}
+
 const supabaseUrl =
   import.meta.env.VITE_SUPABASE_URL ?? 'https://placeholder.supabase.co';
 const supabaseAnonKey =
   import.meta.env.VITE_SUPABASE_ANON_KEY ?? 'placeholder-anon-key';
 
 if (import.meta.env.DEV) {
-  if (!import.meta.env.VITE_SUPABASE_URL) {
+  if (isNode && !import.meta.env.VITE_SUPABASE_URL) {
     Logger.warn(
       '[web.supabase] VITE_SUPABASE_URL not set — using placeholder (pre-render only)'
     );

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -59,6 +59,13 @@ export default defineConfig(({ mode }) => {
     define: {
       __DEV__: JSON.stringify(isDev),
     },
+    // Externalize router packages in SSR/vite-node context so both
+    // react-router-dom (ESM, used by app components) and
+    // react-router-dom/server (CJS) resolve through the same CJS
+    // require() call and share a single NavigationContext instance.
+    ssr: {
+      external: ['react-router', 'react-router-dom', '@remix-run/router'],
+    },
     test: {
       globals: true,
       environment: 'jsdom',

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -90,6 +90,8 @@ export default defineConfig(({ mode }) => {
           // Pure config/data files — no logic to test, always mocked in tests
           'src/config/landing.ts',
           'src/config/landing.example.alt.ts',
+          // Build-time scripts — run by vite-node at build, not part of the app test suite
+          'scripts/',
         ],
       },
     },

--- a/infra/aws/functions/PRPathRouter.js
+++ b/infra/aws/functions/PRPathRouter.js
@@ -3,15 +3,15 @@
  *
  * For deploy.beakerstack.com:
  *   - Routes `/pr-<N>/*` paths to S3 prefix `pr-<N>/*`
- *   - Home path (`/pr-<N>` or `/pr-<N>/`) → `pr-<N>/prerender-home.html`
- *   - Handles SPA fallback: `/pr-<N>/some/route` → `pr-<N>/index.html`
+ *   - Home path (`/pr-<N>` or `/pr-<N>/`) -> `pr-<N>/prerender-home.html`
+ *   - Handles SPA fallback: `/pr-<N>/some/route` -> `pr-<N>/index.html`
  *   - Supports both file paths (with extensions) and directory-like paths
  *
  * Example URIs:
- *   - `/pr-123/` → `pr-123/prerender-home.html` (pre-rendered landing page)
- *   - `/pr-123/static/js/main.js` → `pr-123/static/js/main.js`
- *   - `/pr-123/dashboard` → `pr-123/index.html` (SPA routing)
- *   - `/pr-123/dashboard/settings` → `pr-123/index.html` (SPA routing)
+ *   - `/pr-123/` -> `pr-123/prerender-home.html` (pre-rendered landing page)
+ *   - `/pr-123/static/js/main.js` -> `pr-123/static/js/main.js`
+ *   - `/pr-123/dashboard` -> `pr-123/index.html` (SPA routing)
+ *   - `/pr-123/dashboard/settings` -> `pr-123/index.html` (SPA routing)
  *
  * The bootstrap script injects the values for PREVIEW_PREFIX via template substitution.
  */
@@ -35,7 +35,7 @@ function handler(event) {
     var sanitizedPrefix = prPrefix.replace(/^\/+|\/+$/g, '');
     var sanitizedPath = (restOfPath || '/').replace(/^\/+/, '');
 
-    // Home path (no sub-path or just a slash) → pre-rendered landing page.
+    // Home path (no sub-path or just a slash) -> pre-rendered landing page.
     // Mirrors the CloudFront Default Root Object used for prod/staging.
     if (!sanitizedPath || sanitizedPath === '' || sanitizedPath === '/') {
       return sanitizedPrefix + '/prerender-home.html';

--- a/infra/aws/functions/PRPathRouter.js
+++ b/infra/aws/functions/PRPathRouter.js
@@ -3,11 +3,12 @@
  *
  * For deploy.beakerstack.com:
  *   - Routes `/pr-<N>/*` paths to S3 prefix `pr-<N>/*`
+ *   - Home path (`/pr-<N>` or `/pr-<N>/`) → `pr-<N>/prerender-home.html`
  *   - Handles SPA fallback: `/pr-<N>/some/route` → `pr-<N>/index.html`
  *   - Supports both file paths (with extensions) and directory-like paths
  *
  * Example URIs:
- *   - `/pr-123/` → `pr-123/index.html`
+ *   - `/pr-123/` → `pr-123/prerender-home.html` (pre-rendered landing page)
  *   - `/pr-123/static/js/main.js` → `pr-123/static/js/main.js`
  *   - `/pr-123/dashboard` → `pr-123/index.html` (SPA routing)
  *   - `/pr-123/dashboard/settings` → `pr-123/index.html` (SPA routing)
@@ -34,9 +35,10 @@ function handler(event) {
     var sanitizedPrefix = prPrefix.replace(/^\/+|\/+$/g, '');
     var sanitizedPath = (restOfPath || '/').replace(/^\/+/, '');
 
-    // If no path or just a slash, serve index.html
+    // Home path (no sub-path or just a slash) → pre-rendered landing page.
+    // Mirrors the CloudFront Default Root Object used for prod/staging.
     if (!sanitizedPath || sanitizedPath === '' || sanitizedPath === '/') {
-      return sanitizedPrefix + '/index.html';
+      return sanitizedPrefix + '/prerender-home.html';
     }
 
     // If path doesn't have a file extension, treat as SPA route

--- a/infra/aws/functions/PRPathRouter.js
+++ b/infra/aws/functions/PRPathRouter.js
@@ -1,64 +1,34 @@
-/**
- * CloudFront viewer-request function to map path-based PR previews to S3 prefixes.
- *
- * For deploy.beakerstack.com:
- *   - Routes `/pr-<N>/*` paths to S3 prefix `pr-<N>/*`
- *   - Home path (`/pr-<N>` or `/pr-<N>/`) -> `pr-<N>/prerender-home.html`
- *   - Handles SPA fallback: `/pr-<N>/some/route` -> `pr-<N>/index.html`
- *   - Supports both file paths (with extensions) and directory-like paths
- *
- * Example URIs:
- *   - `/pr-123/` -> `pr-123/prerender-home.html` (pre-rendered landing page)
- *   - `/pr-123/static/js/main.js` -> `pr-123/static/js/main.js`
- *   - `/pr-123/dashboard` -> `pr-123/index.html` (SPA routing)
- *   - `/pr-123/dashboard/settings` -> `pr-123/index.html` (SPA routing)
- *
- * The bootstrap script injects the values for PREVIEW_PREFIX via template substitution.
- */
 function handler(event) {
   var request = event.request;
   var uri = request.uri || '/';
-  var previewPrefixBase = '%%PREVIEW_PREFIX%%'; // e.g., "pr-"
+  var previewPrefixBase = '%%PREVIEW_PREFIX%%';
 
-  // Match /pr-<N>/ pattern at the start of the path
   var prPathPattern = new RegExp('^/(' + previewPrefixBase + '\\d+)(/.*)?$');
   var match = uri.match(prPathPattern);
 
-  function isFilePath(path) {
-    // Check if path has a file extension (e.g., .js, .css, .png)
-    // Exclude trailing slashes
-    var trimmed = path.replace(/\/$/, '');
-    return /\.[a-z0-9]+$/i.test(trimmed);
-  }
-
-  function rewritePath(prPrefix, restOfPath) {
-    var sanitizedPrefix = prPrefix.replace(/^\/+|\/+$/g, '');
-    var sanitizedPath = (restOfPath || '/').replace(/^\/+/, '');
-
-    // Home path (no sub-path or just a slash) -> pre-rendered landing page.
-    // Mirrors the CloudFront Default Root Object used for prod/staging.
-    if (!sanitizedPath || sanitizedPath === '' || sanitizedPath === '/') {
-      return sanitizedPrefix + '/prerender-home.html';
-    }
-
-    // If path doesn't have a file extension, treat as SPA route
-    if (!isFilePath(sanitizedPath)) {
-      return sanitizedPrefix + '/index.html';
-    }
-
-    // File path - preserve as-is
-    return sanitizedPrefix + '/' + sanitizedPath;
-  }
-
-  // If the URI matches the PR pattern, rewrite it
-  if (match) {
-    var prPrefix = match[1]; // e.g., "pr-123"
-    var restOfPath = match[2]; // e.g., "/dashboard" or "/static/js/main.js"
-    request.uri = '/' + rewritePath(prPrefix, restOfPath);
+  if (!match) {
     return request;
   }
 
-  // If URI doesn't match PR pattern, pass through unchanged
-  // (For root domain requests to deploy.beakerstack.com, this might be an error page)
+  var prPrefix = match[1];
+  var restOfPath = match[2];
+
+  // No sub-path or root slash -> pre-rendered home page (mirrors Default Root Object for prod/staging)
+  if (!restOfPath || restOfPath === '/') {
+    request.uri = '/' + prPrefix + '/prerender-home.html';
+    return request;
+  }
+
+  // Strip slashes for extension check
+  var trimmedPath = restOfPath.replace(/^\//, '').replace(/\/$/, '');
+
+  // File path (has extension) -> serve directly
+  if (/\.[a-z0-9]+$/i.test(trimmedPath)) {
+    request.uri = '/' + prPrefix + restOfPath;
+    return request;
+  }
+
+  // No extension -> SPA route, serve index.html
+  request.uri = '/' + prPrefix + '/index.html';
   return request;
 }

--- a/infra/aws/pr-preview-stack.yml
+++ b/infra/aws/pr-preview-stack.yml
@@ -339,22 +339,23 @@ Resources:
           var request = event.request;
           var uri = request.uri || '/';
           var previewPrefixBase = '${PreviewPrefix}';
-          // Match /pr-<N>/ pattern at the start of the path
           var prPathPattern = new RegExp('^/(' + previewPrefixBase + '\\d+)(/.*)?$');
           var match = uri.match(prPathPattern);
-          if (match) {
-            var prPrefix = match[1];
-            var restOfPath = match[2] || '/';
-            var trimmed = restOfPath.replace(/\/$/, '');
-            var hasExtension = /\.[a-z0-9]+$/i.test(trimmed);
-            if (!hasExtension && trimmed !== '' && trimmed !== '/') {
-              request.uri = '/' + prPrefix + '/index.html';
-            } else if (trimmed === '' || trimmed === '/') {
-              request.uri = '/' + prPrefix + '/index.html';
-            } else {
-              request.uri = '/' + prPrefix + restOfPath;
-            }
+          if (!match) {
+            return request;
           }
+          var prPrefix = match[1];
+          var restOfPath = match[2];
+          if (!restOfPath || restOfPath === '/') {
+            request.uri = '/' + prPrefix + '/prerender-home.html';
+            return request;
+          }
+          var trimmedPath = restOfPath.replace(/^\//, '').replace(/\/$/, '');
+          if (/\.[a-z0-9]+$/i.test(trimmedPath)) {
+            request.uri = '/' + prPrefix + restOfPath;
+            return request;
+          }
+          request.uri = '/' + prPrefix + '/index.html';
           return request;
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,6 +139,7 @@
         "tailwindcss": "^3.3.0",
         "typescript": "^5.3.0",
         "vite": "^6.4.2",
+        "vite-node": "^3.2.4",
         "vitest": "^3.2.4"
       }
     },

--- a/scripts/pr-preview/bootstrap-aws-stack.sh
+++ b/scripts/pr-preview/bootstrap-aws-stack.sh
@@ -215,10 +215,7 @@ if not kv or int(kv.get("Quantity") or 0) == 0:
 else:
     fc["KeyValueStoreAssociations"] = kv
 
-with open(rendered_path, encoding="utf-8") as fp:
-    code = fp.read()
-
-body = {"Name": name, "IfMatch": etag, "FunctionConfig": fc, "FunctionCode": code}
+body = {"Name": name, "IfMatch": etag, "FunctionConfig": fc, "FunctionCode": "fileb://" + os.path.abspath(rendered_path)}
 json.dump(body, sys.stdout)
 ' <<<"${desc}" >"${update_json}" 2>"${err}"; then
     log "WARN" "Could not build update-function payload for ${function_id}: $(tr '\n' ' ' <"${err}")"

--- a/scripts/pr-preview/bootstrap-aws-stack.sh
+++ b/scripts/pr-preview/bootstrap-aws-stack.sh
@@ -178,74 +178,78 @@ publish_pr_path_router_function() {
   local function_id="${function_arn##*/}"
   function_id="${function_id%%/*}"
 
-  local desc err update_json
+  local err
   err="$(mktemp)"
-  update_json="$(mktemp)"
-  # Prefer DEVELOPMENT stage (where update-function applies).
-  if ! desc="$("${AWS_CLI[@]}" cloudfront describe-function \
+
+  # Pre-publish validation: rendered file must be UTF-8 JS starting with `function`.
+  # Catches an unrendered `%%PREVIEW_PREFIX%%` template or a truncated/binary file before
+  # we touch the live edge code.
+  if ! RENDERED_PATH="${rendered_path}" python3 -c '
+import os, sys
+
+src_path = os.environ["RENDERED_PATH"]
+with open(src_path, "rb") as fp:
+    raw = fp.read()
+try:
+    text = raw.decode("utf-8")
+except UnicodeDecodeError as exc:
+    print(f"rendered function is not valid UTF-8: {exc}", file=sys.stderr)
+    sys.exit(1)
+if "%%PREVIEW_PREFIX%%" in text:
+    print("rendered function still contains %%PREVIEW_PREFIX%% placeholder", file=sys.stderr)
+    sys.exit(1)
+if not text.lstrip().startswith("function"):
+    print("rendered function does not start with a `function` declaration", file=sys.stderr)
+    sys.exit(1)
+' 2>"${err}"; then
+    log "ERROR" "Refusing to publish corrupt CloudFront function source: $(tr '\n' ' ' <"${err}")"
+    rm -f "${err}"
+    exit 1
+  fi
+
+  # Get current DEVELOPMENT ETag so update-function can use If-Match.
+  # Prefer DEVELOPMENT stage (where update-function applies); fall back to default.
+  local etag
+  etag="$("${AWS_CLI[@]}" cloudfront describe-function \
     --name "${function_id}" \
     --stage DEVELOPMENT \
-    --output json 2>"${err}")"; then
-    if ! desc="$("${AWS_CLI[@]}" cloudfront describe-function \
+    --query 'ETag' \
+    --output text 2>"${err}")" || etag=""
+  if [[ -z "${etag}" || "${etag}" == "None" ]]; then
+    etag="$("${AWS_CLI[@]}" cloudfront describe-function \
       --name "${function_id}" \
-      --output json 2>"${err}")"; then
-      log "WARN" "describe-function failed for ${function_id}; skipping publish. $(head -c 400 "${err}" 2>/dev/null | tr '\n' ' ')"
-      rm -f "${err}" "${update_json}"
-      return 0
-    fi
+      --query 'ETag' \
+      --output text 2>"${err}")" || etag=""
+  fi
+  if [[ -z "${etag}" || "${etag}" == "None" ]]; then
+    log "ERROR" "describe-function returned no ETag for ${function_id}: $(head -c 400 "${err}" 2>/dev/null | tr '\n' ' ')"
+    rm -f "${err}"
+    exit 1
   fi
 
-  if ! RENDERED_PATH="${rendered_path}" FUNCTION_ID="${function_id}" python3 -c '
-import json, os, sys
+  # IMPORTANT: this call deliberately avoids --cli-input-json. In AWS CLI v2, blob fields
+  # read from --cli-input-json are base64-decoded (cli_binary_format=base64), so the JS
+  # source gets corrupted into binary garbage on the live function. The supported path
+  # for raw binary blobs is `--function-code fileb://path` as a direct CLI argument,
+  # which streams the file bytes unchanged.
+  local function_config_json
+  function_config_json="$(python3 -c '
+import json
+print(json.dumps({
+    "Comment": "PR path router",
+    "Runtime": "cloudfront-js-2.0",
+    "KeyValueStoreAssociations": {"Quantity": 0},
+}))
+')"
 
-rendered_path = os.environ["RENDERED_PATH"]
-function_id = os.environ["FUNCTION_ID"]
-desc = json.loads(sys.stdin.read())
-
-etag = (desc.get("ETag") or "").strip()
-if not etag:
-    print("missing ETag from describe-function", file=sys.stderr)
-    sys.exit(1)
-fs = desc.get("FunctionSummary") or {}
-name = (fs.get("Name") or function_id).strip()
-fc = dict(fs.get("FunctionConfig") or {})
-if not fc.get("Runtime"):
-    fc["Runtime"] = "cloudfront-js-2.0"
-if "Comment" not in fc or fc.get("Comment") is None:
-    fc["Comment"] = "PR path router"
-kv = fc.get("KeyValueStoreAssociations")
-if not kv or int(kv.get("Quantity") or 0) == 0:
-    fc["KeyValueStoreAssociations"] = {"Quantity": 0}
-else:
-    fc["KeyValueStoreAssociations"] = kv
-
-# IMPORTANT: when delivering FunctionCode via --cli-input-json, pass the JS source as a
-# plain UTF-8 string. Do NOT use a fileb:// prefix here — that prefix is only honored on
-# CLI argument values; inside --cli-input-json the CLI base64-decodes blob fields, so a
-# fileb:// literal becomes random binary in the live function ("gibberish").
-with open(rendered_path, "r", encoding="utf-8") as fp:
-    code = fp.read()
-stripped = code.lstrip()
-if not stripped.startswith("function"):
-    print(
-        "invalid rendered CloudFront function (expected UTF-8 JS starting with function)",
-        file=sys.stderr,
-    )
-    sys.exit(1)
-
-body = {"Name": name, "IfMatch": etag, "FunctionConfig": fc, "FunctionCode": code}
-json.dump(body, sys.stdout)
-
-' <<<"${desc}" >"${update_json}" 2>"${err}"; then
-    log "WARN" "Could not build update-function payload for ${function_id}: $(tr '\n' ' ' <"${err}")"
-    rm -f "${err}" "${update_json}"
-    return 0
-  fi
-
-  if ! "${AWS_CLI[@]}" cloudfront update-function --cli-input-json "file://${update_json}" >/dev/null 2>"${err}"; then
-    log "WARN" "cloudfront update-function failed for ${function_id}: $(head -c 500 "${err}" 2>/dev/null | tr '\n' ' ')"
-    rm -f "${err}" "${update_json}"
-    return 0
+  if ! "${AWS_CLI[@]}" cloudfront update-function \
+    --name "${function_id}" \
+    --if-match "${etag}" \
+    --function-config "${function_config_json}" \
+    --function-code "fileb://${rendered_path}" >/dev/null 2>"${err}"; then
+    log "ERROR" "cloudfront update-function failed for ${function_id}: $(head -c 500 "${err}" 2>/dev/null | tr '\n' ' ')"
+    rm -f "${err}"
+    exit 1
   fi
 
   local etag_pub
@@ -263,21 +267,73 @@ json.dump(body, sys.stdout)
   fi
 
   if [[ -z "${etag_pub}" || "${etag_pub}" == "None" ]]; then
-    log "WARN" "Could not read ETag after update for ${function_id}; skipping publish-function."
-    rm -f "${err}" "${update_json}"
-    return 0
+    log "ERROR" "Could not read ETag after update for ${function_id}; aborting before publish."
+    rm -f "${err}"
+    exit 1
   fi
 
   if ! "${AWS_CLI[@]}" cloudfront publish-function \
     --name "${function_id}" \
     --if-match "${etag_pub}" >/dev/null 2>"${err}"; then
-    log "WARN" "cloudfront publish-function failed for ${function_id}: $(head -c 500 "${err}" 2>/dev/null | tr '\n' ' ')"
-    rm -f "${err}" "${update_json}"
-    return 0
+    log "ERROR" "cloudfront publish-function failed for ${function_id}: $(head -c 500 "${err}" 2>/dev/null | tr '\n' ' ')"
+    rm -f "${err}"
+    exit 1
   fi
 
-  rm -f "${err}" "${update_json}"
-  log "INFO" "Successfully published CloudFront function: ${function_id}"
+  # Post-publish verification: download what is now LIVE and refuse to call this a success
+  # unless the bytes parse as our rendered JS. Catches CLI encoding regressions (e.g. the
+  # fileb://-inside-cli-input-json bug that base64-decoded the path into binary garbage)
+  # before the broken function reaches users.
+  local live_dump live_err verify_failed
+  live_dump="$(mktemp)"
+  live_err="$(mktemp)"
+  verify_failed=0
+  if ! "${AWS_CLI[@]}" cloudfront get-function \
+    --name "${function_id}" \
+    --stage LIVE \
+    "${live_dump}" >/dev/null 2>"${live_err}"; then
+    log "ERROR" "Could not verify published CloudFront function ${function_id}: $(head -c 500 "${live_err}" 2>/dev/null | tr '\n' ' ')"
+    verify_failed=1
+  else
+    if ! LIVE_DUMP="${live_dump}" RENDERED_PATH="${rendered_path}" python3 -c '
+import os, sys
+
+live_path = os.environ["LIVE_DUMP"]
+src_path = os.environ["RENDERED_PATH"]
+
+with open(live_path, "rb") as fp:
+    live_bytes = fp.read()
+try:
+    live_text = live_bytes.decode("utf-8")
+except UnicodeDecodeError as exc:
+    print(f"LIVE function code is not valid UTF-8 ({exc}); first bytes: {live_bytes[:32]!r}", file=sys.stderr)
+    sys.exit(2)
+
+if not live_text.lstrip().startswith("function"):
+    head = live_text[:200].replace("\n", "\\n")
+    print(f"LIVE function code does not start with a function declaration; head={head!r}", file=sys.stderr)
+    sys.exit(3)
+
+with open(src_path, "r", encoding="utf-8") as fp:
+    expected = fp.read()
+if live_text.strip() != expected.strip():
+    print("LIVE function code does not match the rendered source we just published.", file=sys.stderr)
+    print(f"live_len={len(live_text)} expected_len={len(expected)}", file=sys.stderr)
+    sys.exit(4)
+' 2>"${live_err}"; then
+      log "ERROR" "Published CloudFront function ${function_id} failed verification: $(head -c 500 "${live_err}" 2>/dev/null | tr '\n' ' ')"
+      verify_failed=1
+    fi
+  fi
+
+  rm -f "${err}" "${live_dump}" "${live_err}"
+
+  if [[ "${verify_failed}" -eq 1 ]]; then
+    log "ERROR" "CloudFront function ${function_id} appears corrupted on LIVE. Aborting to surface the regression instead of leaving bad edge code."
+    exit 1
+  fi
+
+  log "INFO" "Successfully published and verified CloudFront function: ${function_id}"
 }
 
 write_exports() {

--- a/scripts/pr-preview/bootstrap-aws-stack.sh
+++ b/scripts/pr-preview/bootstrap-aws-stack.sh
@@ -219,9 +219,10 @@ if not kv or int(kv.get("Quantity") or 0) == 0:
 else:
     fc["KeyValueStoreAssociations"] = kv
 
-# Validate source before publish. Do NOT put raw JS in JSON as FunctionCode: AWS CLI
-# blob parameters must use fileb:// (see AWS CLI User Guide "Binary / blob"). Inline
-# strings are interpreted as base64 and corrupt the live function (binary gibberish).
+# IMPORTANT: when delivering FunctionCode via --cli-input-json, pass the JS source as a
+# plain UTF-8 string. Do NOT use a fileb:// prefix here — that prefix is only honored on
+# CLI argument values; inside --cli-input-json the CLI base64-decodes blob fields, so a
+# fileb:// literal becomes random binary in the live function ("gibberish").
 with open(rendered_path, "r", encoding="utf-8") as fp:
     code = fp.read()
 stripped = code.lstrip()
@@ -232,14 +233,13 @@ if not stripped.startswith("function"):
     )
     sys.exit(1)
 
-abs_src = os.path.abspath(rendered_path)
 body = {
     "Name": name,
     "IfMatch": etag,
     "FunctionConfig": fc,
-    "FunctionCode": "fileb://" + abs_src,
+    "FunctionCode": code,
 }
-json.dump(body, sys.stdout, ensure_ascii=True)
+json.dump(body, sys.stdout, ensure_ascii=False)
 ' <<<"${desc}" >"${update_json}" 2>"${err}"; then
     log "WARN" "Could not build update-function payload for ${function_id}: $(tr '\n' ' ' <"${err}")"
     rm -f "${err}" "${update_json}"

--- a/scripts/pr-preview/bootstrap-aws-stack.sh
+++ b/scripts/pr-preview/bootstrap-aws-stack.sh
@@ -33,6 +33,9 @@ IF_STACK_EXISTS="deploy"
 ALLOW_CONFLICTING_NAMED_BUCKETS=false
 PRINT_PREFLIGHT_JSON=false
 DELETE_FAILED_CHANGE_SETS=false
+# When 1/true, finalize_stack_outputs skips publish_pr_path_router_function (CI uses this
+# so a failed web build cannot publish edge code before assets exist).
+SKIP_CLOUDFRONT_FUNCTION_PUBLISH=""
 
 # Populated by preflight_collect_data()
 PREFLIGHT_BUCKETS_PROD=""
@@ -69,6 +72,7 @@ Optional:
                                  but the stack is missing (orphaned retained buckets; deploy will likely fail)
   --print-preflight-json         Print one JSON object to stdout (no other stdout); then exit 0. For setup tooling.
   --delete-failed-change-sets    Delete FAILED CloudFormation change sets for --stack-name; then exit 0.
+  --skip-cloudfront-function-publish   Skip CloudFront PRPathRouter publish in finalize (stack outputs + error pages still run).
   --help                         Show this help message
 
 Environment exports:
@@ -215,8 +219,18 @@ if not kv or int(kv.get("Quantity") or 0) == 0:
 else:
     fc["KeyValueStoreAssociations"] = kv
 
-body = {"Name": name, "IfMatch": etag, "FunctionConfig": fc, "FunctionCode": "fileb://" + os.path.abspath(rendered_path)}
-json.dump(body, sys.stdout)
+with open(rendered_path, "r", encoding="utf-8") as fp:
+    code = fp.read()
+stripped = code.lstrip()
+if not stripped.startswith("function"):
+    print(
+        "invalid rendered CloudFront function (expected UTF-8 JS starting with function)",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+body = {"Name": name, "IfMatch": etag, "FunctionConfig": fc, "FunctionCode": code}
+json.dump(body, sys.stdout, ensure_ascii=True)
 ' <<<"${desc}" >"${update_json}" 2>"${err}"; then
     log "WARN" "Could not build update-function payload for ${function_id}: $(tr '\n' ' ' <"${err}")"
     rm -f "${err}" "${update_json}"
@@ -874,7 +888,12 @@ finalize_stack_outputs() {
     fi
   done
 
-  publish_pr_path_router_function
+  local skip_cf="${SKIP_CLOUDFRONT_FUNCTION_PUBLISH:-}"
+  if [[ "${skip_cf}" == "1" || "${skip_cf}" == "true" || "${skip_cf}" == "TRUE" ]]; then
+    log "INFO" "Skipping CloudFront function publish (--skip-cloudfront-function-publish or SKIP_CLOUDFRONT_FUNCTION_PUBLISH)."
+  else
+    publish_pr_path_router_function
+  fi
 
   write_exports "PR_PREVIEW_WEBSITE_BUCKET" "${deploy_bucket}"
   write_exports "PR_PREVIEW_LOGS_BUCKET" "${logs_bucket}"
@@ -959,6 +978,10 @@ parse_args() {
         ;;
       --delete-failed-change-sets)
         DELETE_FAILED_CHANGE_SETS=true
+        shift
+        ;;
+      --skip-cloudfront-function-publish)
+        SKIP_CLOUDFRONT_FUNCTION_PUBLISH=1
         shift
         ;;
       --help|-h)

--- a/scripts/pr-preview/bootstrap-aws-stack.sh
+++ b/scripts/pr-preview/bootstrap-aws-stack.sh
@@ -219,6 +219,9 @@ if not kv or int(kv.get("Quantity") or 0) == 0:
 else:
     fc["KeyValueStoreAssociations"] = kv
 
+# Validate source before publish. Do NOT put raw JS in JSON as FunctionCode: AWS CLI
+# blob parameters must use fileb:// (see AWS CLI User Guide "Binary / blob"). Inline
+# strings are interpreted as base64 and corrupt the live function (binary gibberish).
 with open(rendered_path, "r", encoding="utf-8") as fp:
     code = fp.read()
 stripped = code.lstrip()
@@ -229,7 +232,13 @@ if not stripped.startswith("function"):
     )
     sys.exit(1)
 
-body = {"Name": name, "IfMatch": etag, "FunctionConfig": fc, "FunctionCode": code}
+abs_src = os.path.abspath(rendered_path)
+body = {
+    "Name": name,
+    "IfMatch": etag,
+    "FunctionConfig": fc,
+    "FunctionCode": "fileb://" + abs_src,
+}
 json.dump(body, sys.stdout, ensure_ascii=True)
 ' <<<"${desc}" >"${update_json}" 2>"${err}"; then
     log "WARN" "Could not build update-function payload for ${function_id}: $(tr '\n' ' ' <"${err}")"

--- a/scripts/pr-preview/bootstrap-aws-stack.sh
+++ b/scripts/pr-preview/bootstrap-aws-stack.sh
@@ -233,13 +233,9 @@ if not stripped.startswith("function"):
     )
     sys.exit(1)
 
-body = {
-    "Name": name,
-    "IfMatch": etag,
-    "FunctionConfig": fc,
-    "FunctionCode": code,
-}
-json.dump(body, sys.stdout, ensure_ascii=False)
+body = {"Name": name, "IfMatch": etag, "FunctionConfig": fc, "FunctionCode": code}
+json.dump(body, sys.stdout)
+
 ' <<<"${desc}" >"${update_json}" 2>"${err}"; then
     log "WARN" "Could not build update-function payload for ${function_id}: $(tr '\n' ' ' <"${err}")"
     rm -f "${err}" "${update_json}"

--- a/scripts/pr-preview/check-preview-deploy-needed.sh
+++ b/scripts/pr-preview/check-preview-deploy-needed.sh
@@ -3,8 +3,9 @@
 #
 # Keep the path allowlist conceptually aligned with .github/workflows/test.yml
 # (pull_request paths) plus preview-only paths (scripts/pr-preview/**,
-# pr-preview workflow file). If a change cannot affect built previews or this
-# workflow's deploy scripts, we skip the heavy deploy job to save Expo/AWS/CI.
+# infra/aws/** for CloudFormation / CloudFront preview routing, pr-preview
+# workflow file). If a change cannot affect built previews or this workflow's
+# deploy scripts, we skip the heavy deploy job to save Expo/AWS/CI.
 
 set -euo pipefail
 
@@ -27,6 +28,7 @@ preview_path_matches() {
 
   case "$f" in
     apps/* | packages/* | supabase/*) return 0 ;;
+    infra/aws/*) return 0 ;;
     package.json | package-lock.json) return 0 ;;
     .github/workflows/pr-preview-environment.yml) return 0 ;;
     scripts/pr-preview/*) return 0 ;;
@@ -94,6 +96,8 @@ self_test() {
   check_one package.json 1
   check_one package-lock.json 1
   check_one scripts/pr-preview/deploy-web.sh 1
+  check_one infra/aws/functions/PRPathRouter.js 1
+  check_one infra/aws/pr-preview-stack.yml 1
   check_one .github/workflows/pr-preview-environment.yml 1
   check_one tsconfig.json 1
   check_one apps/web/vite.config.ts 1

--- a/scripts/pr-preview/deploy-web.sh
+++ b/scripts/pr-preview/deploy-web.sh
@@ -254,7 +254,7 @@ build_web_app() {
   fi
   
   # Check for critical files that should always be present
-  local required_files=("index.html" "assets")
+  local required_files=("index.html" "prerender-home.html" "assets")
   local missing_required=()
   for file in "${required_files[@]}"; do
     if [[ ! -e "${BUILD_DIR}/${file}" ]]; then
@@ -303,7 +303,7 @@ sync_to_s3() {
       ;;
   esac
 
-  log "INFO" "Syncing assets (excluding index.html) to ${s3_uri} with long cache TTL..."
+  log "INFO" "Syncing assets (excluding HTML entry points) to ${s3_uri} with long cache TTL..."
   log "INFO" "Build directory contents:"
   if [[ -d "${BUILD_DIR}" ]]; then
     find "${BUILD_DIR}" -maxdepth 1 -type f -printf '%f\n' 2>/dev/null | while read -r file; do
@@ -316,36 +316,45 @@ sync_to_s3() {
     exit 1
   fi
   
+  # Exclude both HTML entry points from long-TTL sync; they are uploaded
+  # separately below with a short TTL so deploys take effect promptly.
   run_cmd aws s3 sync "${BUILD_DIR}/" "${s3_uri}/" \
     --delete \
     --exclude "index.html" \
+    --exclude "prerender-home.html" \
     --cache-control "public,max-age=31536000,immutable" \
     --region "${AWS_REGION}" \
     --exact-timestamps
 
-  log "INFO" "Ensuring SPA fallback (index.html) is cached with short TTL..."
+  log "INFO" "Uploading index.html (SPA fallback) with short TTL..."
   run_cmd aws s3 cp "${BUILD_DIR}/index.html" "${s3_uri}/index.html" \
+    --cache-control "public,max-age=60" \
+    --content-type "text/html; charset=utf-8" \
+    --region "${AWS_REGION}"
+
+  log "INFO" "Uploading prerender-home.html (home page pre-render) with short TTL..."
+  run_cmd aws s3 cp "${BUILD_DIR}/prerender-home.html" "${s3_uri}/prerender-home.html" \
     --cache-control "public,max-age=60" \
     --content-type "text/html; charset=utf-8" \
     --region "${AWS_REGION}"
   
   log "INFO" "Verifying all static assets are deployed..."
   
-  # Dynamically discover all static files in build output (excluding index.html and assets directory)
+  # Dynamically discover all static files in build output (excluding HTML entry points and assets directory)
   local missing_files=()
   local verified_count=0
   local files_to_verify=()
   
   if [[ "${DRY_RUN}" != true ]]; then
-    # First, collect all files to verify (excluding index.html and assets directory)
+    # First, collect all files to verify (excluding HTML entry points and assets directory)
     # Use a more robust approach that handles edge cases
     if [[ -d "${BUILD_DIR}" ]]; then
       while IFS= read -r -d '' file; do
         # Get relative path from BUILD_DIR
         local rel_path="${file#${BUILD_DIR}/}"
         
-        # Skip index.html (handled separately) and anything in assets/ directory
-        if [[ "${rel_path}" == "index.html" ]] || [[ "${rel_path}" == assets/* ]]; then
+        # Skip HTML entry points (handled separately) and anything in assets/ directory
+        if [[ "${rel_path}" == "index.html" ]] || [[ "${rel_path}" == "prerender-home.html" ]] || [[ "${rel_path}" == assets/* ]]; then
           continue
         fi
         
@@ -375,7 +384,7 @@ sync_to_s3() {
         fi
       done
     else
-      log "WARN" "No files found to verify (excluding index.html and assets)"
+      log "WARN" "No files found to verify (excluding HTML entry points and assets)"
     fi
     
     if [[ ${#missing_files[@]} -gt 0 ]]; then
@@ -388,6 +397,65 @@ sync_to_s3() {
   fi
 
   write_output "PREVIEW_S3_PREFIX" "${prefix:-/}"
+}
+
+# Ensures the CloudFront distribution's default root object is set to
+# prerender-home.html so that bare / requests receive pre-rendered HTML.
+# Only applies to prod and staging; preview environments use path prefixes.
+configure_cloudfront_root_object() {
+  if [[ "${ENVIRONMENT}" != "prod" && "${ENVIRONMENT}" != "staging" ]]; then
+    return 0
+  fi
+
+  local expected_root="prerender-home.html"
+  log "INFO" "Ensuring CloudFront default root object is '${expected_root}'..."
+
+  if [[ "${DRY_RUN}" == true ]]; then
+    log "DRY" "aws cloudfront update-distribution --id ${CLOUDFRONT_DISTRIBUTION_ID} (set DefaultRootObject=${expected_root})"
+    return 0
+  fi
+
+  local config_json current_root etag
+  config_json="$(aws cloudfront get-distribution-config \
+    --id "${CLOUDFRONT_DISTRIBUTION_ID}" \
+    --output json)"
+
+  current_root="$(echo "${config_json}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data['DistributionConfig'].get('DefaultRootObject', ''))
+")"
+
+  if [[ "${current_root}" == "${expected_root}" ]]; then
+    log "INFO" "CloudFront default root object is already '${expected_root}'."
+    return 0
+  fi
+
+  log "INFO" "Updating CloudFront default root object from '${current_root}' to '${expected_root}'..."
+
+  etag="$(echo "${config_json}" | python3 -c "
+import sys, json
+print(json.load(sys.stdin)['ETag'])
+")"
+
+  local updated_config
+  updated_config="$(echo "${config_json}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+data['DistributionConfig']['DefaultRootObject'] = '${expected_root}'
+print(json.dumps(data['DistributionConfig']))
+")"
+
+  echo "${updated_config}" > /tmp/cloudfront-dist-config.json
+
+  run_cmd aws cloudfront update-distribution \
+    --id "${CLOUDFRONT_DISTRIBUTION_ID}" \
+    --distribution-config "file:///tmp/cloudfront-dist-config.json" \
+    --if-match "${etag}" \
+    --output text > /dev/null
+
+  rm -f /tmp/cloudfront-dist-config.json
+  log "INFO" "CloudFront default root object updated to '${expected_root}'."
 }
 
 create_invalidation() {
@@ -483,6 +551,7 @@ main() {
 
   build_web_app
   sync_to_s3
+  configure_cloudfront_root_object
   create_invalidation
   verify_preview_url
 
@@ -490,4 +559,3 @@ main() {
 }
 
 main "$@"
-

--- a/scripts/pr-preview/deploy-web.sh
+++ b/scripts/pr-preview/deploy-web.sh
@@ -111,6 +111,10 @@ ensure_prereqs() {
     log "ERROR" "curl is required to verify preview URL."
     exit 1
   }
+  command -v python3 >/dev/null 2>&1 || {
+    log "ERROR" "python3 is required for CloudFront config parsing."
+    exit 1
+  }
 }
 
 parse_args() {
@@ -446,15 +450,17 @@ data['DistributionConfig']['DefaultRootObject'] = '${expected_root}'
 print(json.dumps(data['DistributionConfig']))
 ")"
 
-  echo "${updated_config}" > /tmp/cloudfront-dist-config.json
+  local tmp_config
+  tmp_config="$(mktemp)"
+  echo "${updated_config}" > "${tmp_config}"
 
   run_cmd aws cloudfront update-distribution \
     --id "${CLOUDFRONT_DISTRIBUTION_ID}" \
-    --distribution-config "file:///tmp/cloudfront-dist-config.json" \
+    --distribution-config "file://${tmp_config}" \
     --if-match "${etag}" \
     --output text > /dev/null
 
-  rm -f /tmp/cloudfront-dist-config.json
+  rm -f "${tmp_config}"
   log "INFO" "CloudFront default root object updated to '${expected_root}'."
 }
 

--- a/scripts/pr-preview/deploy-web.sh
+++ b/scripts/pr-preview/deploy-web.sh
@@ -58,6 +58,7 @@ Outputs:
 
 Environment variables for build:
   VITE_BASE_PATH                 Base path for React Router (set automatically based on --environment)
+  VITE_PUBLIC_SITE_ORIGIN        Public site origin for pre-render canonical/og:url (set automatically)
   VITE_SUPABASE_URL              Supabase API URL (should be set externally)
   VITE_SUPABASE_ANON_KEY         Supabase anon key (should be set externally)
 EOF
@@ -247,7 +248,21 @@ build_web_app() {
 
   # Set VITE_BASE_PATH for the build
   export VITE_BASE_PATH="${base_path}"
-  
+
+  # Pre-render canonical / og:url (scripts/prerender-home.ts)
+  case "${ENVIRONMENT}" in
+    preview)
+      export VITE_PUBLIC_SITE_ORIGIN="https://deploy.${DOMAIN_NAME}"
+      ;;
+    staging)
+      export VITE_PUBLIC_SITE_ORIGIN="https://staging.${DOMAIN_NAME}"
+      ;;
+    prod)
+      export VITE_PUBLIC_SITE_ORIGIN="https://${DOMAIN_NAME}"
+      ;;
+  esac
+  log "INFO" "Using VITE_PUBLIC_SITE_ORIGIN=${VITE_PUBLIC_SITE_ORIGIN}"
+
   run_cmd npm run --workspace web build
   
   # Verify build output contains expected files
@@ -451,7 +466,8 @@ print(json.dumps(data['DistributionConfig']))
 ")"
 
   local tmp_config
-  tmp_config="$(mktemp)"
+  tmp_config="$(mktemp "${TMPDIR:-/tmp}/cloudfront-dist-config.XXXXXX.json")"
+  trap 'rm -f "${tmp_config}"' EXIT
   echo "${updated_config}" > "${tmp_config}"
 
   run_cmd aws cloudfront update-distribution \
@@ -460,6 +476,7 @@ print(json.dumps(data['DistributionConfig']))
     --if-match "${etag}" \
     --output text > /dev/null
 
+  trap - EXIT
   rm -f "${tmp_config}"
   log "INFO" "CloudFront default root object updated to '${expected_root}'."
 }


### PR DESCRIPTION
Closes #71

## What

Pre-renders `LandingPage` at build time so search engines and social crawlers see real markup and OG tags on the first byte, without switching to SSR at runtime.

## How

**Pre-render script (`scripts/prerender-home.ts`)**
- Runs after `vite build` via `vite-node` (already a vitest transitive dep — zero new runtime cost)
- Uses `renderToStaticMarkup` (no React data attributes, no hydration attempt, no structural mismatch possible)
- Structural smoke check: exits 1 if output contains no `<h1` — catches broken renders without fragility to copy changes
- Injects `<link rel="canonical">` and `og:url` only into `prerender-home.html`; `index.html` stays canonical-free

**`index.html`**
- Added site-wide OG/meta defaults (`og:title`, `og:description`, `og:image`, `og:type`, `twitter:*`)
- `canonical` and `og:url` intentionally excluded — home-only, injected by pre-render script

**`supabase.ts`**
- `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` now use `??` fallbacks instead of throwing
- DEV-only warning when placeholder is active

**`apps/web/package.json`**
- Build: `tsc && vite build && vite-node scripts/prerender-home.ts`
- `vite-node ^3.2.4` added to devDependencies

**`deploy-web.sh`**
- `prerender-home.html` uploaded with short TTL (`public,max-age=60`)
- `configure_cloudfront_root_object()`: sets CloudFront Default Root Object to `prerender-home.html` on prod/staging (idempotent)
- `prerender-home.html` added to required_files validation

## Why separate `prerender-home.html`

Keeps CloudFront serving the pre-rendered shell only at `/`. All other SPA routes continue receiving blank `index.html` via the 403/404 error-response rule — no marketing content flashes on authenticated routes.

## Hydration

`renderToStaticMarkup` strips React server data attributes. Client always calls `createRoot` (not `hydrateRoot`) — no hydration mismatch possible by design.

## Follow-up

`apps/web/public/og-image.png` (1200x630) is referenced but not yet created. The meta tag is in place; image can be added in a follow-up without a code change.

## Test plan

- [ ] `pnpm build` in `apps/web` completes without smoke-check failure
- [ ] `dist/prerender-home.html` exists and contains `<h1` content
- [ ] `dist/prerender-home.html` contains `<link rel="canonical" href="https://beakerstack.com/" />`
- [ ] `dist/index.html` does NOT contain `canonical` or `og:url`
- [ ] PR preview deploy uploads `prerender-home.html` with short TTL