### PR TITLE
feat: web-only / mobile-optional template path

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -146,23 +146,39 @@ jobs:
             --environment prod \
             --region "${AWS_REGION_VALUE}"
 
+  deploy-mobile-production:
+    if: vars.MOBILE_ENABLED != 'false'
+    needs: [deploy-production]
+    runs-on: ubuntu-latest
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
+      EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.PRODUCTION_SUPABASE_URL }}
+      EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PRODUCTION_SUPABASE_ANON_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Deploy mobile to production
         id: mobile
         shell: bash
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-          EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
-          EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.PRODUCTION_SUPABASE_URL }}
-          EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PRODUCTION_SUPABASE_ANON_KEY }}
         run: |
           set -euo pipefail
           EXPO_ACCOUNT_VALUE="${{ vars.EXPO_ACCOUNT }}"
           if [[ -z "${EXPO_ACCOUNT_VALUE}" ]]; then
-            echo "Warning: EXPO_ACCOUNT not set, skipping mobile deployment"
-            exit 0
+            echo "::error::EXPO_ACCOUNT variable is not set. Set vars.MOBILE_ENABLED=false to disable mobile, or set EXPO_ACCOUNT to enable it."
+            exit 1
           fi
           ./scripts/pr-preview/deploy-mobile-production.sh \
             --expo-account "${EXPO_ACCOUNT_VALUE}" \
             --platform all \
             --message "Production deployment from ${GITHUB_SHA:0:7}"
-

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -175,8 +175,13 @@ jobs:
           set -euo pipefail
           EXPO_ACCOUNT_VALUE="${{ vars.EXPO_ACCOUNT }}"
           if [[ -z "${EXPO_ACCOUNT_VALUE}" ]]; then
-            echo "::error::EXPO_ACCOUNT variable is not set. Set vars.MOBILE_ENABLED=false to disable mobile, or set EXPO_ACCOUNT to enable it."
-            exit 1
+            if [[ "${{ vars.MOBILE_ENABLED }}" == "true" ]]; then
+              echo "::error::EXPO_ACCOUNT variable is not set but MOBILE_ENABLED=true. Set vars.MOBILE_ENABLED=false to disable mobile, or provide EXPO_ACCOUNT."
+              exit 1
+            else
+              echo "Warning: EXPO_ACCOUNT not set, skipping mobile deployment"
+              exit 0
+            fi
           fi
           ./scripts/pr-preview/deploy-mobile-production.sh \
             --expo-account "${EXPO_ACCOUNT_VALUE}" \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -175,8 +175,13 @@ jobs:
           set -euo pipefail
           EXPO_ACCOUNT_VALUE="${{ vars.EXPO_ACCOUNT }}"
           if [[ -z "${EXPO_ACCOUNT_VALUE}" ]]; then
-            echo "::error::EXPO_ACCOUNT variable is not set. Set vars.MOBILE_ENABLED=false to disable mobile, or set EXPO_ACCOUNT to enable it."
-            exit 1
+            if [[ "${{ vars.MOBILE_ENABLED }}" == "true" ]]; then
+              echo "::error::EXPO_ACCOUNT variable is not set but MOBILE_ENABLED=true. Set vars.MOBILE_ENABLED=false to disable mobile, or provide EXPO_ACCOUNT."
+              exit 1
+            else
+              echo "Warning: EXPO_ACCOUNT not set, skipping mobile deployment"
+              exit 0
+            fi
           fi
           ./scripts/pr-preview/deploy-mobile-staging.sh \
             --expo-account "${EXPO_ACCOUNT_VALUE}" \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -146,23 +146,39 @@ jobs:
             --environment staging \
             --region "${AWS_REGION_VALUE}"
 
+  deploy-mobile-staging:
+    if: vars.MOBILE_ENABLED != 'false'
+    needs: [deploy-staging]
+    runs-on: ubuntu-latest
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
+      EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+      EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Deploy mobile to staging
         id: mobile
         shell: bash
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-          EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
-          EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
-          EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
         run: |
           set -euo pipefail
           EXPO_ACCOUNT_VALUE="${{ vars.EXPO_ACCOUNT }}"
           if [[ -z "${EXPO_ACCOUNT_VALUE}" ]]; then
-            echo "Warning: EXPO_ACCOUNT not set, skipping mobile deployment"
-            exit 0
+            echo "::error::EXPO_ACCOUNT variable is not set. Set vars.MOBILE_ENABLED=false to disable mobile, or set EXPO_ACCOUNT to enable it."
+            exit 1
           fi
           ./scripts/pr-preview/deploy-mobile-staging.sh \
             --expo-account "${EXPO_ACCOUNT_VALUE}" \
             --platform all \
             --message "Staging deployment from ${GITHUB_SHA:0:7}"
