### PR TITLE
feat(dark-mode): foundation — Tailwind config, anti-FOUC, ThemeContext, CSS cleanup

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,19 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>%APP_TITLE%</title>
 
-    <!-- Site-wide meta — canonical and og:url are home-only and are injected into
-         prerender-home.html by scripts/prerender-home.ts; adding them here would
-         incorrectly set home-page values on /dashboard, /login, etc. -->
-    <meta name="description" content="BeakerStack gives you auth, billing, and a cross-platform React foundation — ready to ship your SaaS." />
-    <meta property="og:type" content="website" />
-    <meta property="og:title" content="BeakerStack — Ship your SaaS faster." />
-    <meta property="og:description" content="Everything you need to ship a real product. Auth, billing, and cross-platform React with a production CI/CD pipeline." />
-    <!-- Shipped icon until a dedicated 1200×630 og-image asset exists. -->
-    <meta property="og:image" content="https://beakerstack.com/android-chrome-512x512.png" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="BeakerStack — Ship your SaaS faster." />
-    <meta name="twitter:description" content="Everything you need to ship a real product." />
-    <meta name="twitter:image" content="https://beakerstack.com/android-chrome-512x512.png" />
+    <!-- Anti-FOUC: apply dark class before first paint.
+         Reads stored user preference first; falls back to OS preference.
+         try/catch guards against CSP or private-browsing environments. -->
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem('beakerstack:theme');
+          var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          if (stored === 'dark' || (stored !== 'light' && prefersDark)) {
+            document.documentElement.classList.add('dark');
+          }
+        } catch (_) {}
+      })();
+    </script>
 
     <!-- Favicons for all browsers -->
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -20,6 +20,20 @@
       })();
     </script>
 
+    <!-- Site-wide meta — canonical and og:url are home-only and are injected into
+         prerender-home.html by scripts/prerender-home.ts; adding them here would
+         incorrectly set home-page values on /dashboard, /login, etc. -->
+    <meta name="description" content="BeakerStack gives you auth, billing, and a cross-platform React foundation — ready to ship your SaaS." />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="BeakerStack — Ship your SaaS faster." />
+    <meta property="og:description" content="Everything you need to ship a real product. Auth, billing, and cross-platform React with a production CI/CD pipeline." />
+    <!-- Shipped icon until a dedicated 1200×630 og-image asset exists. -->
+    <meta property="og:image" content="https://beakerstack.com/android-chrome-512x512.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="BeakerStack — Ship your SaaS faster." />
+    <meta name="twitter:description" content="Everything you need to ship a real product." />
+    <meta name="twitter:image" content="https://beakerstack.com/android-chrome-512x512.png" />
+
     <!-- Favicons for all browsers -->
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />

--- a/apps/web/src/contexts/ThemeContext.tsx
+++ b/apps/web/src/contexts/ThemeContext.tsx
@@ -46,7 +46,7 @@ function applyClass(isDark: boolean): void {
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [preference, setPreference] = useState<ThemePreference>(readStored);
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
-    resolve(readStored())
+    resolve(preference)
   );
 
   // Keep DOM in sync whenever resolved theme changes.

