### PR TITLE
feat(dark-mode): components — dark: variants + ThemeToggle in footer

### DIFF
--- a/apps/web/__tests__/App.test.tsx
+++ b/apps/web/__tests__/App.test.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeAll } from 'vitest';
 import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
+import { ThemeProvider } from '../src/contexts/ThemeContext';
 import App from '../src/App';
 
 // Mock environment variables to prevent real Supabase client creation
@@ -90,13 +91,15 @@ const mockSupabaseClient = {
 
 function renderApp() {
   return render(
-    <AuthProvider supabaseClient={mockSupabaseClient}>
-      <ProfileProvider supabaseClient={mockSupabaseClient}>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </ProfileProvider>
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider supabaseClient={mockSupabaseClient}>
+        <ProfileProvider supabaseClient={mockSupabaseClient}>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </ProfileProvider>
+      </AuthProvider>
+    </ThemeProvider>
   );
 }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,7 +29,7 @@ function RootLayout() {
 
 function App() {
   return (
-    <div className='bg-gray-50'>
+    <div className='bg-gray-50 dark:bg-gray-900'>
       <Routes>
         <Route element={<RootLayout />}>
           <Route

--- a/apps/web/src/components/AppFooter.tsx
+++ b/apps/web/src/components/AppFooter.tsx
@@ -1,35 +1,40 @@
 import { Link } from 'react-router-dom';
 import { LEGAL_CONFIG } from '@beakerstack/shared/config/legal';
+import { ThemeToggle } from './ThemeToggle';
 
 export function AppFooter() {
   const year = new Date().getFullYear();
 
   return (
-    <footer className='border-t border-gray-200 bg-white'>
+    <footer className='border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900'>
       <div className='max-w-[1024px] mx-auto px-4 py-6 sm:px-6 lg:px-8'>
         <div className='flex flex-col items-center gap-3 sm:flex-row sm:justify-between'>
-          <p className='text-sm text-gray-500'>
+          <p className='text-sm text-gray-500 dark:text-gray-400'>
             &copy; {year} {LEGAL_CONFIG.legalEntityName}. All rights reserved.
           </p>
-          <nav className='flex gap-6' aria-label='Legal'>
+          <nav
+            className='flex flex-wrap items-center gap-4 sm:gap-6'
+            aria-label='Legal'
+          >
             <Link
               to='/terms'
-              className='text-sm text-gray-500 hover:text-gray-900 transition-colors'
+              className='text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors'
             >
               Terms of Service
             </Link>
             <Link
               to='/privacy'
-              className='text-sm text-gray-500 hover:text-gray-900 transition-colors'
+              className='text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors'
             >
               Privacy Policy
             </Link>
             <Link
               to='/refunds'
-              className='text-sm text-gray-500 hover:text-gray-900 transition-colors'
+              className='text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors'
             >
               Refund Policy
             </Link>
+            <ThemeToggle />
           </nav>
         </div>
       </div>

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,33 @@
+import { useTheme } from '../hooks/useTheme';
+import type { ThemePreference } from '../contexts/ThemeContext';
+
+const OPTIONS: { value: ThemePreference; label: string; icon: string }[] = [
+  { value: 'light', label: 'Light', icon: '☀' },
+  { value: 'system', label: 'System', icon: '⊙' },
+  { value: 'dark', label: 'Dark', icon: '☾' },
+];
+
+export function ThemeToggle() {
+  const { preference, setTheme } = useTheme();
+
+  return (
+    <div className='inline-flex items-center rounded-full border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 p-0.5'>
+      {OPTIONS.map(({ value, label, icon }) => (
+        <button
+          key={value}
+          type='button'
+          onClick={() => setTheme(value)}
+          aria-label={label}
+          title={label}
+          className={`rounded-full px-2 py-0.5 text-xs font-medium transition-colors ${
+            preference === value
+              ? 'bg-white dark:bg-gray-900 text-gray-900 dark:text-white shadow-sm'
+              : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
+          }`}
+        >
+          {icon}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/__tests__/AppFooter.test.tsx
+++ b/apps/web/src/components/__tests__/AppFooter.test.tsx
@@ -1,13 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from '../../contexts/ThemeContext';
 import { AppFooter } from '../AppFooter';
 
 function renderFooter() {
   return render(
-    <MemoryRouter>
-      <AppFooter />
-    </MemoryRouter>
+    <ThemeProvider>
+      <MemoryRouter>
+        <AppFooter />
+      </MemoryRouter>
+    </ThemeProvider>
   );
 }
 

--- a/apps/web/src/components/__tests__/ThemeToggle.test.tsx
+++ b/apps/web/src/components/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../contexts/ThemeContext';
+import { ThemeToggle } from '../ThemeToggle';
+
+function renderToggle() {
+  return render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>
+  );
+}
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('renders Light, System, and Dark buttons', () => {
+    renderToggle();
+    expect(screen.getByRole('button', { name: 'Light' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'System' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dark' })).toBeInTheDocument();
+  });
+
+  it('clicking Dark applies dark class to documentElement', async () => {
+    const user = userEvent.setup();
+    renderToggle();
+    await user.click(screen.getByRole('button', { name: 'Dark' }));
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('clicking Light removes dark class', async () => {
+    const user = userEvent.setup();
+    renderToggle();
+    await user.click(screen.getByRole('button', { name: 'Dark' }));
+    await user.click(screen.getByRole('button', { name: 'Light' }));
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('clicking System clears stored preference', async () => {
+    localStorage.setItem('beakerstack:theme', 'dark');
+    const user = userEvent.setup();
+    renderToggle();
+    await user.click(screen.getByRole('button', { name: 'System' }));
+    expect(localStorage.getItem('beakerstack:theme')).toBeNull();
+  });
+});

--- a/apps/web/src/components/billing/Banner.web.tsx
+++ b/apps/web/src/components/billing/Banner.web.tsx
@@ -3,10 +3,13 @@ import type { ReactNode } from 'react';
 export type BannerVariant = 'info' | 'success' | 'warning' | 'error';
 
 const variantClass: Record<BannerVariant, string> = {
-  info: 'bg-blue-50 border-blue-200 text-blue-900',
-  success: 'bg-green-50 border-green-200 text-green-900',
-  warning: 'bg-amber-50 border-amber-200 text-amber-900',
-  error: 'bg-red-50 border-red-200 text-red-900',
+  info: 'bg-blue-50 dark:bg-blue-950 border-blue-200 dark:border-blue-800 text-blue-900 dark:text-blue-100',
+  success:
+    'bg-green-50 dark:bg-green-950 border-green-200 dark:border-green-800 text-green-900 dark:text-green-100',
+  warning:
+    'bg-amber-50 dark:bg-amber-950 border-amber-200 dark:border-amber-800 text-amber-900 dark:text-amber-100',
+  error:
+    'bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800 text-red-900 dark:text-red-100',
 };
 
 export function Banner({

--- a/apps/web/src/components/billing/BillingPageShell.web.tsx
+++ b/apps/web/src/components/billing/BillingPageShell.web.tsx
@@ -10,7 +10,7 @@ export function BillingPageShell({
   maxWidthClass?: string;
 }): JSX.Element {
   return (
-    <div className='min-h-screen bg-gray-50'>
+    <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
       <AppHeader supabaseClient={supabase} />
       <div className={`mx-auto ${maxWidthClass} py-6 sm:px-6 lg:px-8`}>
         <div className='px-4 py-6 sm:px-0'>{children}</div>

--- a/apps/web/src/components/billing/CadenceToggle.web.tsx
+++ b/apps/web/src/components/billing/CadenceToggle.web.tsx
@@ -31,14 +31,14 @@ export function CadenceToggle() {
   );
   return (
     <div className='flex items-center justify-center gap-1'>
-      <div className='inline-flex rounded-full border border-gray-200 bg-white p-1 shadow-sm'>
+      <div className='inline-flex rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-1 shadow-sm'>
         <button
           type='button'
           onClick={() => set('monthly')}
           className={`rounded-full px-4 py-1.5 text-sm font-medium transition ${
             cadence === 'monthly'
               ? 'bg-indigo-600 text-white'
-              : 'text-gray-600 hover:text-gray-900'
+              : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
           }`}
         >
           Monthly
@@ -52,7 +52,7 @@ export function CadenceToggle() {
           className={`inline-flex min-h-[2.25rem] items-center justify-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition ${
             cadence === 'annual'
               ? 'bg-indigo-600 text-white'
-              : 'text-gray-600 hover:text-gray-900'
+              : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
           }`}
         >
           <span>Annually</span>

--- a/apps/web/src/components/billing/CurrentPlanCard.web.tsx
+++ b/apps/web/src/components/billing/CurrentPlanCard.web.tsx
@@ -40,31 +40,35 @@ export function CurrentPlanCard({
     : '—';
 
   return (
-    <div className='space-y-4 rounded-xl border border-gray-200 bg-white p-6 sm:p-8 shadow-sm'>
+    <div className='space-y-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 sm:p-8 shadow-sm'>
       {isFree ? (
         <>
-          <h2 className='text-2xl font-bold text-gray-900'>
+          <h2 className='text-2xl font-bold text-gray-900 dark:text-white'>
             You&apos;re on the Free plan
           </h2>
-          <p className='text-sm text-gray-600'>
+          <p className='text-sm text-gray-600 dark:text-gray-300'>
             Upgrade to unlock more capacity and features.
           </p>
         </>
       ) : (
         <>
           <div className='flex flex-wrap items-center gap-2'>
-            <h2 className='text-2xl font-bold text-gray-900'>
+            <h2 className='text-2xl font-bold text-gray-900 dark:text-white'>
               {plan.display_name}
             </h2>
             {subscription && (
               <SubscriptionStatusBadge subscription={subscription} />
             )}
           </div>
-          {priceLine && <p className='text-base text-gray-600'>{priceLine}</p>}
+          {priceLine && (
+            <p className='text-base text-gray-600 dark:text-gray-300'>
+              {priceLine}
+            </p>
+          )}
         </>
       )}
       {!isFree && subscription && (
-        <p className='text-sm text-gray-600'>
+        <p className='text-sm text-gray-600 dark:text-gray-300'>
           {periodSubcopy
             ? periodSubcopy
             : subscription.cancel_at_period_end

--- a/apps/web/src/components/billing/InvoiceList.web.tsx
+++ b/apps/web/src/components/billing/InvoiceList.web.tsx
@@ -17,23 +17,27 @@ export function InvoiceList({
   }
   const slice = items.slice(0, limit);
   return (
-    <div className='rounded-xl border border-gray-200 bg-white p-6 shadow-sm'>
-      <h2 className='text-lg font-semibold text-gray-900'>Recent activity</h2>
-      <ul className='mt-4 divide-y divide-gray-100'>
+    <div className='rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm'>
+      <h2 className='text-lg font-semibold text-gray-900 dark:text-white'>
+        Recent activity
+      </h2>
+      <ul className='mt-4 divide-y divide-gray-100 dark:divide-gray-700'>
         {slice.map(inv => (
           <li
             key={inv.id}
             className='flex items-center justify-between py-3 text-sm'
           >
             <div>
-              <p className='text-gray-900'>{formatDate(inv.created_at)}</p>
-              <p className='text-gray-500'>
+              <p className='text-gray-900 dark:text-white'>
+                {formatDate(inv.created_at)}
+              </p>
+              <p className='text-gray-500 dark:text-gray-400'>
                 {inv.description ?? 'Subscription'}
               </p>
             </div>
             <div className='flex items-center gap-2'>
               <StatusBadge status={inv.status} />
-              <span className='text-gray-900'>
+              <span className='text-gray-900 dark:text-white'>
                 {formatMoneyCents(
                   inv.amount_paid || inv.amount_due,
                   inv.currency

--- a/apps/web/src/components/billing/InvoiceTable.web.tsx
+++ b/apps/web/src/components/billing/InvoiceTable.web.tsx
@@ -23,8 +23,8 @@ export function InvoiceTable({
   }
   if (!loading && items.length === 0) {
     return (
-      <div className='rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm'>
-        <p className='text-sm text-gray-600'>
+      <div className='rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-8 text-center shadow-sm'>
+        <p className='text-sm text-gray-600 dark:text-gray-300'>
           No invoices yet. Your invoices will appear here after your first
           payment.
         </p>
@@ -38,38 +38,38 @@ export function InvoiceTable({
     );
   }
   return (
-    <div className='overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm'>
+    <div className='overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm'>
       <div className='overflow-x-auto'>
-        <table className='min-w-full divide-y divide-gray-200'>
-          <thead className='bg-gray-50'>
+        <table className='min-w-full divide-y divide-gray-200 dark:divide-gray-700'>
+          <thead className='bg-gray-50 dark:bg-gray-700'>
             <tr>
-              <th className='px-4 py-3 text-left text-xs font-medium text-gray-500'>
+              <th className='px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400'>
                 Date
               </th>
-              <th className='px-4 py-3 text-left text-xs font-medium text-gray-500'>
+              <th className='px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400'>
                 Description
               </th>
-              <th className='px-4 py-3 text-right text-xs font-medium text-gray-500'>
+              <th className='px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400'>
                 Amount
               </th>
-              <th className='px-4 py-3 text-left text-xs font-medium text-gray-500'>
+              <th className='px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400'>
                 Status
               </th>
-              <th className='px-4 py-3 text-right text-xs font-medium text-gray-500'>
+              <th className='px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400'>
                 Actions
               </th>
             </tr>
           </thead>
-          <tbody className='divide-y divide-gray-100 bg-white'>
+          <tbody className='divide-y divide-gray-100 dark:divide-gray-700 bg-white dark:bg-gray-800'>
             {items.map(inv => (
               <tr key={inv.id}>
-                <td className='whitespace-nowrap px-4 py-3 text-sm text-gray-900'>
+                <td className='whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-white'>
                   {formatDate(inv.created_at)}
                 </td>
-                <td className='px-4 py-3 text-sm text-gray-600'>
+                <td className='px-4 py-3 text-sm text-gray-600 dark:text-gray-300'>
                   {inv.description ?? '—'}
                 </td>
-                <td className='whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900'>
+                <td className='whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900 dark:text-white'>
                   {formatMoneyCents(
                     inv.amount_paid || inv.amount_due,
                     inv.currency
@@ -106,7 +106,7 @@ export function InvoiceTable({
         </table>
       </div>
       {hasMore && (
-        <div className='border-t border-gray-200 p-4 text-center'>
+        <div className='border-t border-gray-200 dark:border-gray-700 p-4 text-center'>
           <Button
             type='button'
             variant='secondary'

--- a/apps/web/src/components/billing/PlanCard.web.tsx
+++ b/apps/web/src/components/billing/PlanCard.web.tsx
@@ -27,9 +27,9 @@ export function PlanCard({
   priceHeadline: string;
   priceSubline?: string;
   subTag?: string;
-  /** Shown next to plan title in annual cadence (e.g. “2 Months Free”). */
+  /** Shown next to plan title in annual cadence (e.g. "2 Months Free"). */
   savingsCallout?: string | null;
-  /** Used for trial copy (“then billed …”). */
+  /** Used for trial copy ("then billed …"). */
   billingCadence?: 'monthly' | 'annual';
   /** Hard blockers disable the CTA; soft blockers are shown as warnings only (boolean entitlement loss). */
   blockers?: DowngradeBlockersResult;
@@ -60,31 +60,37 @@ export function PlanCard({
   return (
     <div
       id={`plan-card-${plan.id}`}
-      className='flex h-full flex-col rounded-xl border border-gray-200 bg-white p-6 shadow-sm'
+      className='flex h-full flex-col rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm'
     >
       <div className='flex flex-wrap items-center gap-2'>
-        <h3 className='text-xl font-semibold text-gray-900'>
+        <h3 className='text-xl font-semibold text-gray-900 dark:text-white'>
           {plan.display_name}
         </h3>
         {supplementalBadge ? (
-          <span className='shrink-0 rounded-md border border-blue-200 bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-900'>
+          <span className='shrink-0 rounded-md border border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/40 px-2 py-0.5 text-xs font-medium text-blue-900 dark:text-blue-200'>
             {supplementalBadge}
           </span>
         ) : null}
         {savingsCallout ? (
-          <span className='shrink-0 rounded-md border border-rose-300 bg-rose-50 px-2 py-0.5 text-xs font-semibold text-rose-900'>
+          <span className='shrink-0 rounded-md border border-rose-300 dark:border-rose-600 bg-rose-50 dark:bg-rose-900/40 px-2 py-0.5 text-xs font-semibold text-rose-900 dark:text-rose-200'>
             {savingsCallout}
           </span>
         ) : null}
       </div>
-      {tag ? <p className='text-sm text-gray-500'>{tag}</p> : null}
+      {tag ? (
+        <p className='text-sm text-gray-500 dark:text-gray-400'>{tag}</p>
+      ) : null}
       <div className='mt-4'>
-        <p className='text-3xl font-bold text-gray-900'>{priceHeadline}</p>
+        <p className='text-3xl font-bold text-gray-900 dark:text-white'>
+          {priceHeadline}
+        </p>
         {priceSubline && (
-          <p className='text-sm text-gray-500'>{priceSubline}</p>
+          <p className='text-sm text-gray-500 dark:text-gray-400'>
+            {priceSubline}
+          </p>
         )}
         {plan.price_cents > 0 && plan.trial_period_days > 0 ? (
-          <p className='mt-2 text-sm text-gray-600'>
+          <p className='mt-2 text-sm text-gray-600 dark:text-gray-300'>
             {plan.trial_period_days}-day trial, then billed{' '}
             {billingCadence === 'annual' ? 'annually' : 'monthly'} at this rate.
           </p>

--- a/apps/web/src/components/billing/StatCard.web.tsx
+++ b/apps/web/src/components/billing/StatCard.web.tsx
@@ -6,9 +6,11 @@ export function StatCard({
   value: string;
 }): JSX.Element {
   return (
-    <div className='rounded-xl border border-gray-200 bg-white p-4 shadow-sm'>
-      <p className='text-xs text-gray-500'>{label}</p>
-      <p className='mt-1 text-base font-medium text-gray-900'>{value}</p>
+    <div className='rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm'>
+      <p className='text-xs text-gray-500 dark:text-gray-400'>{label}</p>
+      <p className='mt-1 text-base font-medium text-gray-900 dark:text-white'>
+        {value}
+      </p>
     </div>
   );
 }

--- a/apps/web/src/pages/AuthCallbackPage.tsx
+++ b/apps/web/src/pages/AuthCallbackPage.tsx
@@ -77,15 +77,15 @@ export default function AuthCallbackPage() {
 
   if (error) {
     return (
-      <div className='min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8'>
+      <div className='min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8'>
         <div className='max-w-md w-full space-y-8'>
-          <div className='rounded-md bg-red-50 p-4'>
+          <div className='rounded-md bg-red-50 dark:bg-red-900/30 p-4'>
             <div className='flex'>
               <div className='ml-3'>
-                <h3 className='text-sm font-medium text-red-800'>
+                <h3 className='text-sm font-medium text-red-800 dark:text-red-300'>
                   Authentication Error
                 </h3>
-                <div className='mt-2 text-sm text-red-700'>
+                <div className='mt-2 text-sm text-red-700 dark:text-red-400'>
                   <p>{error}</p>
                   <p className='mt-2'>Redirecting to login page...</p>
                 </div>
@@ -98,10 +98,10 @@ export default function AuthCallbackPage() {
   }
 
   return (
-    <div className='min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8'>
+    <div className='min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8'>
       <div className='max-w-md w-full space-y-8 text-center'>
         <div>
-          <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900'>
+          <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900 dark:text-white'>
             Completing sign in...
           </h2>
           <div className='mt-8 flex justify-center'>
@@ -126,7 +126,7 @@ export default function AuthCallbackPage() {
               />
             </svg>
           </div>
-          <p className='mt-4 text-sm text-gray-600'>
+          <p className='mt-4 text-sm text-gray-600 dark:text-gray-400'>
             Please wait while we complete your authentication...
           </p>
         </div>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -9,17 +9,17 @@ import { supabase } from '@/lib/supabase';
 
 export default function DashboardPage() {
   return (
-    <div className='min-h-screen bg-gray-50'>
+    <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
       <AppHeader supabaseClient={supabase} />
 
       <div className='mx-auto max-w-[1024px] px-4 py-6 sm:px-6 lg:px-8'>
         <div className='sm:px-0'>
-          <h1 className='text-2xl font-bold text-gray-900'>
+          <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>
             Welcome to BeakerStack
           </h1>
-          <p className='mt-3 text-sm text-gray-600'>
+          <p className='mt-3 text-sm text-gray-600 dark:text-gray-400'>
             This dashboard is a sandbox for exercising the billing primitives in{' '}
-            <code className='rounded bg-gray-100 px-1 py-0.5 text-xs'>
+            <code className='rounded bg-gray-100 dark:bg-gray-800 dark:text-gray-300 px-1 py-0.5 text-xs'>
               @beakerstack/billing
             </code>{' '}
             directly. Each section below demonstrates one capability with

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -75,7 +75,7 @@ function LoginPageContent() {
   const showPlanAside = postAuthPath !== '/dashboard';
 
   return (
-    <div className='min-h-screen bg-gray-50'>
+    <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
       <AppHeader supabaseClient={supabase} />
       <div className='max-w-[1024px] mx-auto py-12 px-4 sm:px-6 lg:px-8'>
         <div
@@ -91,7 +91,7 @@ function LoginPageContent() {
             }
           >
             <div>
-              <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900 md:mt-0 md:text-left'>
+              <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900 dark:text-white md:mt-0 md:text-left'>
                 Sign in to your account
               </h2>
             </div>
@@ -102,18 +102,20 @@ function LoginPageContent() {
 
             <div className='relative'>
               <div className='absolute inset-0 flex items-center'>
-                <div className='w-full border-t border-gray-300' />
+                <div className='w-full border-t border-gray-300 dark:border-gray-600' />
               </div>
               <div className='relative flex justify-center text-sm'>
-                <span className='px-2 bg-gray-50 text-gray-500'>
+                <span className='px-2 bg-gray-50 dark:bg-gray-900 text-gray-500 dark:text-gray-400'>
                   Or continue with email
                 </span>
               </div>
             </div>
 
             {error && (
-              <div className='rounded-md bg-red-50 p-4'>
-                <h3 className='text-sm font-medium text-red-800'>{error}</h3>
+              <div className='rounded-md bg-red-50 dark:bg-red-900/30 p-4'>
+                <h3 className='text-sm font-medium text-red-800 dark:text-red-300'>
+                  {error}
+                </h3>
               </div>
             )}
 
@@ -132,7 +134,7 @@ function LoginPageContent() {
                     value={email}
                     onChange={e => setEmail(e.target.value)}
                     disabled={isLoading}
-                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
                     placeholder='Email address'
                   />
                 </div>
@@ -149,7 +151,7 @@ function LoginPageContent() {
                     value={password}
                     onChange={e => setPassword(e.target.value)}
                     disabled={isLoading}
-                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
                     placeholder='Password'
                   />
                 </div>

--- a/apps/web/src/pages/PolicyPage.tsx
+++ b/apps/web/src/pages/PolicyPage.tsx
@@ -33,7 +33,7 @@ export default function PolicyPage({ policy }: PolicyPageProps) {
       <div className='max-w-[800px] mx-auto px-4 py-12 sm:px-6 lg:px-8'>
         {/* prose styles rendered via Tailwind Typography — html is build-time generated from our own markdown, not user input */}
         <div
-          className='prose prose-gray max-w-none'
+          className='prose prose-gray dark:prose-invert max-w-none'
           dangerouslySetInnerHTML={{ __html: html }}
         />
       </div>

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -16,7 +16,7 @@ export default function ProfilePage() {
   const profile = useProfileContext();
 
   return (
-    <div className='min-h-screen bg-gray-50'>
+    <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
       <AppHeader supabaseClient={supabase} />
 
       {/* Main Content */}
@@ -26,19 +26,21 @@ export default function ProfilePage() {
           {profile.loading && (
             <div className='text-center py-12'>
               <div className='inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600'></div>
-              <p className='mt-4 text-gray-600'>Loading profile...</p>
+              <p className='mt-4 text-gray-600 dark:text-gray-400'>
+                Loading profile...
+              </p>
             </div>
           )}
 
           {/* Error State */}
           {profile.error && !profile.loading && (
-            <div className='rounded-md bg-red-50 p-4 mb-6'>
+            <div className='rounded-md bg-red-50 dark:bg-red-900/30 p-4 mb-6'>
               <div className='flex'>
                 <div className='ml-3'>
-                  <h3 className='text-sm font-medium text-red-800'>
+                  <h3 className='text-sm font-medium text-red-800 dark:text-red-300'>
                     Error loading profile
                   </h3>
-                  <p className='mt-2 text-sm text-red-700'>
+                  <p className='mt-2 text-sm text-red-700 dark:text-red-400'>
                     {profile.error.message}
                   </p>
                 </div>
@@ -50,7 +52,7 @@ export default function ProfilePage() {
           {!profile.loading && (
             <div className='space-y-6'>
               {/* Profile Header Section */}
-              <div className='bg-white shadow rounded-lg p-6'>
+              <div className='bg-white dark:bg-gray-800 shadow rounded-lg p-6'>
                 <ProfileHeader
                   profile={profile.profile}
                   email={auth.user?.email}
@@ -59,14 +61,14 @@ export default function ProfilePage() {
 
               {/* Profile Stats Section */}
               {profile.profile && (
-                <div className='bg-white shadow rounded-lg p-6'>
+                <div className='bg-white dark:bg-gray-800 shadow rounded-lg p-6'>
                   <ProfileStats profile={profile.profile} />
                 </div>
               )}
 
               {/* Profile Editor Section */}
               {!isEditing && (
-                <div className='bg-white shadow rounded-lg p-6'>
+                <div className='bg-white dark:bg-gray-800 shadow rounded-lg p-6'>
                   <button
                     onClick={() => setIsEditing(true)}
                     className='w-full sm:w-auto px-4 py-2 bg-primary-600 text-white rounded-md text-sm font-medium hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500'
@@ -77,7 +79,7 @@ export default function ProfilePage() {
               )}
 
               {isEditing && (
-                <div className='bg-white shadow rounded-lg p-6'>
+                <div className='bg-white dark:bg-gray-800 shadow rounded-lg p-6'>
                   <ProfileEditor
                     onSuccess={() => {
                       // Refresh profile data after successful update

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -108,20 +108,20 @@ function SignupPageContent() {
 
   if (awaitingEmail) {
     return (
-      <div className='min-h-screen bg-gray-50'>
+      <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
         <AppHeader supabaseClient={supabase} />
         <div className='max-w-[1024px] mx-auto py-12 px-4 sm:px-6 lg:px-8'>
-          <div className='mx-auto max-w-md rounded-lg border border-gray-200 bg-white p-8 shadow-sm'>
-            <h2 className='text-xl font-semibold text-gray-900'>
+          <div className='mx-auto max-w-md rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-8 shadow-sm'>
+            <h2 className='text-xl font-semibold text-gray-900 dark:text-white'>
               Check your email
             </h2>
-            <p className='mt-3 text-sm text-gray-600'>
+            <p className='mt-3 text-sm text-gray-600 dark:text-gray-300'>
               We sent a confirmation link to <strong>{email}</strong>. Click the
               link in that email to finish creating your account — we&apos;ll
               take you to billing to complete your plan when you&apos;re signed
               in.
             </p>
-            <p className='mt-4 text-sm text-gray-500'>
+            <p className='mt-4 text-sm text-gray-500 dark:text-gray-400'>
               <Link to={loginTo} className='font-medium text-primary-600'>
                 Already confirmed? Sign in
               </Link>
@@ -133,7 +133,7 @@ function SignupPageContent() {
   }
 
   return (
-    <div className='min-h-screen bg-gray-50'>
+    <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
       <AppHeader supabaseClient={supabase} />
       <div className='max-w-[1024px] mx-auto py-12 px-4 sm:px-6 lg:px-8'>
         <div
@@ -149,13 +149,13 @@ function SignupPageContent() {
             }
           >
             <div>
-              <h2 className='mt-0 text-center text-3xl font-extrabold text-gray-900 md:text-left'>
+              <h2 className='mt-0 text-center text-3xl font-extrabold text-gray-900 dark:text-white md:text-left'>
                 {paidIntent && postAuthPath !== '/dashboard'
                   ? `Create your account to continue with ${displayName}`
                   : 'Create your account'}
               </h2>
               {paidIntent && postAuthPath !== '/dashboard' ? (
-                <p className='mt-2 text-center text-sm text-gray-600 md:text-left'>
+                <p className='mt-2 text-center text-sm text-gray-600 dark:text-gray-400 md:text-left'>
                   No charge until you finish checkout on the next step.
                 </p>
               ) : null}
@@ -167,18 +167,20 @@ function SignupPageContent() {
 
             <div className='relative'>
               <div className='absolute inset-0 flex items-center'>
-                <div className='w-full border-t border-gray-300' />
+                <div className='w-full border-t border-gray-300 dark:border-gray-600' />
               </div>
               <div className='relative flex justify-center text-sm'>
-                <span className='px-2 bg-gray-50 text-gray-500'>
+                <span className='px-2 bg-gray-50 dark:bg-gray-900 text-gray-500 dark:text-gray-400'>
                   Or continue with email
                 </span>
               </div>
             </div>
 
             {error && (
-              <div className='rounded-md bg-red-50 p-4'>
-                <h3 className='text-sm font-medium text-red-800'>{error}</h3>
+              <div className='rounded-md bg-red-50 dark:bg-red-900/30 p-4'>
+                <h3 className='text-sm font-medium text-red-800 dark:text-red-300'>
+                  {error}
+                </h3>
               </div>
             )}
 
@@ -197,7 +199,7 @@ function SignupPageContent() {
                     value={email}
                     onChange={e => setEmail(e.target.value)}
                     disabled={isLoading}
-                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
                     placeholder='Email address'
                   />
                 </div>
@@ -214,7 +216,7 @@ function SignupPageContent() {
                     value={password}
                     onChange={e => setPassword(e.target.value)}
                     disabled={isLoading}
-                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
                     placeholder='Password'
                   />
                 </div>
@@ -231,7 +233,7 @@ function SignupPageContent() {
                     value={confirmPassword}
                     onChange={e => setConfirmPassword(e.target.value)}
                     disabled={isLoading}
-                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
                     placeholder='Confirm password'
                   />
                 </div>

--- a/packages/shared/src/components/navigation/AppHeader.web.tsx
+++ b/packages/shared/src/components/navigation/AppHeader.web.tsx
@@ -31,7 +31,7 @@ export function AppHeader({ supabaseClient: _supabaseClient }: AppHeaderProps) {
   const basePath = getBasePath();
 
   return (
-    <div className='bg-white shadow'>
+    <div className='bg-white dark:bg-gray-900 shadow dark:shadow-gray-800 border-b border-transparent dark:border-gray-700'>
       <div className='max-w-[1024px] mx-auto px-4 sm:px-6 lg:px-8'>
         <div className='flex justify-between items-center h-16'>
           {/* Left side: App icon and title */}
@@ -45,7 +45,7 @@ export function AppHeader({ supabaseClient: _supabaseClient }: AppHeaderProps) {
             </Link>
             <Link
               to='/'
-              className='text-xl font-semibold text-gray-900 hover:text-gray-700'
+              className='text-xl font-semibold text-gray-900 dark:text-white hover:text-gray-700 dark:hover:text-gray-300'
             >
               {BRANDING.displayName}
             </Link>
@@ -59,7 +59,7 @@ export function AppHeader({ supabaseClient: _supabaseClient }: AppHeaderProps) {
               <>
                 <Link
                   to='/login'
-                  className='text-gray-500 hover:text-gray-700 px-3 py-2 rounded-md text-sm font-medium'
+                  className='text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 px-3 py-2 rounded-md text-sm font-medium'
                 >
                   Sign In
                 </Link>

--- a/packages/shared/src/components/navigation/UserMenu.web.tsx
+++ b/packages/shared/src/components/navigation/UserMenu.web.tsx
@@ -62,13 +62,17 @@ export function UserMenu({ user, profile }: UserMenuProps) {
       </button>
 
       {isOpen && (
-        <div className='absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50'>
+        <div className='absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 dark:ring-gray-700 z-50'>
           <div className='py-1'>
             {/* User name display */}
-            <div className='px-4 py-3 border-b border-gray-200'>
-              <p className='text-sm font-medium text-gray-900'>{displayName}</p>
+            <div className='px-4 py-3 border-b border-gray-200 dark:border-gray-700'>
+              <p className='text-sm font-medium text-gray-900 dark:text-white'>
+                {displayName}
+              </p>
               {user.email && (
-                <p className='text-xs text-gray-500 mt-1'>{user.email}</p>
+                <p className='text-xs text-gray-500 dark:text-gray-400 mt-1'>
+                  {user.email}
+                </p>
               )}
             </div>
 
@@ -76,14 +80,14 @@ export function UserMenu({ user, profile }: UserMenuProps) {
             <Link
               to='/profile'
               onClick={() => setIsOpen(false)}
-              className='block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100'
+              className='block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700'
             >
               Profile
             </Link>
             <Link
               to='/billing'
               onClick={() => setIsOpen(false)}
-              className='flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100'
+              className='flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700'
             >
               <CreditCard className='h-4 w-4 shrink-0' aria-hidden />
               Billing
@@ -91,14 +95,14 @@ export function UserMenu({ user, profile }: UserMenuProps) {
             <Link
               to='/dashboard'
               onClick={() => setIsOpen(false)}
-              className='block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100'
+              className='block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700'
             >
               Dashboard
             </Link>
-            <div className='my-1 border-t border-gray-200' />
+            <div className='my-1 border-t border-gray-200 dark:border-gray-700' />
             <button
               onClick={handleSignOut}
-              className='block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100'
+              className='block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700'
             >
               Sign Out
             </button>


### PR DESCRIPTION
Depends on #77 (merge that first).

## What's in this PR

This is the second of two PRs for issue #75. The foundation PR adds `darkMode: 'class'` to Tailwind config, the anti-FOUC script, and ThemeContext. This PR wires it up to every visible surface.

### New component

**`apps/web/src/components/ThemeToggle.tsx`**
Three-segment pill (☀ / ⊙ / ☾) wired to `useTheme().setTheme()`. Reads `preference` (not `resolvedTheme`) so the selected segment stays stable while OS preference is active in `system` mode.

### AppFooter

Added `ThemeToggle` as the last item in the legal nav. Footer background and border get `dark:bg-gray-900` / `dark:border-gray-700`; copyright and link text get `dark:text-gray-400` / `dark:hover:text-white`.

### Page-level backgrounds

`App.tsx`, `BillingPageShell`, `DashboardPage`, `ProfilePage`, `LoginPage`, `SignupPage`, `AuthCallbackPage` — all get `dark:bg-gray-900` on their outermost `min-h-screen` wrapper.

### Auth forms (LoginPage, SignupPage)

Form inputs: `dark:bg-gray-800 dark:border-gray-600 dark:text-white dark:placeholder-gray-400`.
Divider separator span: `dark:bg-gray-900` to blend with the page.
Error banners: `dark:bg-red-900/30 dark:text-red-300`.

### Card components

All white cards (`bg-white`) gain `dark:bg-gray-800` and `dark:border-gray-700`:
- `StatCard`, `PlanCard`, `CurrentPlanCard`, `InvoiceTable`, `InvoiceList`, `CadenceToggle`
- Table header row: `dark:bg-gray-700`; tbody row text: `dark:text-white` / `dark:text-gray-300`
- `CadenceToggle` inactive button: `dark:text-gray-400 dark:hover:text-white`

### Banner

`variantClass` map extended with dark pairs for all four variants using `dark:bg-{color}-950` / `dark:border-{color}-800` / `dark:text-{color}-100`.

### PolicyPage

`prose prose-gray` → `prose prose-gray dark:prose-invert`. Tailwind Typography's built-in class inverts all prose colors for dark mode with no per-element overrides needed.

### ProfilePage

White card sections (`bg-white shadow rounded-lg`) gain `dark:bg-gray-800`. Error state gets `dark:bg-red-900/30`.

### PricingSection

Already had dark: variants from a prior PR — no changes needed.

## Testing

1. Toggle the footer pill to Dark → every page should flip immediately (ThemeContext updates `<html>` class)
2. Toggle to System → matches OS, live-updates when OS preference changes
3. Reload in dark mode → no white flash (anti-FOUC from PR #77)
4. Check: LoginPage, SignupPage inputs readable on dark bg
5. Check: billing cards (PlanCard, StatCard, InvoiceTable) have correct dark backgrounds
6. Check: policy pages (Terms, Privacy, Refunds) readable in dark (prose-invert)