-

--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -51,6 +51,8 @@ jobs:
     if: github.event.action != 'closed' && needs.preview-scope.outputs.run_deploy == 'true' && (github.base_ref != 'develop' || github.head_ref != 'main')
     needs: preview-scope
     runs-on: ubuntu-latest
+    outputs:
+      preview-web-url: ${{ steps.web.outputs.PREVIEW_WEB_URL }}
     env:
       PREVIEW_DOMAIN: ${{ vars.PR_PREVIEW_DOMAIN }}
       PREVIEW_HOSTED_ZONE_ID: ${{ vars.PR_PREVIEW_HOSTED_ZONE_ID }}
@@ -103,8 +105,7 @@ jobs:
             --domain "${PREVIEW_DOMAIN}" \
             --hosted-zone-id "${PREVIEW_HOSTED_ZONE_ID}" \
             --certificate-arn "${PREVIEW_CERTIFICATE_ARN}" \
-            --preview-prefix "${PREVIEW_PREFIX_VALUE}" \
-            --skip-cloudfront-function-publish
+            --preview-prefix "${PREVIEW_PREFIX_VALUE}"
 
       - name: Prepare Supabase preview database
         id: supabase
@@ -193,31 +194,34 @@ jobs:
             --preview-prefix "${PREVIEW_PREFIX_VALUE}" \
             --region "${AWS_REGION_VALUE}"
 
-      # Publish edge routing only after a successful web build so a failed deploy cannot
-      # replace live CloudFront function code while leaving stale or missing S3 assets.
-      - name: Publish PR path router (CloudFront)
-        if: steps.web.outcome == 'success'
-        shell: bash
-        run: |
-          set -euo pipefail
-          STACK_NAME="${PREVIEW_STACK_NAME:-beakerstack-pr-preview}"
-          AWS_REGION_VALUE="${PREVIEW_AWS_REGION:-us-east-1}"
-          PREVIEW_PREFIX_VALUE="${PREVIEW_PREFIX:-pr-}"
-          ./scripts/pr-preview/bootstrap-aws-stack.sh \
-            --stack-name "${STACK_NAME}" \
-            --region "${AWS_REGION_VALUE}" \
-            --domain "${PREVIEW_DOMAIN}" \
-            --hosted-zone-id "${PREVIEW_HOSTED_ZONE_ID}" \
-            --certificate-arn "${PREVIEW_CERTIFICATE_ARN}" \
-            --preview-prefix "${PREVIEW_PREFIX_VALUE}" \
-            --if-stack-exists refresh-outputs
+  deploy-preview-mobile:
+    if: github.event.action != 'closed' && needs.preview-scope.outputs.run_deploy == 'true' && (github.base_ref != 'develop' || github.head_ref != 'main') && vars.MOBILE_ENABLED != 'false'
+    needs: [preview-scope, deploy-preview]
+    runs-on: ubuntu-latest
+    outputs:
+      mobile-channel: ${{ steps.mobile.outputs.PREVIEW_MOBILE_CHANNEL }}
+      mobile-update-url: ${{ steps.mobile.outputs.PREVIEW_MOBILE_UPDATE_URL }}
+      mobile-ios-download-url: ${{ steps.mobile.outputs.PREVIEW_MOBILE_IOS_DOWNLOAD_URL }}
+      mobile-android-download-url: ${{ steps.mobile.outputs.PREVIEW_MOBILE_ANDROID_DOWNLOAD_URL }}
+      needs-native-build: ${{ steps.native-changes.outputs.needs_native_build }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Check for native code changes
         id: native-changes
         shell: bash
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
           set -euo pipefail
           BASE_REF="origin/${{ github.base_ref }}"
@@ -237,7 +241,6 @@ jobs:
           EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
           EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.PREVIEW_SUPABASE_URL }}
           EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PREVIEW_SUPABASE_ANON_KEY }}
-          # Google Services variables (needed for google-services.json generation)
           GOOGLE_SERVICES_PROJECT_NUMBER: ${{ secrets.GOOGLE_SERVICES_PROJECT_NUMBER }}
           GOOGLE_SERVICES_PROJECT_ID: ${{ secrets.GOOGLE_SERVICES_PROJECT_ID }}
           GOOGLE_SERVICES_STORAGE_BUCKET: ${{ secrets.GOOGLE_SERVICES_STORAGE_BUCKET }}