--- a/apps/web/src/contexts/ThemeContext.tsx
+++ b/apps/web/src/contexts/ThemeContext.tsx
@@ -20,6 +20,7 @@ interface ThemeContextValue {
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 function getSystemDark(): boolean {
+  if (typeof window === 'undefined') return false;
   return window.matchMedia('(prefers-color-scheme: dark)').matches;
 }
 

--- a/apps/web/src/contexts/ThemeContext.tsx
+++ b/apps/web/src/contexts/ThemeContext.tsx
@@ -1,0 +1,94 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+
+export type ThemePreference = 'system' | 'light' | 'dark';
+export type ResolvedTheme = 'light' | 'dark';
+
+const THEME_KEY = 'beakerstack:theme';
+
+interface ThemeContextValue {
+  preference: ThemePreference;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: ThemePreference) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function getSystemDark(): boolean {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+function resolve(pref: ThemePreference): ResolvedTheme {
+  if (pref === 'dark') return 'dark';
+  if (pref === 'light') return 'light';
+  return getSystemDark() ? 'dark' : 'light';
+}
+
+function readStored(): ThemePreference {
+  try {
+    const v = localStorage.getItem(THEME_KEY);
+    if (v === 'dark' || v === 'light') return v;
+  } catch {
+    // private browsing / CSP
+  }
+  return 'system';
+}
+
+function applyClass(isDark: boolean): void {
+  document.documentElement.classList.toggle('dark', isDark);
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [preference, setPreference] = useState<ThemePreference>(readStored);
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
+    resolve(readStored())
+  );
+
+  // Keep DOM in sync whenever resolved theme changes.
+  useEffect(() => {
+    applyClass(resolvedTheme === 'dark');
+  }, [resolvedTheme]);
+
+  // Watch OS preference while user has 'system' selected.
+  useEffect(() => {
+    if (preference !== 'system') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => {
+      const next: ResolvedTheme = e.matches ? 'dark' : 'light';
+      setResolvedTheme(next);
+    };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [preference]);
+
+  function setTheme(pref: ThemePreference) {
+    setPreference(pref);
+    setResolvedTheme(resolve(pref));
+    try {
+      if (pref === 'system') {
+        localStorage.removeItem(THEME_KEY);
+      } else {
+        localStorage.setItem(THEME_KEY, pref);
+      }
+    } catch {
+      // private browsing / CSP
+    }
+  }
+
+  return (
+    <ThemeContext.Provider value={{ preference, resolvedTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}

--- a/apps/web/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/ThemeContext.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, useTheme } from '../ThemeContext';
+import { useTheme as useThemeFromHook } from '../../hooks/useTheme';
+
+function TestConsumer() {
+  const { preference, resolvedTheme, setTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid='preference'>{preference}</span>
+      <span data-testid='resolved'>{resolvedTheme}</span>
+      <button onClick={() => setTheme('dark')}>Dark</button>
+      <button onClick={() => setTheme('light')}>Light</button>
+      <button onClick={() => setTheme('system')}>System</button>
+    </div>
+  );
+}
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+    vi.restoreAllMocks();
+  });
+
+  it('re-exports useTheme via hooks/useTheme', () => {
+    expect(useThemeFromHook).toBeDefined();
+  });
+
+  it('useTheme throws when used outside ThemeProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(<TestConsumer />)).toThrow(
+      'useTheme must be used within ThemeProvider'
+    );
+    spy.mockRestore();
+  });
+
+  it('defaults to system preference when nothing is stored', () => {
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('preference').textContent).toBe('system');
+  });
+
+  it('reads stored dark preference from localStorage', () => {
+    localStorage.setItem('beakerstack:theme', 'dark');
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('preference').textContent).toBe('dark');
+    expect(screen.getByTestId('resolved').textContent).toBe('dark');
+  });
+
+  it('reads stored light preference from localStorage', () => {
+    localStorage.setItem('beakerstack:theme', 'light');
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('preference').textContent).toBe('light');
+    expect(screen.getByTestId('resolved').textContent).toBe('light');
+  });
+
+  it('setTheme dark persists to localStorage and applies dark class', async () => {
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    await user.click(screen.getByRole('button', { name: 'Dark' }));
+    expect(screen.getByTestId('preference').textContent).toBe('dark');
+    expect(screen.getByTestId('resolved').textContent).toBe('dark');
+    expect(localStorage.getItem('beakerstack:theme')).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('setTheme light persists to localStorage and removes dark class', async () => {
+    document.documentElement.classList.add('dark');
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    await user.click(screen.getByRole('button', { name: 'Light' }));
+    expect(screen.getByTestId('preference').textContent).toBe('light');
+    expect(screen.getByTestId('resolved').textContent).toBe('light');
+    expect(localStorage.getItem('beakerstack:theme')).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('setTheme system removes stored preference from localStorage', async () => {
+    localStorage.setItem('beakerstack:theme', 'dark');
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    await user.click(screen.getByRole('button', { name: 'System' }));
+    expect(screen.getByTestId('preference').textContent).toBe('system');
+    expect(localStorage.getItem('beakerstack:theme')).toBeNull();
+  });
+
+  it('applies dark class to documentElement when theme is dark', () => {
+    localStorage.setItem('beakerstack:theme', 'dark');
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('responds to OS preference changes while in system mode', async () => {
+    let osListener: ((e: Partial<MediaQueryListEvent>) => void) | null = null;
+    const mockMq = {
+      matches: false,
+      addEventListener: vi.fn(
+        (_: string, fn: (e: Partial<MediaQueryListEvent>) => void) => {
+          osListener = fn;
+        }
+      ),
+      removeEventListener: vi.fn(),
+    };
+    vi.spyOn(window, 'matchMedia').mockReturnValue(
+      mockMq as unknown as MediaQueryList
+    );
+
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('resolved').textContent).toBe('light');
+
+    act(() => {
+      osListener?.({ matches: true } as MediaQueryListEvent);
+    });
+    expect(screen.getByTestId('resolved').textContent).toBe('dark');
+
+    act(() => {
+      osListener?.({ matches: false } as MediaQueryListEvent);
+    });
+    expect(screen.getByTestId('resolved').textContent).toBe('light');
+  });
+});

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -1,0 +1,2 @@
+export { useTheme } from '../contexts/ThemeContext';
+export type { ThemePreference, ResolvedTheme } from '../contexts/ThemeContext';

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8,8 +8,6 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -49,14 +47,3 @@ button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-}
-

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
+import { ThemeProvider } from './contexts/ThemeContext';
 import { supabase } from './lib/supabase';
 import App from './App';
 import './index.css';
@@ -18,12 +19,14 @@ const basePath = import.meta.env.VITE_BASE_PATH || '/';
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <AuthProvider supabaseClient={supabase}>
-      <ProfileProvider supabaseClient={supabase}>
-        <BrowserRouter basename={basePath}>
-          <App />
-        </BrowserRouter>
-      </ProfileProvider>
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider supabaseClient={supabase}>
+        <ProfileProvider supabaseClient={supabase}>
+          <BrowserRouter basename={basePath}>
+            <App />
+          </BrowserRouter>
+        </ProfileProvider>
+      </AuthProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -2,6 +2,7 @@ import typography from '@tailwindcss/typography';
 
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     './index.html',
     './src/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
Closes #75 (partial — foundation layer)

## What's in this PR

This is the first of two PRs for issue #75. It lays the foundation that makes dark mode work at all — without these changes, every `dark:` utility in the codebase is silently ignored.

### Changes

**`apps/web/tailwind.config.js`** — Added `darkMode: 'class'`
The root cause: without this, Tailwind never emits `dark:` utilities. One line, fixes the entire broken chain.

**`apps/web/index.html`** — Anti-FOUC inline script in `<head>`
Reads `localStorage['beakerstack:theme']` synchronously before React boots. Falls back to `matchMedia('prefers-color-scheme: dark')`. Wrapped in `try/catch` for CSP / private browsing safety. Prevents white flash on dark-preferring users.

**`apps/web/src/index.css`** — Removed conflicting Vite-template dark defaults
The template's `:root` set `color: rgba(255,255,255,0.87)` and `background-color: #242424` (dark always), with a `@media (prefers-color-scheme: light)` override. These fought Tailwind's `bg-white` / `text-gray-*` utilities. Removed entirely; kept `color-scheme: light dark`, fonts, and button rules.

**`apps/web/src/contexts/ThemeContext.tsx`** — New ThemeContext
Three-state preference (`system` | `light` | `dark`) with `localStorage` persistence (`beakerstack:theme` key). OS preference watcher via `matchMedia` (active only in `system` mode). `setTheme()` setter for the footer toggle component (coming in PR 2). `useTheme()` hook throws if used outside provider.

**`apps/web/src/hooks/useTheme.ts`** — Re-export for clean import paths
`import { useTheme } from '../hooks/useTheme'` works from any component.

**`apps/web/src/main.tsx`** — Wrapped app in `<ThemeProvider>`
Outermost provider, before `AuthProvider`, so the resolved theme is available everywhere.

## What's NOT in this PR

Dark-mode `dark:` variants on individual components and the `ThemeToggle` footer button are in PR 2 (`diego/issue-75-dark-mode-components`). That PR will be opened after this one merges to `develop`.

## Testing

1. Open the app with no `localStorage` entry — should match OS preference with no flash
2. Set `localStorage['beakerstack:theme'] = 'dark'` and reload — `dark` class on `<html>` immediately, no flash
3. Set to `'light'` — same, no flash even on dark-OS machines
4. Toggle OS dark mode while app is open with `system` preference — resolves live