@@ -252,8 +255,8 @@ jobs:
           PR_NUMBER_VALUE="${PR_NUMBER}"
           EXPO_ACCOUNT_VALUE="${{ vars.EXPO_ACCOUNT }}"
           if [[ -z "${EXPO_ACCOUNT_VALUE}" ]]; then
-            echo "Warning: EXPO_ACCOUNT not set, skipping mobile deployment"
-            exit 0
+            echo "::error::EXPO_ACCOUNT variable is not set. Set vars.MOBILE_ENABLED=false to disable mobile, or set EXPO_ACCOUNT to enable it."
+            exit 1
           fi
           BUILD_NATIVE_FLAG=""
           if [[ "${{ steps.native-changes.outputs.needs_native_build }}" == "true" ]]; then
@@ -268,21 +271,28 @@ jobs:
             --platform all \
             ${BUILD_NATIVE_FLAG}
 
+  comment:
+    if: always() && needs.deploy-preview.result == 'success'
+    needs: [deploy-preview, deploy-preview-mobile]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
       - name: Post preview summary comment
-        if: always()
         uses: actions/github-script@v7
         env:
-          WEB_URL: ${{ steps.web.outputs.PREVIEW_WEB_URL }}
-          MOBILE_CHANNEL: ${{ steps.mobile.outputs.PREVIEW_MOBILE_CHANNEL }}
-          MOBILE_UPDATE_URL: ${{ steps.mobile.outputs.PREVIEW_MOBILE_UPDATE_URL }}
-          MOBILE_IOS_DOWNLOAD_URL: ${{ steps.mobile.outputs.PREVIEW_MOBILE_IOS_DOWNLOAD_URL }}
-          MOBILE_ANDROID_DOWNLOAD_URL: ${{ steps.mobile.outputs.PREVIEW_MOBILE_ANDROID_DOWNLOAD_URL }}
-          NEEDS_NATIVE_BUILD: ${{ steps.native-changes.outputs.needs_native_build }}
-          MOBILE_DEPLOY_OUTCOME: ${{ steps.mobile.outcome }}
+          WEB_URL: ${{ needs.deploy-preview.outputs.preview-web-url }}
+          MOBILE_JOB_RESULT: ${{ needs.deploy-preview-mobile.result }}
+          MOBILE_CHANNEL: ${{ needs.deploy-preview-mobile.outputs.mobile-channel }}
+          MOBILE_UPDATE_URL: ${{ needs.deploy-preview-mobile.outputs.mobile-update-url }}
+          MOBILE_IOS_DOWNLOAD_URL: ${{ needs.deploy-preview-mobile.outputs.mobile-ios-download-url }}
+          MOBILE_ANDROID_DOWNLOAD_URL: ${{ needs.deploy-preview-mobile.outputs.mobile-android-download-url }}
+          NEEDS_NATIVE_BUILD: ${{ needs.deploy-preview-mobile.outputs.needs-native-build }}
         with:
           script: |
             const marker = '<!-- pr-preview-links -->';
             const webUrl = process.env.WEB_URL;
+            const mobileJobResult = process.env.MOBILE_JOB_RESULT;
             const mobileChannel = process.env.MOBILE_CHANNEL;
             const mobileUpdateUrl = process.env.MOBILE_UPDATE_URL;
 
@@ -291,7 +301,12 @@ jobs:
             if (webUrl) {
               lines.push(`🌐 **Web preview:** ${webUrl}`);
             }
-            if (mobileUpdateUrl) {
+            if (mobileJobResult === 'skipped') {
+              // Mobile disabled via MOBILE_ENABLED=false — omit mobile section
+            } else if (mobileJobResult === 'failure') {
+              lines.push('');
+              lines.push('❌ **Mobile preview failed.** Check the **deploy-preview-mobile** job logs for details.');
+            } else if (mobileUpdateUrl) {
               const iosDownloadUrl = process.env.MOBILE_IOS_DOWNLOAD_URL;
               const androidDownloadUrl = process.env.MOBILE_ANDROID_DOWNLOAD_URL;
               const needsNativeBuild = process.env.NEEDS_NATIVE_BUILD === 'true';
@@ -325,21 +340,11 @@ jobs:
               } else if (needsNativeBuild) {
                 lines.push('### 📱 Mobile Preview Builds');
                 lines.push('');
-                const mobileOutcome = process.env.MOBILE_DEPLOY_OUTCOME || '';
-                if (mobileOutcome === 'failure') {
-                  lines.push('❌ **Native preview build failed in CI.**');
-                  lines.push('');
-                  lines.push('The OTA update may still be on the channel above. Open the **deploy-preview** workflow run for this PR and inspect the **Deploy mobile preview** step logs (EAS / Expo errors, `google-services.json`, etc.).');
-                  lines.push('');
-                  lines.push('Re-run the workflow after fixing the failure; the PR comment will update when the job succeeds.');
-                  lines.push('');
-                } else {
-                  lines.push('⚠️ **Native build in progress or not finished in this job...**');
-                  lines.push('');
-                  lines.push('Native code changes were detected. If the **deploy-preview** job is still running, EAS builds may take 10–15 minutes after the job completes.');
-                  lines.push('If the job already finished without download links, check the workflow logs and the [Expo builds dashboard](https://expo.dev/accounts/artificer-innovations-llc/projects/beaker-stack/builds).');
-                  lines.push('');
-                }
+                lines.push('⚠️ **Native build in progress or not finished...**');
+                lines.push('');
+                lines.push('Native code changes were detected. EAS builds may take 10–15 minutes after the **deploy-preview-mobile** job completes.');
+                lines.push('If the job already finished without download links, check the workflow logs and the [Expo builds dashboard](https://expo.dev/accounts/artificer-innovations-llc/projects/beaker-stack/builds).');
+                lines.push('');
               } else {
                 lines.push('### 📱 Mobile Preview (OTA Updates)');
                 lines.push('');

--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -303,6 +303,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
       - name: Post preview summary comment
         uses: actions/github-script@v7

--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -105,7 +105,8 @@ jobs:
             --domain "${PREVIEW_DOMAIN}" \
             --hosted-zone-id "${PREVIEW_HOSTED_ZONE_ID}" \
             --certificate-arn "${PREVIEW_CERTIFICATE_ARN}" \
-            --preview-prefix "${PREVIEW_PREFIX_VALUE}"
+            --preview-prefix "${PREVIEW_PREFIX_VALUE}" \
+            --skip-cloudfront-function-publish
 
       - name: Prepare Supabase preview database
         id: supabase
@@ -194,6 +195,23 @@ jobs:
             --preview-prefix "${PREVIEW_PREFIX_VALUE}" \
             --region "${AWS_REGION_VALUE}"
 
+      - name: Publish PR path router (CloudFront)
+        if: steps.web.outcome == 'success'
+        shell: bash
+        run: |
+          set -euo pipefail
+          STACK_NAME="${PREVIEW_STACK_NAME:-beakerstack-pr-preview}"
+          AWS_REGION_VALUE="${PREVIEW_AWS_REGION:-us-east-1}"
+          PREVIEW_PREFIX_VALUE="${PREVIEW_PREFIX:-pr-}"
+          ./scripts/pr-preview/bootstrap-aws-stack.sh \
+            --stack-name "${STACK_NAME}" \
+            --region "${AWS_REGION_VALUE}" \
+            --domain "${PREVIEW_DOMAIN}" \
+            --hosted-zone-id "${PREVIEW_HOSTED_ZONE_ID}" \
+            --certificate-arn "${PREVIEW_CERTIFICATE_ARN}" \
+            --preview-prefix "${PREVIEW_PREFIX_VALUE}" \
+            --if-stack-exists refresh-outputs
+
   deploy-preview-mobile:
     if: github.event.action != 'closed' && needs.preview-scope.outputs.run_deploy == 'true' && (github.base_ref != 'develop' || github.head_ref != 'main') && vars.MOBILE_ENABLED != 'false'
     needs: [preview-scope, deploy-preview]
@@ -204,6 +222,9 @@ jobs:
       mobile-ios-download-url: ${{ steps.mobile.outputs.PREVIEW_MOBILE_IOS_DOWNLOAD_URL }}
       mobile-android-download-url: ${{ steps.mobile.outputs.PREVIEW_MOBILE_ANDROID_DOWNLOAD_URL }}
       needs-native-build: ${{ steps.native-changes.outputs.needs_native_build }}
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -255,8 +276,13 @@ jobs:
           PR_NUMBER_VALUE="${PR_NUMBER}"
           EXPO_ACCOUNT_VALUE="${{ vars.EXPO_ACCOUNT }}"
           if [[ -z "${EXPO_ACCOUNT_VALUE}" ]]; then
-            echo "::error::EXPO_ACCOUNT variable is not set. Set vars.MOBILE_ENABLED=false to disable mobile, or set EXPO_ACCOUNT to enable it."
-            exit 1
+            if [[ "${{ vars.MOBILE_ENABLED }}" == "true" ]]; then
+              echo "::error::EXPO_ACCOUNT variable is not set but MOBILE_ENABLED=true. Set vars.MOBILE_ENABLED=false to disable mobile, or provide EXPO_ACCOUNT."
+              exit 1
+            else
+              echo "Warning: EXPO_ACCOUNT not set, skipping mobile deployment"
+              exit 0
+            fi
           fi
           BUILD_NATIVE_FLAG=""
           if [[ "${{ steps.native-changes.outputs.needs_native_build }}" == "true" ]]; then

--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -51,8 +51,6 @@ jobs:
     if: github.event.action != 'closed' && needs.preview-scope.outputs.run_deploy == 'true' && (github.base_ref != 'develop' || github.head_ref != 'main')
     needs: preview-scope
     runs-on: ubuntu-latest
-    outputs:
-      preview-web-url: ${{ steps.web.outputs.PREVIEW_WEB_URL }}
     env:
       PREVIEW_DOMAIN: ${{ vars.PR_PREVIEW_DOMAIN }}
       PREVIEW_HOSTED_ZONE_ID: ${{ vars.PR_PREVIEW_HOSTED_ZONE_ID }}
@@ -308,7 +306,8 @@ jobs:
       - name: Post preview summary comment
         uses: actions/github-script@v7
         env:
-          WEB_URL: ${{ needs.deploy-preview.outputs.preview-web-url }}
+          PREVIEW_DOMAIN: ${{ vars.PR_PREVIEW_DOMAIN }}
+          PREVIEW_PREFIX: ${{ vars.PR_PREVIEW_PREFIX }}
           MOBILE_JOB_RESULT: ${{ needs.deploy-preview-mobile.result }}
           MOBILE_CHANNEL: ${{ needs.deploy-preview-mobile.outputs.mobile-channel }}
           MOBILE_UPDATE_URL: ${{ needs.deploy-preview-mobile.outputs.mobile-update-url }}
@@ -318,7 +317,10 @@ jobs:
         with:
           script: |
             const marker = '<!-- pr-preview-links -->';
-            const webUrl = process.env.WEB_URL;
+            const domain = process.env.PREVIEW_DOMAIN;
+            const prefix = process.env.PREVIEW_PREFIX || 'pr-';
+            const prNumber = context.payload.pull_request.number;
+            const webUrl = domain ? `https://deploy.${domain}/${prefix}${prNumber}/` : '';
             const mobileJobResult = process.env.MOBILE_JOB_RESULT;
             const mobileChannel = process.env.MOBILE_CHANNEL;
             const mobileUpdateUrl = process.env.MOBILE_UPDATE_URL;

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -101,7 +101,7 @@ npm run docs:actions-secrets
 
 Commit any updates to `docs/reference/github-actions-secrets.md` when you change `scripts/lib/setup-manifest.mjs`.
 
-At minimum for deploy workflows you will need **`SUPABASE_ACCESS_TOKEN`**, **`EXPO_TOKEN`**, and **AWS access keys** (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, plus optional `AWS_SESSION_TOKEN`), plus the Supabase URL/keys and project refs for each tier—see the generated table.
+At minimum for deploy workflows you will need **`SUPABASE_ACCESS_TOKEN`** and **AWS access keys** (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, plus optional `AWS_SESSION_TOKEN`), plus the Supabase URL/keys and project refs for each tier—see the generated table. **`EXPO_TOKEN`**, `EXPO_PROJECT_ID`, `EXPO_ACCOUNT`, and all `GOOGLE_SERVICES_*` entries are mobile-only; set `MOBILE_ENABLED=false` (GitHub variable) to skip them for web-only repos.
 
 ### 6.2 Full interactive bootstrap
 
@@ -117,6 +117,7 @@ Options (see also `npm run setup:full -- --help`):
 | `--from=PHASE`       | Resume at a phase (see table below)  |
 | `--skip-rename`      | Skip template rename                 |
 | `--skip-github`      | Do not push secrets with `gh`        |
+| `--skip-mobile`      | Skip Expo/EAS/Google setup (web-only repos) |
 | `--aws-profile=NAME` | Pass through to AWS bootstrap script |
 
 **Phase names** for `--from=` (order matters; later phases assume earlier work or merged `.env*` files):

--- a/scripts/lib/setup-google-services.mjs
+++ b/scripts/lib/setup-google-services.mjs
@@ -48,3 +48,19 @@ export async function envVarsFromGoogleServicesJson(filePath) {
   if (apiKeyCurrent) out.GOOGLE_SERVICES_API_KEY = String(apiKeyCurrent);
   return out;
 }
+
+export function clearGoogleKeysFromAcc(acc) {
+  for (const k of [
+    'GOOGLE_SERVICES_PROJECT_NUMBER',
+    'GOOGLE_SERVICES_PROJECT_ID',
+    'GOOGLE_SERVICES_STORAGE_BUCKET',
+    'GOOGLE_SERVICES_MOBILESDK_APP_ID',
+    'GOOGLE_SERVICES_ANDROID_CLIENT_ID',
+    'GOOGLE_SERVICES_ANDROID_CERTIFICATE_HASH',
+    'GOOGLE_SERVICES_WEB_CLIENT_ID',
+    'GOOGLE_SERVICES_IOS_CLIENT_ID',
+    'GOOGLE_SERVICES_API_KEY',
+  ]) {
+    delete acc[k];
+  }
+}

--- a/scripts/lib/setup-manifest.mjs
+++ b/scripts/lib/setup-manifest.mjs
@@ -305,6 +305,13 @@ export const GITHUB_VARIABLES = [
     envKeys: ['EXPO_ACCOUNT'],
     group: 'expo',
   },
+  {
+    type: 'variable',
+    name: 'MOBILE_ENABLED',
+    envKeys: ['MOBILE_ENABLED'],
+    optional: true,
+    group: 'core',
+  },
 ];
 
 /** Env keys written by setup but not listed on GitHub secret defs (local generated env only). */
@@ -346,6 +353,8 @@ export function resolveValueForGithub(env, def) {
   return '';
 }
 
+const MOBILE_GROUPS = new Set(['expo', 'google']);
+
 /**
  * @param {Record<string, string>} env
  * @param {string} [group] if set, only entries with this group
@@ -353,8 +362,10 @@ export function resolveValueForGithub(env, def) {
 export function collectGithubSecretPayload(env, group) {
   /** @type {Record<string, string>} */
   const out = {};
+  const mobileDisabled = env.MOBILE_ENABLED === 'false';
   for (const def of GITHUB_SECRETS) {
     if (group && def.group !== group) continue;
+    if (mobileDisabled && MOBILE_GROUPS.has(def.group)) continue;
     const val = resolveValueForGithub(env, def);
     if (!val && def.optional) continue;
     if (val) out[def.name] = val;
@@ -369,8 +380,10 @@ export function collectGithubSecretPayload(env, group) {
 export function collectGithubVariablePayload(env, group) {
   /** @type {Record<string, string>} */
   const out = {};
+  const mobileDisabled = env.MOBILE_ENABLED === 'false';
   for (const def of GITHUB_VARIABLES) {
     if (group && def.group !== group) continue;
+    if (mobileDisabled && MOBILE_GROUPS.has(def.group)) continue;
     const val = resolveValueForGithub(env, def);
     if (!val && def.optional) continue;
     if (val) out[def.name] = val;
@@ -403,13 +416,16 @@ export function mergeGithubSyncEnv(session, local, cloud, aws) {
 export function listMissingRequiredGithubForCi(env) {
   /** @type {{ kind: 'secret' | 'variable'; name: string; group: string }[]} */
   const missing = [];
+  const mobileDisabled = env.MOBILE_ENABLED === 'false';
   for (const def of GITHUB_SECRETS) {
     if (def.optional) continue;
+    if (mobileDisabled && MOBILE_GROUPS.has(def.group)) continue;
     if (resolveValueForGithub(env, def)) continue;
     missing.push({ kind: 'secret', name: def.name, group: def.group || 'unknown' });
   }
   for (const def of GITHUB_VARIABLES) {
     if (def.optional) continue;
+    if (mobileDisabled && MOBILE_GROUPS.has(def.group)) continue;
     if (resolveValueForGithub(env, def)) continue;
     missing.push({ kind: 'variable', name: def.name, group: def.group || 'unknown' });
   }

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -36,7 +36,7 @@ import {
 } from './lib/setup-manifest.mjs';
 import { escapeDotEnvDoubleQuotedValue, parseDotEnv } from './lib/setup-dotenv.mjs';
 import { readMaskedLineIfTty, resolveSecretInputLine } from './lib/setup-secret-input.mjs';
-import { envVarsFromGoogleServicesJson } from './lib/setup-google-services.mjs';
+import { clearGoogleKeysFromAcc, envVarsFromGoogleServicesJson } from './lib/setup-google-services.mjs';
 import {
   printIntroBanner,
   printPhaseIntro,
@@ -1983,6 +1983,7 @@ async function main() {
       if ((phase === 'expo' || phase === 'google') && acc.MOBILE_ENABLED === 'false') {
         logInfo(`Skipping ${phase} phase (mobile disabled).`);
         if (phase === 'expo') clearExpoKeysFromAcc(acc);
+        if (phase === 'google') clearGoogleKeysFromAcc(acc);
         continue;
       }
 

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -80,7 +80,7 @@ const PHASE_ORDER = ['prereqs', 'identity', 'supabase', 'aws', 'expo', 'google',
 /** Merged from dotenv-style secret files / pastes (allowlisted keys only). */
 const MERGEABLE_SETUP_ENV_KEYS = mergeableSetupEnvKeys();
 
-/** @typedef {{ dryRun: boolean; fromPhase: string; skipRename: boolean; awsProfile: string; skipGithub: boolean; plainSecretPrompts: boolean }} CliFlags */
+/** @typedef {{ dryRun: boolean; fromPhase: string; skipRename: boolean; awsProfile: string; skipGithub: boolean; mobileEnabled: boolean; plainSecretPrompts: boolean }} CliFlags */
 
 function printHelp() {
   console.log(`Usage: node scripts/setup-full.mjs [options]
@@ -93,6 +93,7 @@ Options:
                          merges existing .env*.local first when resuming)
   --skip-rename          Skip the identity / rename phase entirely
   --skip-github          Skip GitHub Actions secret/variable sync
+  --skip-mobile          Skip Expo, EAS, and Google Services setup (web-only repos)
   --aws-profile=NAME     Pass through to bootstrap-aws-stack.sh
   --plain-secret-prompts Echo secret prompts in plain text (default: mask typed secrets on a TTY)
 
@@ -130,12 +131,14 @@ function parseArgv(argv) {
     skipRename: false,
     awsProfile: '',
     skipGithub: false,
+    mobileEnabled: true,
     plainSecretPrompts: false,
   };
   for (const a of argv) {
     if (a === '--dry-run') flags.dryRun = true;
     else if (a === '--skip-rename') flags.skipRename = true;
     else if (a === '--skip-github') flags.skipGithub = true;
+    else if (a === '--skip-mobile') flags.mobileEnabled = false;
     else if (a === '--plain-secret-prompts') flags.plainSecretPrompts = true;
     else if (a.startsWith('--from=')) flags.fromPhase = resolveSetupFromPhase(a.slice('--from='.length));
     else if (a.startsWith('--aws-profile=')) flags.awsProfile = a.slice('--aws-profile='.length);
@@ -1744,6 +1747,7 @@ async function phaseWrite(acc, flags) {
       {
         lastRun: new Date().toISOString(),
         phases: PHASE_ORDER,
+        mobileEnabled: acc.MOBILE_ENABLED !== 'false',
         note: 'No secrets stored in this file.',
       },
       null,
@@ -1936,6 +1940,24 @@ async function main() {
     }
   }
 
+  if (!flags.mobileEnabled) {
+    acc.MOBILE_ENABLED = 'false';
+    logInfo('Mobile disabled (--skip-mobile) — skipping Expo, EAS, and Google Services setup.');
+  } else if (startIdx <= PHASE_ORDER.indexOf('expo')) {
+    if (!flags.dryRun) {
+      const mobileAns = (await rlQuestion(rl, 'Enable mobile (Expo / EAS) builds? [Y/n]: ')).trim().toLowerCase();
+      if (mobileAns === 'n' || mobileAns === 'no') {
+        flags.mobileEnabled = false;
+        logInfo('Mobile disabled — skipping Expo, EAS, and Google Services setup.');
+      }
+    } else {
+      logInfo('[dry-run] would prompt for mobile setup choice (defaulting to enabled).');
+    }
+    acc.MOBILE_ENABLED = flags.mobileEnabled ? 'true' : 'false';
+  } else {
+    if (!acc.MOBILE_ENABLED) acc.MOBILE_ENABLED = 'true';
+  }
+
   try {
     for (let i = startIdx; i < PHASE_ORDER.length; i += 1) {
       const phase = PHASE_ORDER[i];
@@ -1956,6 +1978,11 @@ async function main() {
       }
       if (phase === 'github' && flags.skipGithub) {
         logInfo('Skipping GitHub sync (--skip-github).');
+        continue;
+      }
+      if ((phase === 'expo' || phase === 'google') && acc.MOBILE_ENABLED === 'false') {
+        logInfo(`Skipping ${phase} phase (mobile disabled).`);
+        if (phase === 'expo') clearExpoKeysFromAcc(acc);
         continue;
       }
 

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -1944,7 +1944,11 @@ async function main() {
     acc.MOBILE_ENABLED = 'false';
     logInfo('Mobile disabled (--skip-mobile) — skipping Expo, EAS, and Google Services setup.');
   } else if (startIdx <= PHASE_ORDER.indexOf('expo')) {
-    if (!flags.dryRun) {
+    if (acc.MOBILE_ENABLED) {
+      // Resume: honour the stored choice instead of re-prompting with a true default.
+      flags.mobileEnabled = acc.MOBILE_ENABLED !== 'false';
+      logInfo(`Resuming with mobile ${flags.mobileEnabled ? 'enabled' : 'disabled'} (stored MOBILE_ENABLED=${acc.MOBILE_ENABLED}).`);
+    } else if (!flags.dryRun) {
       const mobileAns = (await rlQuestion(rl, 'Enable mobile (Expo / EAS) builds? [Y/n]: ')).trim().toLowerCase();
       if (mobileAns === 'n' || mobileAns === 'no') {
         flags.mobileEnabled = false;


### PR DESCRIPTION
Closes #74

## Summary

- **`MOBILE_ENABLED` GitHub variable** is the single source of truth. Absent or `true` = mobile enabled (backward-compatible). `false` = web-only mode.
- **`setup-full.mjs`**: adds `--skip-mobile` flag + interactive `[Y/n]` prompt before the expo phase; gates expo/google phases; writes `mobileEnabled` to state JSON. When resuming (`--from=<phase>`), honours any stored `MOBILE_ENABLED` value from env files instead of re-prompting with an enabled default.
- **`setup-manifest.mjs`**: adds `MOBILE_ENABLED` to `GITHUB_VARIABLES`; new `MOBILE_GROUPS` constant gates expo/google secrets/variables from GitHub sync and CI-completeness warnings when disabled.
- **`pr-preview-environment.yml`**: splits mobile deploy into a separate `deploy-preview-mobile` job (gated by `vars.MOBILE_ENABLED != 'false'`); adds a dedicated `comment` job that waits on both and handles skipped/failed mobile gracefully. Web deploy no longer blocked by mobile build time. `comment` job has both `pull-requests: write` and `issues: write` (required by `github.rest.issues.*`).
- **`deploy-staging.yml`** and **`deploy-production.yml`**: mobile step extracted to `deploy-mobile-staging` / `deploy-mobile-production` jobs, each gated by `vars.MOBILE_ENABLED != 'false'`. Missing `EXPO_ACCOUNT` fails loudly only when `MOBILE_ENABLED=true`; otherwise exits 0 with a warning (preserves backwards compat for repos with neither variable set).
- **`QUICKSTART.md`**: documents `--skip-mobile` flag; notes Expo/Google secrets are mobile-only.

## Security

Per Mei's review: `PREVIEW_SUPABASE_ANON_KEY` is read directly from `secrets.*` in the mobile job — not passed as a cross-job output — so it never appears in plaintext in workflow logs.

## CloudFront function publish timing

The initial commit accidentally removed `--skip-cloudfront-function-publish` from the bootstrap call and dropped the "Publish PR path router" step entirely. This was an **unintentional refactoring side effect**, not a deliberate change. Commit c49c1c8 restores the original behaviour:

1. `bootstrap-aws-stack.sh` is called with `--skip-cloudfront-function-publish` — creates/updates the stack without touching CloudFront function code.
2. A separate "Publish PR path router (CloudFront)" step runs **only after `steps.web.outcome == 'success'`**, ensuring S3 assets are in place before the routing function is updated.

This preserves the safety guard from PR #72: a failed web build cannot replace live CloudFront function code while leaving stale or missing S3 assets.

## Test plan

- [ ] Web-only: set `MOBILE_ENABLED=false` → mobile jobs skipped, PR comment shows only web URL
- [ ] Mobile-enabled: leave `MOBILE_ENABLED` unset → both jobs run, comment shows web + mobile
- [ ] Explicitly set `MOBILE_ENABLED=true` → same as unset (both enable mobile; `!= 'false'` gate treats them identically)
- [ ] Existing repo with neither `MOBILE_ENABLED` nor `EXPO_ACCOUNT` set → `deploy-mobile-*` jobs skip with warning, not failure
- [ ] `npm run setup:full -- --skip-mobile --dry-run` → expo/google phases skipped
- [ ] `npm run setup:full -- --dry-run`, answer `n` at mobile prompt → same result
- [ ] Resume with `--from=aws` after a run that answered `n` → expo/google still skipped (stored value honoured, no re-prompt)
- [ ] `npm run docs:actions-secrets` regenerates without drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)