### PR TITLE
Release: staging → production — dark mode, SEO prerender, optional mobile

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -146,23 +146,44 @@ jobs:
             --environment prod \
             --region "${AWS_REGION_VALUE}"
 
+  deploy-mobile-production:
+    if: vars.MOBILE_ENABLED != 'false'
+    needs: [deploy-production]
+    runs-on: ubuntu-latest
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
+      EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.PRODUCTION_SUPABASE_URL }}
+      EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PRODUCTION_SUPABASE_ANON_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Deploy mobile to production
         id: mobile
         shell: bash
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-          EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
-          EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.PRODUCTION_SUPABASE_URL }}
-          EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PRODUCTION_SUPABASE_ANON_KEY }}
         run: |
           set -euo pipefail
           EXPO_ACCOUNT_VALUE="${{ vars.EXPO_ACCOUNT }}"
           if [[ -z "${EXPO_ACCOUNT_VALUE}" ]]; then
-            echo "Warning: EXPO_ACCOUNT not set, skipping mobile deployment"
-            exit 0
+            if [[ "${{ vars.MOBILE_ENABLED }}" == "true" ]]; then
+              echo "::error::EXPO_ACCOUNT variable is not set but MOBILE_ENABLED=true. Set vars.MOBILE_ENABLED=false to disable mobile, or provide EXPO_ACCOUNT."
+              exit 1
+            else
+              echo "Warning: EXPO_ACCOUNT not set, skipping mobile deployment"
+              exit 0
+            fi
           fi
           ./scripts/pr-preview/deploy-mobile-production.sh \
             --expo-account "${EXPO_ACCOUNT_VALUE}" \
             --platform all \
             --message "Production deployment from ${GITHUB_SHA:0:7}"
-

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -146,23 +146,44 @@ jobs:
             --environment staging \
             --region "${AWS_REGION_VALUE}"
 
+  deploy-mobile-staging:
+    if: vars.MOBILE_ENABLED != 'false'
+    needs: [deploy-staging]
+    runs-on: ubuntu-latest
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
+      EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+      EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Deploy mobile to staging
         id: mobile
         shell: bash
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-          EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
-          EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
-          EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
         run: |
           set -euo pipefail
           EXPO_ACCOUNT_VALUE="${{ vars.EXPO_ACCOUNT }}"
           if [[ -z "${EXPO_ACCOUNT_VALUE}" ]]; then
-            echo "Warning: EXPO_ACCOUNT not set, skipping mobile deployment"
-            exit 0
+            if [[ "${{ vars.MOBILE_ENABLED }}" == "true" ]]; then
+              echo "::error::EXPO_ACCOUNT variable is not set but MOBILE_ENABLED=true. Set vars.MOBILE_ENABLED=false to disable mobile, or provide EXPO_ACCOUNT."
+              exit 1
+            else
+              echo "Warning: EXPO_ACCOUNT not set, skipping mobile deployment"
+              exit 0
+            fi
           fi
           ./scripts/pr-preview/deploy-mobile-staging.sh \
             --expo-account "${EXPO_ACCOUNT_VALUE}" \
             --platform all \
             --message "Staging deployment from ${GITHUB_SHA:0:7}"
-

--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -103,7 +103,8 @@ jobs:
             --domain "${PREVIEW_DOMAIN}" \
             --hosted-zone-id "${PREVIEW_HOSTED_ZONE_ID}" \
             --certificate-arn "${PREVIEW_CERTIFICATE_ARN}" \
-            --preview-prefix "${PREVIEW_PREFIX_VALUE}"
+            --preview-prefix "${PREVIEW_PREFIX_VALUE}" \
+            --skip-cloudfront-function-publish
 
       - name: Prepare Supabase preview database
         id: supabase
@@ -191,6 +192,25 @@ jobs:
             --environment preview \
             --preview-prefix "${PREVIEW_PREFIX_VALUE}" \
             --region "${AWS_REGION_VALUE}"
+
+      # Publish edge routing only after a successful web build so a failed deploy cannot
+      # replace live CloudFront function code while leaving stale or missing S3 assets.
+      - name: Publish PR path router (CloudFront)
+        if: steps.web.outcome == 'success'
+        shell: bash
+        run: |
+          set -euo pipefail
+          STACK_NAME="${PREVIEW_STACK_NAME:-beakerstack-pr-preview}"
+          AWS_REGION_VALUE="${PREVIEW_AWS_REGION:-us-east-1}"
+          PREVIEW_PREFIX_VALUE="${PREVIEW_PREFIX:-pr-}"
+          ./scripts/pr-preview/bootstrap-aws-stack.sh \
+            --stack-name "${STACK_NAME}" \
+            --region "${AWS_REGION_VALUE}" \
+            --domain "${PREVIEW_DOMAIN}" \
+            --hosted-zone-id "${PREVIEW_HOSTED_ZONE_ID}" \
+            --certificate-arn "${PREVIEW_CERTIFICATE_ARN}" \
+            --preview-prefix "${PREVIEW_PREFIX_VALUE}" \
+            --if-stack-exists refresh-outputs
 
       - name: Check for native code changes
         id: native-changes

--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -193,8 +193,6 @@ jobs:
             --preview-prefix "${PREVIEW_PREFIX_VALUE}" \
             --region "${AWS_REGION_VALUE}"
 
-      # Publish edge routing only after a successful web build so a failed deploy cannot
-      # replace live CloudFront function code while leaving stale or missing S3 assets.
       - name: Publish PR path router (CloudFront)
         if: steps.web.outcome == 'success'
         shell: bash
@@ -212,12 +210,37 @@ jobs:
             --preview-prefix "${PREVIEW_PREFIX_VALUE}" \
             --if-stack-exists refresh-outputs
 
+  deploy-preview-mobile:
+    if: github.event.action != 'closed' && needs.preview-scope.outputs.run_deploy == 'true' && (github.base_ref != 'develop' || github.head_ref != 'main') && vars.MOBILE_ENABLED != 'false'
+    needs: [preview-scope, deploy-preview]
+    runs-on: ubuntu-latest
+    outputs:
+      mobile-channel: ${{ steps.mobile.outputs.PREVIEW_MOBILE_CHANNEL }}
+      mobile-update-url: ${{ steps.mobile.outputs.PREVIEW_MOBILE_UPDATE_URL }}
+      mobile-ios-download-url: ${{ steps.mobile.outputs.PREVIEW_MOBILE_IOS_DOWNLOAD_URL }}
+      mobile-android-download-url: ${{ steps.mobile.outputs.PREVIEW_MOBILE_ANDROID_DOWNLOAD_URL }}
+      needs-native-build: ${{ steps.native-changes.outputs.needs_native_build }}
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Check for native code changes
         id: native-changes
         shell: bash
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
           set -euo pipefail
           BASE_REF="origin/${{ github.base_ref }}"
@@ -237,7 +260,6 @@ jobs:
           EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
           EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.PREVIEW_SUPABASE_URL }}
           EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PREVIEW_SUPABASE_ANON_KEY }}
-          # Google Services variables (needed for google-services.json generation)
           GOOGLE_SERVICES_PROJECT_NUMBER: ${{ secrets.GOOGLE_SERVICES_PROJECT_NUMBER }}
           GOOGLE_SERVICES_PROJECT_ID: ${{ secrets.GOOGLE_SERVICES_PROJECT_ID }}
           GOOGLE_SERVICES_STORAGE_BUCKET: ${{ secrets.GOOGLE_SERVICES_STORAGE_BUCKET }}
@@ -252,8 +274,13 @@ jobs:
           PR_NUMBER_VALUE="${PR_NUMBER}"
           EXPO_ACCOUNT_VALUE="${{ vars.EXPO_ACCOUNT }}"
           if [[ -z "${EXPO_ACCOUNT_VALUE}" ]]; then
-            echo "Warning: EXPO_ACCOUNT not set, skipping mobile deployment"
-            exit 0
+            if [[ "${{ vars.MOBILE_ENABLED }}" == "true" ]]; then
+              echo "::error::EXPO_ACCOUNT variable is not set but MOBILE_ENABLED=true. Set vars.MOBILE_ENABLED=false to disable mobile, or provide EXPO_ACCOUNT."
+              exit 1
+            else
+              echo "Warning: EXPO_ACCOUNT not set, skipping mobile deployment"
+              exit 0
+            fi
           fi
           BUILD_NATIVE_FLAG=""
           if [[ "${{ steps.native-changes.outputs.needs_native_build }}" == "true" ]]; then
@@ -268,21 +295,33 @@ jobs:
             --platform all \
             ${BUILD_NATIVE_FLAG}
 
+  comment:
+    if: always() && needs.deploy-preview.result == 'success'
+    needs: [deploy-preview, deploy-preview-mobile]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
       - name: Post preview summary comment
-        if: always()
         uses: actions/github-script@v7
         env:
-          WEB_URL: ${{ steps.web.outputs.PREVIEW_WEB_URL }}
-          MOBILE_CHANNEL: ${{ steps.mobile.outputs.PREVIEW_MOBILE_CHANNEL }}
-          MOBILE_UPDATE_URL: ${{ steps.mobile.outputs.PREVIEW_MOBILE_UPDATE_URL }}
-          MOBILE_IOS_DOWNLOAD_URL: ${{ steps.mobile.outputs.PREVIEW_MOBILE_IOS_DOWNLOAD_URL }}
-          MOBILE_ANDROID_DOWNLOAD_URL: ${{ steps.mobile.outputs.PREVIEW_MOBILE_ANDROID_DOWNLOAD_URL }}
-          NEEDS_NATIVE_BUILD: ${{ steps.native-changes.outputs.needs_native_build }}
-          MOBILE_DEPLOY_OUTCOME: ${{ steps.mobile.outcome }}
+          PREVIEW_DOMAIN: ${{ vars.PR_PREVIEW_DOMAIN }}
+          PREVIEW_PREFIX: ${{ vars.PR_PREVIEW_PREFIX }}
+          MOBILE_JOB_RESULT: ${{ needs.deploy-preview-mobile.result }}
+          MOBILE_CHANNEL: ${{ needs.deploy-preview-mobile.outputs.mobile-channel }}
+          MOBILE_UPDATE_URL: ${{ needs.deploy-preview-mobile.outputs.mobile-update-url }}
+          MOBILE_IOS_DOWNLOAD_URL: ${{ needs.deploy-preview-mobile.outputs.mobile-ios-download-url }}
+          MOBILE_ANDROID_DOWNLOAD_URL: ${{ needs.deploy-preview-mobile.outputs.mobile-android-download-url }}
+          NEEDS_NATIVE_BUILD: ${{ needs.deploy-preview-mobile.outputs.needs-native-build }}
         with:
           script: |
             const marker = '<!-- pr-preview-links -->';
-            const webUrl = process.env.WEB_URL;
+            const domain = process.env.PREVIEW_DOMAIN;
+            const prefix = process.env.PREVIEW_PREFIX || 'pr-';
+            const prNumber = context.payload.pull_request.number;
+            const webUrl = domain ? `https://deploy.${domain}/${prefix}${prNumber}/` : '';
+            const mobileJobResult = process.env.MOBILE_JOB_RESULT;
             const mobileChannel = process.env.MOBILE_CHANNEL;
             const mobileUpdateUrl = process.env.MOBILE_UPDATE_URL;
 
@@ -291,7 +330,12 @@ jobs:
             if (webUrl) {
               lines.push(`🌐 **Web preview:** ${webUrl}`);
             }
-            if (mobileUpdateUrl) {
+            if (mobileJobResult === 'skipped') {
+              // Mobile disabled via MOBILE_ENABLED=false — omit mobile section
+            } else if (mobileJobResult === 'failure') {
+              lines.push('');
+              lines.push('❌ **Mobile preview failed.** Check the **deploy-preview-mobile** job logs for details.');
+            } else if (mobileUpdateUrl) {
               const iosDownloadUrl = process.env.MOBILE_IOS_DOWNLOAD_URL;
               const androidDownloadUrl = process.env.MOBILE_ANDROID_DOWNLOAD_URL;
               const needsNativeBuild = process.env.NEEDS_NATIVE_BUILD === 'true';
@@ -325,21 +369,11 @@ jobs:
               } else if (needsNativeBuild) {
                 lines.push('### 📱 Mobile Preview Builds');
                 lines.push('');
-                const mobileOutcome = process.env.MOBILE_DEPLOY_OUTCOME || '';
-                if (mobileOutcome === 'failure') {
-                  lines.push('❌ **Native preview build failed in CI.**');
-                  lines.push('');
-                  lines.push('The OTA update may still be on the channel above. Open the **deploy-preview** workflow run for this PR and inspect the **Deploy mobile preview** step logs (EAS / Expo errors, `google-services.json`, etc.).');
-                  lines.push('');
-                  lines.push('Re-run the workflow after fixing the failure; the PR comment will update when the job succeeds.');
-                  lines.push('');
-                } else {
-                  lines.push('⚠️ **Native build in progress or not finished in this job...**');
-                  lines.push('');
-                  lines.push('Native code changes were detected. If the **deploy-preview** job is still running, EAS builds may take 10–15 minutes after the job completes.');
-                  lines.push('If the job already finished without download links, check the workflow logs and the [Expo builds dashboard](https://expo.dev/accounts/artificer-innovations-llc/projects/beaker-stack/builds).');
-                  lines.push('');
-                }
+                lines.push('⚠️ **Native build in progress or not finished...**');
+                lines.push('');
+                lines.push('Native code changes were detected. EAS builds may take 10–15 minutes after the **deploy-preview-mobile** job completes.');
+                lines.push('If the job already finished without download links, check the workflow logs and the [Expo builds dashboard](https://expo.dev/accounts/artificer-innovations-llc/projects/beaker-stack/builds).');
+                lines.push('');
               } else {
                 lines.push('### 📱 Mobile Preview (OTA Updates)');
                 lines.push('');

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -101,7 +101,7 @@ npm run docs:actions-secrets
 
 Commit any updates to `docs/reference/github-actions-secrets.md` when you change `scripts/lib/setup-manifest.mjs`.
 
-At minimum for deploy workflows you will need **`SUPABASE_ACCESS_TOKEN`**, **`EXPO_TOKEN`**, and **AWS access keys** (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, plus optional `AWS_SESSION_TOKEN`), plus the Supabase URL/keys and project refs for each tier—see the generated table.
+At minimum for deploy workflows you will need **`SUPABASE_ACCESS_TOKEN`** and **AWS access keys** (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, plus optional `AWS_SESSION_TOKEN`), plus the Supabase URL/keys and project refs for each tier—see the generated table. **`EXPO_TOKEN`**, `EXPO_PROJECT_ID`, `EXPO_ACCOUNT`, and all `GOOGLE_SERVICES_*` entries are mobile-only; set `MOBILE_ENABLED=false` (GitHub variable) to skip them for web-only repos.
 
 ### 6.2 Full interactive bootstrap
 
@@ -117,6 +117,7 @@ Options (see also `npm run setup:full -- --help`):
 | `--from=PHASE`       | Resume at a phase (see table below)  |
 | `--skip-rename`      | Skip template rename                 |
 | `--skip-github`      | Do not push secrets with `gh`        |
+| `--skip-mobile`      | Skip Expo/EAS/Google setup (web-only repos) |
 | `--aws-profile=NAME` | Pass through to AWS bootstrap script |
 
 **Phase names** for `--from=` (order matters; later phases assume earlier work or merged `.env*` files):

--- a/apps/web/__tests__/App.test.tsx
+++ b/apps/web/__tests__/App.test.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeAll } from 'vitest';
 import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
+import { ThemeProvider } from '../src/contexts/ThemeContext';
 import App from '../src/App';
 
 // Mock environment variables to prevent real Supabase client creation
@@ -90,13 +91,15 @@ const mockSupabaseClient = {
 
 function renderApp() {
   return render(
-    <AuthProvider supabaseClient={mockSupabaseClient}>
-      <ProfileProvider supabaseClient={mockSupabaseClient}>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </ProfileProvider>
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider supabaseClient={mockSupabaseClient}>
+        <ProfileProvider supabaseClient={mockSupabaseClient}>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </ProfileProvider>
+      </AuthProvider>
+    </ThemeProvider>
   );
 }
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,6 +5,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>%APP_TITLE%</title>
 
+    <!-- Anti-FOUC: apply dark class before first paint.
+         Reads stored user preference first; falls back to OS preference.
+         try/catch guards against CSP or private-browsing environments. -->
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem('beakerstack:theme');
+          var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          if (stored === 'dark' || (stored !== 'light' && prefersDark)) {
+            document.documentElement.classList.add('dark');
+          }
+        } catch (_) {}
+      })();
+    </script>
+
     <!-- Site-wide meta — canonical and og:url are home-only and are injected into
          prerender-home.html by scripts/prerender-home.ts; adding them here would
          incorrectly set home-page values on /dashboard, /login, etc. -->

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,21 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>%APP_TITLE%</title>
-    
+
+    <!-- Site-wide meta — canonical and og:url are home-only and are injected into
+         prerender-home.html by scripts/prerender-home.ts; adding them here would
+         incorrectly set home-page values on /dashboard, /login, etc. -->
+    <meta name="description" content="BeakerStack gives you auth, billing, and a cross-platform React foundation — ready to ship your SaaS." />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="BeakerStack — Ship your SaaS faster." />
+    <meta property="og:description" content="Everything you need to ship a real product. Auth, billing, and cross-platform React with a production CI/CD pipeline." />
+    <!-- Shipped icon until a dedicated 1200×630 og-image asset exists. -->
+    <meta property="og:image" content="https://beakerstack.com/android-chrome-512x512.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="BeakerStack — Ship your SaaS faster." />
+    <meta name="twitter:description" content="Everything you need to ship a real product." />
+    <meta name="twitter:image" content="https://beakerstack.com/android-chrome-512x512.png" />
+
     <!-- Favicons for all browsers -->
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && vite-node scripts/prerender-home.ts",
     "preview": "vite preview",
     "test": "vitest --run",
     "test:watch": "vitest --watch",
@@ -46,6 +46,7 @@
     "tailwindcss": "^3.3.0",
     "typescript": "^5.3.0",
     "vite": "^6.4.2",
+    "vite-node": "^3.2.4",
     "vitest": "^3.2.4"
   }
 }

--- a/apps/web/scripts/prerender-home.ts
+++ b/apps/web/scripts/prerender-home.ts
@@ -1,0 +1,102 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { join, dirname } from 'path';
+
+// Shim WebSocket for Node < 22 before any app module loads.
+// supabase-js checks globalThis.WebSocket at createClient() time (module load, not runtime).
+// renderToStaticMarkup never opens a socket, but the check throws on Node 20 without this.
+// Dynamic imports below ensure this assignment runs first (static imports are hoisted).
+if (typeof globalThis.WebSocket === 'undefined') {
+  (globalThis as any).WebSocket = class WebSocket {
+    constructor(_url: string) {}
+    close() {}
+    addEventListener() {}
+    removeEventListener() {}
+  };
+}
+
+const { createElement } = await import('react');
+const { renderToStaticMarkup } = await import('react-dom/server');
+// MemoryRouter comes from the same react-router-dom instance as <Link> and other
+// router-aware components in LandingPage, so they share the same NavigationContext.
+// StaticRouter (from react-router-dom/server) is a separate sub-package with its
+// own bundled context, causing a null-context mismatch in vite-node's module graph.
+const { MemoryRouter } = await import('react-router-dom');
+const { LandingPage } = await import('../src/components/landing/LandingPage');
+
+const webRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Public home URL for canonical / og:url (set by deploy-web.sh per environment).
+const siteOrigin = (
+  process.env.VITE_PUBLIC_SITE_ORIGIN ?? 'https://beakerstack.com'
+).replace(/\/$/, '');
+let basePath = process.env.VITE_BASE_PATH ?? '/';
+if (!basePath.startsWith('/')) basePath = `/${basePath}`;
+basePath = basePath.replace(/\/+$/, '');
+const homePath = basePath === '' ? '/' : `${basePath}/`;
+const publicHomeUrl = `${siteOrigin}${homePath === '/' ? '/' : homePath}`;
+
+const routerBasename =
+  basePath === '' || basePath === '/' ? undefined : basePath;
+
+// MemoryRouter matches locations against basename: with basename "/pr-N", "/" does not
+// match (RR warns and renders nothing). Use the same pathname as publicHomeUrl path.
+const initialEntries = [homePath];
+
+const html = renderToStaticMarkup(
+  createElement(
+    MemoryRouter,
+    { basename: routerBasename, initialEntries },
+    createElement(LandingPage)
+  )
+);
+
+// Structural smoke check — catches a broken render without hardcoding copy text.
+// Fails the build if LandingPage produced no heading element.
+if (!html.includes('<h1')) {
+  console.error(
+    'pre-render smoke check: no <h1> in output — LandingPage did not render'
+  );
+  process.exit(1);
+}
+
+const template = readFileSync(join(webRoot, 'dist', 'index.html'), 'utf8');
+
+// canonical and og:url are home-only; inject here rather than in the base
+// template which is also served as the SPA fallback for all other routes.
+const withHomeMeta = template.replace(
+  '</head>',
+  [
+    `  <link rel="canonical" href="${publicHomeUrl}" />`,
+    `  <meta property="og:url" content="${publicHomeUrl}" />`,
+    '  </head>',
+  ].join('\n')
+);
+
+if (
+  withHomeMeta === template ||
+  !withHomeMeta.includes('rel="canonical"') ||
+  !withHomeMeta.includes('property="og:url"')
+) {
+  console.error(
+    'pre-render smoke check: </head> injection failed — dist/index.html may be missing </head> or markup changed'
+  );
+  process.exit(1);
+}
+
+const out = withHomeMeta.replace(
+  '<div id="root"></div>',
+  `<div id="root">${html}</div>`
+);
+
+// Verify the mount-point injection landed — catches a silent no-op if the
+// root div markup ever changes (e.g. id renamed from "root" to "app").
+if (out.includes('<div id="root"></div>')) {
+  console.error(
+    'pre-render smoke check: mount point injection failed — <div id="root"></div> still empty in output'
+  );
+  process.exit(1);
+}
+
+writeFileSync(join(webRoot, 'dist', 'prerender-home.html'), out);
+console.log(`pre-render complete — ${html.length} chars`);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,7 +29,7 @@ function RootLayout() {
 
 function App() {
   return (
-    <div className='bg-gray-50'>
+    <div className='bg-gray-50 dark:bg-gray-900'>
       <Routes>
         <Route element={<RootLayout />}>
           <Route

--- a/apps/web/src/auth/__tests__/planSignupBullets.meterCopy.test.ts
+++ b/apps/web/src/auth/__tests__/planSignupBullets.meterCopy.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+function mockConfig(overrides: {
+  usageMeterCopy: Record<string, { label?: string }>;
+  plans: Array<{
+    id: string;
+    trialPeriodDays: number;
+    features: Record<string, unknown>;
+    usageLimits?: { ai_summarize?: number };
+  }>;
+}) {
+  vi.doMock('../../billing/beakerstackBillingConfig', () => ({
+    beakerstackBillingConfig: {
+      plans: overrides.plans,
+      planFeatureRows: [],
+      usageMeterCopy: overrides.usageMeterCopy,
+    },
+  }));
+}
+
+describe('planSignupBullets (AI meter label branches)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock('../../billing/beakerstackBillingConfig');
+    vi.resetModules();
+  });
+
+  it('uses meter label for unlimited AI when configured', async () => {
+    mockConfig({
+      usageMeterCopy: { ai_summarize: { label: 'Summaries' } },
+      plans: [
+        {
+          id: 'meter_label',
+          trialPeriodDays: 0,
+          features: {},
+          usageLimits: { ai_summarize: -1 },
+        },
+      ],
+    });
+    const { planSignupBullets } = await import('../planSignupBullets');
+    expect(planSignupBullets('meter_label')).toContain('Unlimited Summaries');
+  });
+
+  it('falls back for unlimited AI when meter label is absent', async () => {
+    mockConfig({
+      usageMeterCopy: {},
+      plans: [
+        {
+          id: 'meter_ul',
+          trialPeriodDays: 0,
+          features: {},
+          usageLimits: { ai_summarize: -1 },
+        },
+      ],
+    });
+    const { planSignupBullets } = await import('../planSignupBullets');
+    expect(planSignupBullets('meter_ul')).toContain('Unlimited AI summarize');
+  });
+
+  it('formats finite AI usage without a meter label', async () => {
+    mockConfig({
+      usageMeterCopy: {},
+      plans: [
+        {
+          id: 'meter_fin',
+          trialPeriodDays: 0,
+          features: {},
+          usageLimits: { ai_summarize: 12 },
+        },
+      ],
+    });
+    const { planSignupBullets } = await import('../planSignupBullets');
+    expect(planSignupBullets('meter_fin')).toContain(
+      '12 AI summarize requests / billing period'
+    );
+  });
+
+  it('formats finite AI usage with a meter label', async () => {
+    mockConfig({
+      usageMeterCopy: { ai_summarize: { label: 'Summaries' } },
+      plans: [
+        {
+          id: 'meter_finite',
+          trialPeriodDays: 0,
+          features: {},
+          usageLimits: { ai_summarize: 7 },
+        },
+      ],
+    });
+    const { planSignupBullets } = await import('../planSignupBullets');
+    expect(planSignupBullets('meter_finite')).toContain(
+      '7 Summaries / billing period'
+    );
+  });
+});

--- a/apps/web/src/auth/__tests__/postAuthRedirect.test.ts
+++ b/apps/web/src/auth/__tests__/postAuthRedirect.test.ts
@@ -7,6 +7,7 @@ import {
   serializePostAuthRedirectPayload,
   validateInternalPostAuthPath,
   POST_AUTH_REDIRECT_TTL_MS,
+  clearPostAuthRedirectKeys,
 } from '../postAuthRedirect';
 
 const ORIGIN = 'http://localhost:5173';
@@ -16,6 +17,23 @@ describe('validateInternalPostAuthPath', () => {
     expect(validateInternalPostAuthPath('/billing/plans?plan=x', ORIGIN)).toBe(
       '/billing/plans?plan=x'
     );
+  });
+
+  it('defaults origin when window is undefined', () => {
+    vi.stubGlobal('window', undefined as unknown as Window & typeof globalThis);
+    expect(validateInternalPostAuthPath('/dashboard')).toBe('/dashboard');
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects empty or non-string paths', () => {
+    expect(validateInternalPostAuthPath('', ORIGIN)).toBeNull();
+    expect(
+      validateInternalPostAuthPath(null as unknown as string, ORIGIN)
+    ).toBeNull();
+  });
+
+  it('returns null when URL parsing fails', () => {
+    expect(validateInternalPostAuthPath('/ok', 'http://[')).toBeNull();
   });
 
   it('rejects protocol-relative //evil.com', () => {
@@ -94,6 +112,23 @@ describe('parseStoredPostAuthRedirect', () => {
       parseStoredPostAuthRedirect('not-json', Date.now(), ORIGIN)
     ).toBeNull();
   });
+
+  it('returns null for JSON missing structured fields', () => {
+    expect(
+      parseStoredPostAuthRedirect(
+        JSON.stringify({ path: '/ok' }),
+        Date.now(),
+        ORIGIN
+      )
+    ).toBeNull();
+    expect(
+      parseStoredPostAuthRedirect(
+        JSON.stringify({ ts: 1, path: 123 }),
+        Date.now(),
+        ORIGIN
+      )
+    ).toBeNull();
+  });
 });
 
 function storageMock(store: Record<string, string>) {
@@ -137,5 +172,31 @@ describe('readAndClearPostAuthRedirect', () => {
     memS[POST_AUTH_REDIRECT_KEY] = serializePostAuthRedirectPayload(a);
     memL[POST_AUTH_REDIRECT_KEY] = serializePostAuthRedirectPayload(b);
     expect(readAndClearPostAuthRedirect()).toBe(a);
+  });
+
+  it('parses localStorage when sessionStorage payload is invalid JSON', () => {
+    const dest = '/billing/plans?plan=beakerstack_max&welcome=1';
+    memS[POST_AUTH_REDIRECT_KEY] = '{broken';
+    memL[POST_AUTH_REDIRECT_KEY] = serializePostAuthRedirectPayload(dest);
+    expect(readAndClearPostAuthRedirect()).toBe(dest);
+  });
+
+  it('falls back to localStorage when sessionStorage is unavailable', () => {
+    vi.stubGlobal('sessionStorage', undefined as unknown as Storage);
+    const path = '/billing/plans?plan=beakerstack_pro&welcome=1';
+    memL[POST_AUTH_REDIRECT_KEY] = serializePostAuthRedirectPayload(path);
+    expect(readAndClearPostAuthRedirect()).toBe(path);
+  });
+});
+
+describe('clearPostAuthRedirectKeys', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('no-ops when storage globals are missing', () => {
+    vi.stubGlobal('sessionStorage', undefined as unknown as Storage);
+    vi.stubGlobal('localStorage', undefined as unknown as Storage);
+    expect(() => clearPostAuthRedirectKeys()).not.toThrow();
   });
 });

--- a/apps/web/src/billing/__tests__/billingSyncDisplay.test.ts
+++ b/apps/web/src/billing/__tests__/billingSyncDisplay.test.ts
@@ -80,6 +80,32 @@ describe('billingSyncDisplay', () => {
     expect(annualSavingsPercentForPlan('unknown_plan', 0)).toBeNull();
   });
 
+  it('annualSavingsPercentForPlan returns null when annual price equals monthly×12', () => {
+    expect(annualSavingsPercentForPlan('unknown_plan', 1000)).toBeNull();
+  });
+
+  it('cadenceAnnualSavingsFromPlans returns none when there are no paid plans', () => {
+    const plans: Plan[] = [
+      {
+        id: 'beakerstack_free',
+        product_id: 'beakerstack',
+        display_name: 'Free',
+        description: null,
+        price_cents: 0,
+        billing_period: 'free',
+        stripe_price_id_monthly: null,
+        stripe_price_id_annual: null,
+        stripe_product_id: null,
+        features: {},
+        usage_limits: {},
+        trial_period_days: 0,
+        is_public: true,
+        display_order: 1,
+      },
+    ];
+    expect(cadenceAnnualSavingsFromPlans(plans)).toEqual({ kind: 'none' });
+  });
+
   it('cadenceAnnualSavingsFromPlans aggregates paid plans', () => {
     const plans: Plan[] = [
       {

--- a/apps/web/src/billing/__tests__/formatters.test.ts
+++ b/apps/web/src/billing/__tests__/formatters.test.ts
@@ -14,6 +14,10 @@ describe('formatMoneyCents', () => {
     expect(formatMoneyCents(100, 'eur')).toMatch(/€|EUR/);
   });
 
+  it('uses USD when currency code is not length 3', () => {
+    expect(formatMoneyCents(100, 'US')).toMatch(/\$1\.00/);
+  });
+
   it('falls back when Intl.NumberFormat throws', () => {
     vi.spyOn(Intl, 'NumberFormat').mockImplementation(() => {
       throw new Error('unsupported');

--- a/apps/web/src/billing/__tests__/planPresentation.test.ts
+++ b/apps/web/src/billing/__tests__/planPresentation.test.ts
@@ -228,6 +228,24 @@ describe('exclusiveBooleanFeaturePlanName', () => {
     expect(exclusiveBooleanFeaturePlanName(plans, 'feature_b')).toBe('High');
   });
 
+  it('sorts holders treating missing display_order as zero', () => {
+    const ranked = [
+      basePlan({
+        id: 'lo',
+        display_name: 'Low',
+        display_order: undefined,
+        features: { feature_x: true },
+      }),
+      basePlan({
+        id: 'hi',
+        display_name: 'Hi',
+        display_order: 5,
+        features: { feature_x: true },
+      }),
+    ] as Plan[];
+    expect(exclusiveBooleanFeaturePlanName(ranked, 'feature_x')).toBe('Hi');
+  });
+
   it('returns null when top holder has no display name', () => {
     const holderNoName = basePlan({
       id: 'top',
@@ -238,6 +256,16 @@ describe('exclusiveBooleanFeaturePlanName', () => {
     expect(
       exclusiveBooleanFeaturePlanName([holderNoName], 'feature_b')
     ).toBeNull();
+  });
+
+  it('returns null when display_name is undefined after sort', () => {
+    const holder = basePlan({
+      id: 'top',
+      display_name: undefined as unknown as string,
+      display_order: 5,
+      features: { feature_z: true },
+    });
+    expect(exclusiveBooleanFeaturePlanName([holder], 'feature_z')).toBeNull();
   });
 });
 
@@ -271,5 +299,13 @@ describe('mergeUsageLimitsCopy', () => {
     );
     expect(m.collectionsRowName).toBe('Cols');
     expect(m.itemsRowName).toContain('Items');
+  });
+
+  it('treats null usageLimitsCopy like empty overrides', () => {
+    const m = mergeUsageLimitsCopy({
+      ...minimalConfig(),
+      usageLimitsCopy: null,
+    } as unknown as ProductBillingConfig);
+    expect(m.collectionsRowName).toContain('Collections');
   });
 });

--- a/apps/web/src/billing/__tests__/useDemoCollectionCount.test.tsx
+++ b/apps/web/src/billing/__tests__/useDemoCollectionCount.test.tsx
@@ -44,6 +44,16 @@ describe('useDemoCollectionCount', () => {
     expect(result.current.maxItemsInAnyCollection).toBe(0);
   });
 
+  it('uses 0 max items when collections list is empty', async () => {
+    rpc.mockResolvedValue({ data: [], error: null });
+    const { result } = renderHook(() => useDemoCollectionCount());
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.count).toBe(0);
+    expect(result.current.maxItemsInAnyCollection).toBe(0);
+  });
+
   it('refresh refetches and updates max items', async () => {
     rpc
       .mockResolvedValueOnce({

--- a/apps/web/src/billing/__tests__/useDemoCollections.test.tsx
+++ b/apps/web/src/billing/__tests__/useDemoCollections.test.tsx
@@ -58,6 +58,16 @@ describe('useDemoCollections', () => {
     expect(result.current.collections).toEqual([]);
   });
 
+  it('surfaces Error message when fetch fails with Error', async () => {
+    rpc.mockRejectedValue(new Error('network'));
+    const { result } = renderHook(() => useDemoCollections());
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.error).toBe('network');
+    expect(result.current.collections).toEqual([]);
+  });
+
   it('refresh refetches after initial load', async () => {
     rpc
       .mockResolvedValueOnce({

--- a/apps/web/src/components/AppFooter.tsx
+++ b/apps/web/src/components/AppFooter.tsx
@@ -1,35 +1,40 @@
 import { Link } from 'react-router-dom';
 import { LEGAL_CONFIG } from '@beakerstack/shared/config/legal';
+import { ThemeToggle } from './ThemeToggle';
 
 export function AppFooter() {
   const year = new Date().getFullYear();
 
   return (
-    <footer className='border-t border-gray-200 bg-white'>
+    <footer className='border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900'>
       <div className='max-w-[1024px] mx-auto px-4 py-6 sm:px-6 lg:px-8'>
         <div className='flex flex-col items-center gap-3 sm:flex-row sm:justify-between'>
-          <p className='text-sm text-gray-500'>
+          <p className='text-sm text-gray-500 dark:text-gray-400'>
             &copy; {year} {LEGAL_CONFIG.legalEntityName}. All rights reserved.
           </p>
-          <nav className='flex gap-6' aria-label='Legal'>
+          <nav
+            className='flex flex-wrap items-center gap-4 sm:gap-6'
+            aria-label='Legal'
+          >
             <Link
               to='/terms'
-              className='text-sm text-gray-500 hover:text-gray-900 transition-colors'
+              className='text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors'
             >
               Terms of Service
             </Link>
             <Link
               to='/privacy'
-              className='text-sm text-gray-500 hover:text-gray-900 transition-colors'
+              className='text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors'
             >
               Privacy Policy
             </Link>
             <Link
               to='/refunds'
-              className='text-sm text-gray-500 hover:text-gray-900 transition-colors'
+              className='text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors'
             >
               Refund Policy
             </Link>
+            <ThemeToggle />
           </nav>
         </div>
       </div>

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,33 @@
+import { useTheme } from '../hooks/useTheme';
+import type { ThemePreference } from '../contexts/ThemeContext';
+
+const OPTIONS: { value: ThemePreference; label: string; icon: string }[] = [
+  { value: 'light', label: 'Light', icon: '☀' },
+  { value: 'system', label: 'System', icon: '⊙' },
+  { value: 'dark', label: 'Dark', icon: '☾' },
+];
+
+export function ThemeToggle() {
+  const { preference, setTheme } = useTheme();
+
+  return (
+    <div className='inline-flex items-center rounded-full border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 p-0.5'>
+      {OPTIONS.map(({ value, label, icon }) => (
+        <button
+          key={value}
+          type='button'
+          onClick={() => setTheme(value)}
+          aria-label={label}
+          title={label}
+          className={`rounded-full px-2 py-0.5 text-xs font-medium transition-colors ${
+            preference === value
+              ? 'bg-white dark:bg-gray-900 text-gray-900 dark:text-white shadow-sm'
+              : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
+          }`}
+        >
+          {icon}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/__tests__/AppFooter.test.tsx
+++ b/apps/web/src/components/__tests__/AppFooter.test.tsx
@@ -1,13 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from '../../contexts/ThemeContext';
 import { AppFooter } from '../AppFooter';
 
 function renderFooter() {
   return render(
-    <MemoryRouter>
-      <AppFooter />
-    </MemoryRouter>
+    <ThemeProvider>
+      <MemoryRouter>
+        <AppFooter />
+      </MemoryRouter>
+    </ThemeProvider>
   );
 }
 

--- a/apps/web/src/components/__tests__/ThemeToggle.test.tsx
+++ b/apps/web/src/components/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../contexts/ThemeContext';
+import { ThemeToggle } from '../ThemeToggle';
+
+function renderToggle() {
+  return render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>
+  );
+}
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('renders Light, System, and Dark buttons', () => {
+    renderToggle();
+    expect(screen.getByRole('button', { name: 'Light' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'System' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dark' })).toBeInTheDocument();
+  });
+
+  it('clicking Dark applies dark class to documentElement', async () => {
+    const user = userEvent.setup();
+    renderToggle();
+    await user.click(screen.getByRole('button', { name: 'Dark' }));
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('clicking Light removes dark class', async () => {
+    const user = userEvent.setup();
+    renderToggle();
+    await user.click(screen.getByRole('button', { name: 'Dark' }));
+    await user.click(screen.getByRole('button', { name: 'Light' }));
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('clicking System clears stored preference', async () => {
+    localStorage.setItem('beakerstack:theme', 'dark');
+    const user = userEvent.setup();
+    renderToggle();
+    await user.click(screen.getByRole('button', { name: 'System' }));
+    expect(localStorage.getItem('beakerstack:theme')).toBeNull();
+  });
+});

--- a/apps/web/src/components/auth/__tests__/SignupPlanSummary.test.tsx
+++ b/apps/web/src/components/auth/__tests__/SignupPlanSummary.test.tsx
@@ -34,6 +34,10 @@ vi.mock('../../billing/CadenceToggle.web', () => ({
   getCadenceFromSearch: vi.fn(() => 'monthly'),
 }));
 
+vi.mock('../../../auth/planSignupBullets', () => ({
+  planSignupBullets: vi.fn(() => ['First bullet', 'Second bullet']),
+}));
+
 vi.mock('../../../billing/billingSyncDisplay', () => ({
   annualListCentsFromSync: vi.fn(() => 22_800),
   formatSavingsCalloutFromCopy: vi.fn((copy: PlanSavingsCopy) =>
@@ -49,6 +53,7 @@ vi.mock('../../../billing/billingSyncDisplay', () => ({
 import { usePlanCatalog } from '@beakerstack/billing';
 import { getCadenceFromSearch } from '../../billing/CadenceToggle.web';
 import * as billingSync from '../../../billing/billingSyncDisplay';
+import { planSignupBullets } from '../../../auth/planSignupBullets';
 
 describe('PlanIntentSummary', () => {
   beforeEach(() => {
@@ -62,6 +67,10 @@ describe('PlanIntentSummary', () => {
     vi.mocked(billingSync.planAnnualSavingsCopy).mockReturnValue({
       kind: 'none',
     });
+    vi.mocked(planSignupBullets).mockReturnValue([
+      'First bullet',
+      'Second bullet',
+    ]);
   });
 
   it('renders nothing when plan query is missing', () => {
@@ -97,7 +106,7 @@ describe('PlanIntentSummary', () => {
     expect(screen.getByText('Your selection')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Pro' })).toBeInTheDocument();
     expect(screen.getByText(/per month/i)).toBeInTheDocument();
-    expect(screen.getByText(/Feature A/i)).toBeInTheDocument();
+    expect(screen.getByText(/First bullet/i)).toBeInTheDocument();
   });
 
   it('shows savings callout when annual cadence and copy exists', () => {
@@ -130,6 +139,16 @@ describe('PlanIntentSummary', () => {
       </MemoryRouter>
     );
     expect(container.firstChild).toBeNull();
+  });
+
+  it('omits bullet list when planSignupBullets returns empty', () => {
+    vi.mocked(planSignupBullets).mockReturnValue([]);
+    render(
+      <MemoryRouter initialEntries={['/signup?plan=beakerstack_pro']}>
+        <SignupPlanSummary />
+      </MemoryRouter>
+    );
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
   });
 
   it('uses compact login styling and fewer bullets', () => {

--- a/apps/web/src/components/billing/Banner.web.tsx
+++ b/apps/web/src/components/billing/Banner.web.tsx
@@ -3,10 +3,13 @@ import type { ReactNode } from 'react';
 export type BannerVariant = 'info' | 'success' | 'warning' | 'error';
 
 const variantClass: Record<BannerVariant, string> = {
-  info: 'bg-blue-50 border-blue-200 text-blue-900',
-  success: 'bg-green-50 border-green-200 text-green-900',
-  warning: 'bg-amber-50 border-amber-200 text-amber-900',
-  error: 'bg-red-50 border-red-200 text-red-900',
+  info: 'bg-blue-50 dark:bg-blue-950 border-blue-200 dark:border-blue-800 text-blue-900 dark:text-blue-100',
+  success:
+    'bg-green-50 dark:bg-green-950 border-green-200 dark:border-green-800 text-green-900 dark:text-green-100',
+  warning:
+    'bg-amber-50 dark:bg-amber-950 border-amber-200 dark:border-amber-800 text-amber-900 dark:text-amber-100',
+  error:
+    'bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800 text-red-900 dark:text-red-100',
 };
 
 export function Banner({

--- a/apps/web/src/components/billing/BillingPageShell.web.tsx
+++ b/apps/web/src/components/billing/BillingPageShell.web.tsx
@@ -10,7 +10,7 @@ export function BillingPageShell({
   maxWidthClass?: string;
 }): JSX.Element {
   return (
-    <div className='min-h-screen bg-gray-50'>
+    <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
       <AppHeader supabaseClient={supabase} />
       <div className={`mx-auto ${maxWidthClass} py-6 sm:px-6 lg:px-8`}>
         <div className='px-4 py-6 sm:px-0'>{children}</div>

--- a/apps/web/src/components/billing/CadenceToggle.web.tsx
+++ b/apps/web/src/components/billing/CadenceToggle.web.tsx
@@ -31,14 +31,14 @@ export function CadenceToggle() {
   );
   return (
     <div className='flex items-center justify-center gap-1'>
-      <div className='inline-flex rounded-full border border-gray-200 bg-white p-1 shadow-sm'>
+      <div className='inline-flex rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-1 shadow-sm'>
         <button
           type='button'
           onClick={() => set('monthly')}
           className={`rounded-full px-4 py-1.5 text-sm font-medium transition ${
             cadence === 'monthly'
               ? 'bg-indigo-600 text-white'
-              : 'text-gray-600 hover:text-gray-900'
+              : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
           }`}
         >
           Monthly
@@ -52,7 +52,7 @@ export function CadenceToggle() {
           className={`inline-flex min-h-[2.25rem] items-center justify-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition ${
             cadence === 'annual'
               ? 'bg-indigo-600 text-white'
-              : 'text-gray-600 hover:text-gray-900'
+              : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
           }`}
         >
           <span>Annually</span>

--- a/apps/web/src/components/billing/CurrentPlanCard.web.tsx
+++ b/apps/web/src/components/billing/CurrentPlanCard.web.tsx
@@ -40,31 +40,35 @@ export function CurrentPlanCard({
     : '—';
 
   return (
-    <div className='space-y-4 rounded-xl border border-gray-200 bg-white p-6 sm:p-8 shadow-sm'>
+    <div className='space-y-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 sm:p-8 shadow-sm'>
       {isFree ? (
         <>
-          <h2 className='text-2xl font-bold text-gray-900'>
+          <h2 className='text-2xl font-bold text-gray-900 dark:text-white'>
             You&apos;re on the Free plan
           </h2>
-          <p className='text-sm text-gray-600'>
+          <p className='text-sm text-gray-600 dark:text-gray-300'>
             Upgrade to unlock more capacity and features.
           </p>
         </>
       ) : (
         <>
           <div className='flex flex-wrap items-center gap-2'>
-            <h2 className='text-2xl font-bold text-gray-900'>
+            <h2 className='text-2xl font-bold text-gray-900 dark:text-white'>
               {plan.display_name}
             </h2>
             {subscription && (
               <SubscriptionStatusBadge subscription={subscription} />
             )}
           </div>
-          {priceLine && <p className='text-base text-gray-600'>{priceLine}</p>}
+          {priceLine && (
+            <p className='text-base text-gray-600 dark:text-gray-300'>
+              {priceLine}
+            </p>
+          )}
         </>
       )}
       {!isFree && subscription && (
-        <p className='text-sm text-gray-600'>
+        <p className='text-sm text-gray-600 dark:text-gray-300'>
           {periodSubcopy
             ? periodSubcopy
             : subscription.cancel_at_period_end

--- a/apps/web/src/components/billing/InvoiceList.web.tsx
+++ b/apps/web/src/components/billing/InvoiceList.web.tsx
@@ -17,23 +17,27 @@ export function InvoiceList({
   }
   const slice = items.slice(0, limit);
   return (
-    <div className='rounded-xl border border-gray-200 bg-white p-6 shadow-sm'>
-      <h2 className='text-lg font-semibold text-gray-900'>Recent activity</h2>
-      <ul className='mt-4 divide-y divide-gray-100'>
+    <div className='rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm'>
+      <h2 className='text-lg font-semibold text-gray-900 dark:text-white'>
+        Recent activity
+      </h2>
+      <ul className='mt-4 divide-y divide-gray-100 dark:divide-gray-700'>
         {slice.map(inv => (
           <li
             key={inv.id}
             className='flex items-center justify-between py-3 text-sm'
           >
             <div>
-              <p className='text-gray-900'>{formatDate(inv.created_at)}</p>
-              <p className='text-gray-500'>
+              <p className='text-gray-900 dark:text-white'>
+                {formatDate(inv.created_at)}
+              </p>
+              <p className='text-gray-500 dark:text-gray-400'>
                 {inv.description ?? 'Subscription'}
               </p>
             </div>
             <div className='flex items-center gap-2'>
               <StatusBadge status={inv.status} />
-              <span className='text-gray-900'>
+              <span className='text-gray-900 dark:text-white'>
                 {formatMoneyCents(
                   inv.amount_paid || inv.amount_due,
                   inv.currency

--- a/apps/web/src/components/billing/InvoiceTable.web.tsx
+++ b/apps/web/src/components/billing/InvoiceTable.web.tsx
@@ -23,8 +23,8 @@ export function InvoiceTable({
   }
   if (!loading && items.length === 0) {
     return (
-      <div className='rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm'>
-        <p className='text-sm text-gray-600'>
+      <div className='rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-8 text-center shadow-sm'>
+        <p className='text-sm text-gray-600 dark:text-gray-300'>
           No invoices yet. Your invoices will appear here after your first
           payment.
         </p>
@@ -38,38 +38,38 @@ export function InvoiceTable({
     );
   }
   return (
-    <div className='overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm'>
+    <div className='overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm'>
       <div className='overflow-x-auto'>
-        <table className='min-w-full divide-y divide-gray-200'>
-          <thead className='bg-gray-50'>
+        <table className='min-w-full divide-y divide-gray-200 dark:divide-gray-700'>
+          <thead className='bg-gray-50 dark:bg-gray-700'>
             <tr>
-              <th className='px-4 py-3 text-left text-xs font-medium text-gray-500'>
+              <th className='px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400'>
                 Date
               </th>
-              <th className='px-4 py-3 text-left text-xs font-medium text-gray-500'>
+              <th className='px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400'>
                 Description
               </th>
-              <th className='px-4 py-3 text-right text-xs font-medium text-gray-500'>
+              <th className='px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400'>
                 Amount
               </th>
-              <th className='px-4 py-3 text-left text-xs font-medium text-gray-500'>
+              <th className='px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400'>
                 Status
               </th>
-              <th className='px-4 py-3 text-right text-xs font-medium text-gray-500'>
+              <th className='px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400'>
                 Actions
               </th>
             </tr>
           </thead>
-          <tbody className='divide-y divide-gray-100 bg-white'>
+          <tbody className='divide-y divide-gray-100 dark:divide-gray-700 bg-white dark:bg-gray-800'>
             {items.map(inv => (
               <tr key={inv.id}>
-                <td className='whitespace-nowrap px-4 py-3 text-sm text-gray-900'>
+                <td className='whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-white'>
                   {formatDate(inv.created_at)}
                 </td>
-                <td className='px-4 py-3 text-sm text-gray-600'>
+                <td className='px-4 py-3 text-sm text-gray-600 dark:text-gray-300'>
                   {inv.description ?? '—'}
                 </td>
-                <td className='whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900'>
+                <td className='whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900 dark:text-white'>
                   {formatMoneyCents(
                     inv.amount_paid || inv.amount_due,
                     inv.currency
@@ -106,7 +106,7 @@ export function InvoiceTable({
         </table>
       </div>
       {hasMore && (
-        <div className='border-t border-gray-200 p-4 text-center'>
+        <div className='border-t border-gray-200 dark:border-gray-700 p-4 text-center'>
           <Button
             type='button'
             variant='secondary'

--- a/apps/web/src/components/billing/PlanCard.web.tsx
+++ b/apps/web/src/components/billing/PlanCard.web.tsx
@@ -27,9 +27,9 @@ export function PlanCard({
   priceHeadline: string;
   priceSubline?: string;
   subTag?: string;
-  /** Shown next to plan title in annual cadence (e.g. “2 Months Free”). */
+  /** Shown next to plan title in annual cadence (e.g. "2 Months Free"). */
   savingsCallout?: string | null;
-  /** Used for trial copy (“then billed …”). */
+  /** Used for trial copy ("then billed …"). */
   billingCadence?: 'monthly' | 'annual';
   /** Hard blockers disable the CTA; soft blockers are shown as warnings only (boolean entitlement loss). */
   blockers?: DowngradeBlockersResult;
@@ -60,31 +60,37 @@ export function PlanCard({
   return (
     <div
       id={`plan-card-${plan.id}`}
-      className='flex h-full flex-col rounded-xl border border-gray-200 bg-white p-6 shadow-sm'
+      className='flex h-full flex-col rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm'
     >
       <div className='flex flex-wrap items-center gap-2'>
-        <h3 className='text-xl font-semibold text-gray-900'>
+        <h3 className='text-xl font-semibold text-gray-900 dark:text-white'>
           {plan.display_name}
         </h3>
         {supplementalBadge ? (
-          <span className='shrink-0 rounded-md border border-blue-200 bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-900'>
+          <span className='shrink-0 rounded-md border border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/40 px-2 py-0.5 text-xs font-medium text-blue-900 dark:text-blue-200'>
             {supplementalBadge}
           </span>
         ) : null}
         {savingsCallout ? (
-          <span className='shrink-0 rounded-md border border-rose-300 bg-rose-50 px-2 py-0.5 text-xs font-semibold text-rose-900'>
+          <span className='shrink-0 rounded-md border border-rose-300 dark:border-rose-600 bg-rose-50 dark:bg-rose-900/40 px-2 py-0.5 text-xs font-semibold text-rose-900 dark:text-rose-200'>
             {savingsCallout}
           </span>
         ) : null}
       </div>
-      {tag ? <p className='text-sm text-gray-500'>{tag}</p> : null}
+      {tag ? (
+        <p className='text-sm text-gray-500 dark:text-gray-400'>{tag}</p>
+      ) : null}
       <div className='mt-4'>
-        <p className='text-3xl font-bold text-gray-900'>{priceHeadline}</p>
+        <p className='text-3xl font-bold text-gray-900 dark:text-white'>
+          {priceHeadline}
+        </p>
         {priceSubline && (
-          <p className='text-sm text-gray-500'>{priceSubline}</p>
+          <p className='text-sm text-gray-500 dark:text-gray-400'>
+            {priceSubline}
+          </p>
         )}
         {plan.price_cents > 0 && plan.trial_period_days > 0 ? (
-          <p className='mt-2 text-sm text-gray-600'>
+          <p className='mt-2 text-sm text-gray-600 dark:text-gray-300'>
             {plan.trial_period_days}-day trial, then billed{' '}
             {billingCadence === 'annual' ? 'annually' : 'monthly'} at this rate.
           </p>

--- a/apps/web/src/components/billing/StatCard.web.tsx
+++ b/apps/web/src/components/billing/StatCard.web.tsx
@@ -6,9 +6,11 @@ export function StatCard({
   value: string;
 }): JSX.Element {
   return (
-    <div className='rounded-xl border border-gray-200 bg-white p-4 shadow-sm'>
-      <p className='text-xs text-gray-500'>{label}</p>
-      <p className='mt-1 text-base font-medium text-gray-900'>{value}</p>
+    <div className='rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm'>
+      <p className='text-xs text-gray-500 dark:text-gray-400'>{label}</p>
+      <p className='mt-1 text-base font-medium text-gray-900 dark:text-white'>
+        {value}
+      </p>
     </div>
   );
 }

--- a/apps/web/src/components/billing/__tests__/FeatureLimitRow.web.test.tsx
+++ b/apps/web/src/components/billing/__tests__/FeatureLimitRow.web.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FeatureLimitRow } from '../FeatureLimitRow.web';
+
+describe('FeatureLimitRow', () => {
+  it('renders unlimited mode without ratio styling', () => {
+    render(
+      <FeatureLimitRow name='Widgets' used={4} cap={100} capIsUnlimited />
+    );
+    expect(screen.getByText('Widgets')).toBeInTheDocument();
+    expect(screen.getByText(/4 of unlimited/)).toBeInTheDocument();
+  });
+
+  it('marks heavy usage below cap', () => {
+    const { container } = render(
+      <FeatureLimitRow name='A' used={8} cap={10} capIsUnlimited={false} />
+    );
+    expect(container.textContent).toContain('8 of 10');
+    expect(container.querySelector('.text-amber-800')).toBeTruthy();
+  });
+
+  it('marks at-cap usage in red', () => {
+    const { container } = render(
+      <FeatureLimitRow name='B' used={10} cap={10} capIsUnlimited={false} />
+    );
+    expect(container.querySelector('.text-red-700')).toBeTruthy();
+  });
+
+  it('treats zero cap as ratio zero', () => {
+    render(
+      <FeatureLimitRow name='C' used={3} cap={0} capIsUnlimited={false} />
+    );
+    expect(screen.getByText(/3 of 0/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/__tests__/PlanCard.web.test.tsx
+++ b/apps/web/src/components/billing/__tests__/PlanCard.web.test.tsx
@@ -112,6 +112,26 @@ describe('PlanCard', () => {
     ).not.toBeDisabled();
   });
 
+  it('renders supplemental badge and savings callout when provided', () => {
+    render(
+      <PlanCard
+        plan={proPlan}
+        priceHeadline='US$19'
+        priceSubline='per month'
+        supplementalBadge='Scheduled'
+        savingsCallout='2 Months Free'
+        primary={{
+          label: 'Go Pro',
+          onClick: vi.fn(),
+          disabled: false,
+          loading: false,
+        }}
+      />
+    );
+    expect(screen.getByText('Scheduled')).toBeInTheDocument();
+    expect(screen.getByText('2 Months Free')).toBeInTheDocument();
+  });
+
   it('shows trial line when plan has trial_period_days', () => {
     const maxLike: Plan = {
       ...proPlan,

--- a/apps/web/src/components/billing/__tests__/PlanFeatureList.test.tsx
+++ b/apps/web/src/components/billing/__tests__/PlanFeatureList.test.tsx
@@ -41,4 +41,16 @@ describe('PlanFeatureList', () => {
     expect(screen.getByText('Feature A')).toBeInTheDocument();
     expect(screen.getByText('Up to 2 collections')).toBeInTheDocument();
   });
+
+  it('renders X icon row when a boolean feature is off', () => {
+    const { container } = render(<PlanFeatureList plan={freePlan} />);
+    const featureAListItem = screen.getByText('Feature A').closest('li');
+    expect(featureAListItem?.querySelector('.text-gray-300')).toBeTruthy();
+    expect(container.querySelector('.text-green-600')).toBeTruthy();
+  });
+
+  it('accepts public mode without changing output', () => {
+    render(<PlanFeatureList plan={freePlan} mode='public' />);
+    expect(screen.getByText("What's included")).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/billing/__tests__/StatusBadge.web.test.tsx
+++ b/apps/web/src/components/billing/__tests__/StatusBadge.web.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StatusBadge } from '../StatusBadge.web';
+
+describe('StatusBadge', () => {
+  it('maps known statuses', () => {
+    render(<StatusBadge status='paid' />);
+    expect(screen.getByText('Paid')).toBeInTheDocument();
+  });
+
+  it('falls back to raw label for unknown statuses', () => {
+    render(<StatusBadge status='custom_status' />);
+    expect(screen.getByText('custom_status')).toBeInTheDocument();
+  });
+
+  it('treats empty status as unknown label', () => {
+    const { container } = render(<StatusBadge status='' />);
+    expect(container.querySelector('span')?.textContent).toBe('');
+  });
+});

--- a/apps/web/src/components/billing/__tests__/presentational.billing.test.tsx
+++ b/apps/web/src/components/billing/__tests__/presentational.billing.test.tsx
@@ -107,6 +107,44 @@ describe('billing presentational components', () => {
     expect(screen.getByText('View all invoices →')).toBeInTheDocument();
   });
 
+  it('InvoiceList returns null when there are no invoices', () => {
+    render(
+      <MemoryRouter>
+        <InvoiceList items={[]} />
+      </MemoryRouter>
+    );
+    expect(screen.queryByText('Recent activity')).not.toBeInTheDocument();
+  });
+
+  it('InvoiceList omits view-all link when showViewAll is false', () => {
+    const inv = sampleInvoice();
+    render(
+      <MemoryRouter>
+        <InvoiceList items={[inv]} showViewAll={false} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Recent activity')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /View all invoices/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('InvoiceList uses description fallback and amount_due when paid is zero', () => {
+    const inv: BillingInvoiceRow = {
+      ...sampleInvoice(),
+      description: null,
+      amount_paid: 0,
+      amount_due: 2500,
+    };
+    render(
+      <MemoryRouter>
+        <InvoiceList items={[inv]} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Subscription')).toBeInTheDocument();
+    expect(screen.getByText(/\$25\.00/)).toBeInTheDocument();
+  });
+
   it('InvoiceTable shows empty, loading, and row states', () => {
     const { rerender } = render(
       <MemoryRouter>

--- a/apps/web/src/components/dashboard/__tests__/DemoControlsPanel.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/DemoControlsPanel.test.tsx
@@ -93,6 +93,18 @@ describe('DemoControlsPanel', () => {
     });
   });
 
+  it('shows Error message when RPC rejects with Error', async () => {
+    const user = userEvent.setup();
+    demoSupabase.rpc.mockRejectedValue(new Error('database unavailable'));
+    render(<DemoControlsPanel />);
+    await user.click(screen.getByRole('button', { name: /Switch to Pro/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(
+        'database unavailable'
+      );
+    });
+  });
+
   it('resets usage for each meter and refreshes usage', async () => {
     const user = userEvent.setup();
     render(<DemoControlsPanel />);

--- a/apps/web/src/components/dashboard/__tests__/MeteredUsageDemo.realAi.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/MeteredUsageDemo.realAi.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * `useRealAi` is resolved when this module loads — set env before importing `MeteredUsageDemo`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+const usage = vi.hoisted(() => ({
+  used: 2,
+  limit: 10 as number | null,
+  resetsAt: '2026-06-01T00:00:00.000Z' as string | null,
+  exceeded: false,
+  loading: false,
+  error: null as { message: string } | null,
+  refresh: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@beakerstack/billing', async importOriginal => {
+  const actual = await importOriginal<typeof import('@beakerstack/billing')>();
+  return {
+    ...actual,
+    useBillingContext: () => ({
+      config: { productId: 'beakerstack' },
+    }),
+    useUsage: () => ({
+      used: usage.used,
+      limit: usage.limit,
+      resetsAt: usage.resetsAt,
+      exceeded: usage.exceeded,
+      loading: usage.loading,
+      error: usage.error,
+      refresh: usage.refresh,
+      remaining:
+        usage.limit != null ? Math.max(0, usage.limit - usage.used) : null,
+    }),
+  };
+});
+
+const meterSupabase = vi.hoisted(() => {
+  const rpc = vi.fn();
+  const invoke = vi.fn();
+  const client = {
+    rpc,
+    functions: { invoke },
+  };
+  return { rpc, invoke, client };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: meterSupabase.client,
+  supabaseRpc: meterSupabase.client,
+}));
+
+async function renderWithRealAiEnv() {
+  vi.resetModules();
+  vi.stubEnv('VITE_DEMO_USE_REAL_AI', 'true');
+  const { MeteredUsageDemo } = await import('../MeteredUsageDemo');
+  return render(
+    <MemoryRouter>
+      <MeteredUsageDemo />
+    </MemoryRouter>
+  );
+}
+
+describe('MeteredUsageDemo (VITE_DEMO_USE_REAL_AI)', () => {
+  beforeEach(() => {
+    usage.used = 2;
+    usage.limit = 10;
+    usage.exceeded = false;
+    usage.refresh.mockClear();
+    meterSupabase.rpc.mockReset();
+    meterSupabase.invoke.mockReset();
+    meterSupabase.rpc.mockResolvedValue({ error: null });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('uses edge function text when invoke succeeds', async () => {
+    const user = userEvent.setup();
+    meterSupabase.invoke.mockResolvedValue({
+      data: { text: '  Edge summary  ' },
+      error: null,
+    });
+    await renderWithRealAiEnv();
+    await user.click(
+      screen.getByRole('button', { name: /Simulate AI summarize/i })
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Edge summary')).toBeInTheDocument();
+    });
+  });
+
+  it('falls back when invoke returns empty text', async () => {
+    const user = userEvent.setup();
+    meterSupabase.invoke.mockResolvedValue({
+      data: { text: '   ' },
+      error: null,
+    });
+    await renderWithRealAiEnv();
+    await user.click(
+      screen.getByRole('button', { name: /Simulate AI summarize/i })
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('listitem')).toBeInTheDocument();
+    });
+  });
+
+  it('falls back when invoke throws', async () => {
+    const user = userEvent.setup();
+    meterSupabase.invoke.mockRejectedValue(new Error('offline'));
+    await renderWithRealAiEnv();
+    await user.click(
+      screen.getByRole('button', { name: /Simulate AI summarize/i })
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('listitem')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/dashboard/__tests__/NumericCapsDemo.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/NumericCapsDemo.test.tsx
@@ -125,6 +125,16 @@ describe('NumericCapsDemo', () => {
     expect(limits[0]).toBeDisabled();
   });
 
+  it('surfaces Error rejects from addCollection', async () => {
+    const user = userEvent.setup();
+    demo.addCollection.mockRejectedValue(new Error('quota'));
+    render(<NumericCapsDemo />);
+    await user.click(screen.getByRole('button', { name: /Add collection/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('quota');
+    });
+  });
+
   it('surfaces non-Error rejects from addItem', async () => {
     const user = userEvent.setup();
     demo.collections = [{ id: 'c9', item_count: 0 }];

--- a/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
@@ -26,6 +26,35 @@ function renderNav() {
 }
 
 describe('Nav', () => {
+  it('prefixes default logo path with PR preview base when pathname matches', () => {
+    const originalPath = window.location.pathname;
+    const configNoLogo = {
+      ...config,
+      brand: {
+        name: 'BeakerStack',
+        tagline: 'Ship your SaaS faster.',
+      },
+    };
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...window.location,
+        pathname: '/pr-42/dashboard',
+      },
+    });
+    render(
+      <MemoryRouter>
+        <Nav config={configNoLogo} />
+      </MemoryRouter>
+    );
+    const img = screen.getByRole('img', { name: 'BeakerStack' });
+    expect(img.getAttribute('src')).toBe('/pr-42/demo-flask-icon.svg');
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, pathname: originalPath },
+    });
+  });
+
   it('renders the brand name', () => {
     renderNav();
     expect(screen.getByText('BeakerStack')).toBeInTheDocument();

--- a/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
@@ -52,8 +52,8 @@ vi.mock('../../../billing/CadenceToggle.web', () => ({
 }));
 vi.mock('../../../../billing/billingSyncDisplay', () => ({
   annualListCentsFromSync: vi.fn(() => 22800),
-  planAnnualSavingsCopy: vi.fn(() => null),
-  formatSavingsCalloutFromCopy: vi.fn(() => null),
+  planAnnualSavingsCopy: vi.fn(() => ({ kind: 'months', months: 2 })),
+  formatSavingsCalloutFromCopy: vi.fn(() => '2 Months Free'),
 }));
 
 import { usePlanCatalog } from '@beakerstack/billing';

--- a/apps/web/src/contexts/ThemeContext.tsx
+++ b/apps/web/src/contexts/ThemeContext.tsx
@@ -1,0 +1,95 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+
+export type ThemePreference = 'system' | 'light' | 'dark';
+export type ResolvedTheme = 'light' | 'dark';
+
+const THEME_KEY = 'beakerstack:theme';
+
+interface ThemeContextValue {
+  preference: ThemePreference;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: ThemePreference) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function getSystemDark(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+function resolve(pref: ThemePreference): ResolvedTheme {
+  if (pref === 'dark') return 'dark';
+  if (pref === 'light') return 'light';
+  return getSystemDark() ? 'dark' : 'light';
+}
+
+function readStored(): ThemePreference {
+  try {
+    const v = localStorage.getItem(THEME_KEY);
+    if (v === 'dark' || v === 'light') return v;
+  } catch {
+    // private browsing / CSP
+  }
+  return 'system';
+}
+
+function applyClass(isDark: boolean): void {
+  document.documentElement.classList.toggle('dark', isDark);
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [preference, setPreference] = useState<ThemePreference>(readStored);
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
+    resolve(preference)
+  );
+
+  // Keep DOM in sync whenever resolved theme changes.
+  useEffect(() => {
+    applyClass(resolvedTheme === 'dark');
+  }, [resolvedTheme]);
+
+  // Watch OS preference while user has 'system' selected.
+  useEffect(() => {
+    if (preference !== 'system') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => {
+      const next: ResolvedTheme = e.matches ? 'dark' : 'light';
+      setResolvedTheme(next);
+    };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [preference]);
+
+  function setTheme(pref: ThemePreference) {
+    setPreference(pref);
+    setResolvedTheme(resolve(pref));
+    try {
+      if (pref === 'system') {
+        localStorage.removeItem(THEME_KEY);
+      } else {
+        localStorage.setItem(THEME_KEY, pref);
+      }
+    } catch {
+      // private browsing / CSP
+    }
+  }
+
+  return (
+    <ThemeContext.Provider value={{ preference, resolvedTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}

--- a/apps/web/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/ThemeContext.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, useTheme } from '../ThemeContext';
+import { useTheme as useThemeFromHook } from '../../hooks/useTheme';
+
+function TestConsumer() {
+  const { preference, resolvedTheme, setTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid='preference'>{preference}</span>
+      <span data-testid='resolved'>{resolvedTheme}</span>
+      <button onClick={() => setTheme('dark')}>Dark</button>
+      <button onClick={() => setTheme('light')}>Light</button>
+      <button onClick={() => setTheme('system')}>System</button>
+    </div>
+  );
+}
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+    vi.restoreAllMocks();
+  });
+
+  it('re-exports useTheme via hooks/useTheme', () => {
+    expect(useThemeFromHook).toBeDefined();
+  });
+
+  it('useTheme throws when used outside ThemeProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(<TestConsumer />)).toThrow(
+      'useTheme must be used within ThemeProvider'
+    );
+    spy.mockRestore();
+  });
+
+  it('defaults to system preference when nothing is stored', () => {
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('preference').textContent).toBe('system');
+  });
+
+  it('reads stored dark preference from localStorage', () => {
+    localStorage.setItem('beakerstack:theme', 'dark');
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('preference').textContent).toBe('dark');
+    expect(screen.getByTestId('resolved').textContent).toBe('dark');
+  });
+
+  it('reads stored light preference from localStorage', () => {
+    localStorage.setItem('beakerstack:theme', 'light');
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('preference').textContent).toBe('light');
+    expect(screen.getByTestId('resolved').textContent).toBe('light');
+  });
+
+  it('setTheme dark persists to localStorage and applies dark class', async () => {
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    await user.click(screen.getByRole('button', { name: 'Dark' }));
+    expect(screen.getByTestId('preference').textContent).toBe('dark');
+    expect(screen.getByTestId('resolved').textContent).toBe('dark');
+    expect(localStorage.getItem('beakerstack:theme')).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('setTheme light persists to localStorage and removes dark class', async () => {
+    document.documentElement.classList.add('dark');
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    await user.click(screen.getByRole('button', { name: 'Light' }));
+    expect(screen.getByTestId('preference').textContent).toBe('light');
+    expect(screen.getByTestId('resolved').textContent).toBe('light');
+    expect(localStorage.getItem('beakerstack:theme')).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('setTheme system removes stored preference from localStorage', async () => {
+    localStorage.setItem('beakerstack:theme', 'dark');
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    await user.click(screen.getByRole('button', { name: 'System' }));
+    expect(screen.getByTestId('preference').textContent).toBe('system');
+    expect(localStorage.getItem('beakerstack:theme')).toBeNull();
+  });
+
+  it('applies dark class to documentElement when theme is dark', () => {
+    localStorage.setItem('beakerstack:theme', 'dark');
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('responds to OS preference changes while in system mode', async () => {
+    let osListener: ((e: Partial<MediaQueryListEvent>) => void) | null = null;
+    const mockMq = {
+      matches: false,
+      addEventListener: vi.fn(
+        (_: string, fn: (e: Partial<MediaQueryListEvent>) => void) => {
+          osListener = fn;
+        }
+      ),
+      removeEventListener: vi.fn(),
+    };
+    vi.spyOn(window, 'matchMedia').mockReturnValue(
+      mockMq as unknown as MediaQueryList
+    );
+
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('resolved').textContent).toBe('light');
+
+    act(() => {
+      osListener?.({ matches: true } as MediaQueryListEvent);
+    });
+    expect(screen.getByTestId('resolved').textContent).toBe('dark');
+
+    act(() => {
+      osListener?.({ matches: false } as MediaQueryListEvent);
+    });
+    expect(screen.getByTestId('resolved').textContent).toBe('light');
+  });
+});

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -1,0 +1,2 @@
+export { useTheme } from '../contexts/ThemeContext';
+export type { ThemePreference, ResolvedTheme } from '../contexts/ThemeContext';

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8,8 +8,6 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -49,14 +47,3 @@ button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-}
-

--- a/apps/web/src/lib/__tests__/appBasePath.test.ts
+++ b/apps/web/src/lib/__tests__/appBasePath.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { appBasePath } from '../appBasePath';
+
+describe('appBasePath', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns empty string when window is undefined (SSR)', () => {
+    vi.stubGlobal('window', undefined as unknown as Window & typeof globalThis);
+    expect(appBasePath()).toBe('');
+  });
+
+  it('combines origin and vite base URL without trailing slash', () => {
+    vi.stubEnv('BASE_URL', '/pr-9/');
+    vi.stubGlobal('window', {
+      location: { origin: 'https://example.com' },
+    } as unknown as Window & typeof globalThis);
+    expect(appBasePath()).toBe('https://example.com/pr-9');
+    vi.unstubAllEnvs();
+  });
+});

--- a/apps/web/src/lib/__tests__/supabase-env-throws.test.ts
+++ b/apps/web/src/lib/__tests__/supabase-env-throws.test.ts
@@ -8,18 +8,20 @@ describe('supabase module env guards', () => {
   });
 
   it('throws when VITE_SUPABASE_URL is missing', async () => {
+    vi.stubGlobal('window', globalThis);
     vi.stubEnv('VITE_SUPABASE_URL', '');
     vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'test-anon-key');
     await expect(import('../supabase')).rejects.toThrow(
-      /Missing VITE_SUPABASE_URL/
+      /VITE_SUPABASE_URL.*is not set/
     );
   });
 
   it('throws when VITE_SUPABASE_ANON_KEY is missing', async () => {
+    vi.stubGlobal('window', globalThis);
     vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co');
     vi.stubEnv('VITE_SUPABASE_ANON_KEY', '');
     await expect(import('../supabase')).rejects.toThrow(
-      /Missing VITE_SUPABASE_ANON_KEY/
+      /VITE_SUPABASE_ANON_KEY.*is not set/
     );
   });
 });

--- a/apps/web/src/lib/__tests__/supabase-env-throws.test.ts
+++ b/apps/web/src/lib/__tests__/supabase-env-throws.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, afterEach, vi } from 'vitest';
+
+describe('supabase module env guards', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('throws when VITE_SUPABASE_URL is missing', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', '');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'test-anon-key');
+    await expect(import('../supabase')).rejects.toThrow(
+      /Missing VITE_SUPABASE_URL/
+    );
+  });
+
+  it('throws when VITE_SUPABASE_ANON_KEY is missing', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', '');
+    await expect(import('../supabase')).rejects.toThrow(
+      /Missing VITE_SUPABASE_ANON_KEY/
+    );
+  });
+});

--- a/apps/web/src/lib/supabase.ts
+++ b/apps/web/src/lib/supabase.ts
@@ -2,18 +2,34 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@beakerstack/shared/types/database';
 import { Logger } from '@beakerstack/shared/utils/logger';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+// In the Node/vite-node pre-render path, env vars may be absent and no Supabase
+// calls happen during renderToStaticMarkup, so placeholder values are safe.
+// In browser context a missing env var is a build misconfiguration — throw loudly.
+const isNode = typeof window === 'undefined';
 
-if (!supabaseUrl) {
-  throw new Error('Missing VITE_SUPABASE_URL environment variable');
+if (!isNode) {
+  if (!import.meta.env.VITE_SUPABASE_URL)
+    throw new Error('[web.supabase] VITE_SUPABASE_URL is not set');
+  if (!import.meta.env.VITE_SUPABASE_ANON_KEY)
+    throw new Error('[web.supabase] VITE_SUPABASE_ANON_KEY is not set');
 }
 
-if (!supabaseAnonKey) {
-  throw new Error('Missing VITE_SUPABASE_ANON_KEY environment variable');
-}
+const supabaseUrl =
+  import.meta.env.VITE_SUPABASE_URL ?? 'https://placeholder.supabase.co';
+const supabaseAnonKey =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ?? 'placeholder-anon-key';
 
 if (import.meta.env.DEV) {
+  if (isNode && !import.meta.env.VITE_SUPABASE_URL) {
+    Logger.warn(
+      '[web.supabase] VITE_SUPABASE_URL not set — using placeholder (pre-render only)'
+    );
+  }
+  if (isNode && !import.meta.env.VITE_SUPABASE_ANON_KEY) {
+    Logger.warn(
+      '[web.supabase] VITE_SUPABASE_ANON_KEY not set — using placeholder (pre-render only)'
+    );
+  }
   const realtimeUrl = supabaseUrl.replace(
     /^http(s?)/,
     (_: string, secure: string) => (secure ? 'wss' : 'ws')

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
+import { ThemeProvider } from './contexts/ThemeContext';
 import { supabase } from './lib/supabase';
 import App from './App';
 import './index.css';
@@ -18,12 +19,14 @@ const basePath = import.meta.env.VITE_BASE_PATH || '/';
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <AuthProvider supabaseClient={supabase}>
-      <ProfileProvider supabaseClient={supabase}>
-        <BrowserRouter basename={basePath}>
-          <App />
-        </BrowserRouter>
-      </ProfileProvider>
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider supabaseClient={supabase}>
+        <ProfileProvider supabaseClient={supabase}>
+          <BrowserRouter basename={basePath}>
+            <App />
+          </BrowserRouter>
+        </ProfileProvider>
+      </AuthProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/apps/web/src/pages/AuthCallbackPage.tsx
+++ b/apps/web/src/pages/AuthCallbackPage.tsx
@@ -77,15 +77,15 @@ export default function AuthCallbackPage() {
 
   if (error) {
     return (
-      <div className='min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8'>
+      <div className='min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8'>
         <div className='max-w-md w-full space-y-8'>
-          <div className='rounded-md bg-red-50 p-4'>
+          <div className='rounded-md bg-red-50 dark:bg-red-900/30 p-4'>
             <div className='flex'>
               <div className='ml-3'>
-                <h3 className='text-sm font-medium text-red-800'>
+                <h3 className='text-sm font-medium text-red-800 dark:text-red-300'>
                   Authentication Error
                 </h3>
-                <div className='mt-2 text-sm text-red-700'>
+                <div className='mt-2 text-sm text-red-700 dark:text-red-400'>
                   <p>{error}</p>
                   <p className='mt-2'>Redirecting to login page...</p>
                 </div>
@@ -98,10 +98,10 @@ export default function AuthCallbackPage() {
   }
 
   return (
-    <div className='min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8'>
+    <div className='min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8'>
       <div className='max-w-md w-full space-y-8 text-center'>
         <div>
-          <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900'>
+          <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900 dark:text-white'>
             Completing sign in...
           </h2>
           <div className='mt-8 flex justify-center'>
@@ -126,7 +126,7 @@ export default function AuthCallbackPage() {
               />
             </svg>
           </div>
-          <p className='mt-4 text-sm text-gray-600'>
+          <p className='mt-4 text-sm text-gray-600 dark:text-gray-400'>
             Please wait while we complete your authentication...
           </p>
         </div>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -9,17 +9,17 @@ import { supabase } from '@/lib/supabase';
 
 export default function DashboardPage() {
   return (
-    <div className='min-h-screen bg-gray-50'>
+    <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
       <AppHeader supabaseClient={supabase} />
 
       <div className='mx-auto max-w-[1024px] px-4 py-6 sm:px-6 lg:px-8'>
         <div className='sm:px-0'>
-          <h1 className='text-2xl font-bold text-gray-900'>
+          <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>
             Welcome to BeakerStack
           </h1>
-          <p className='mt-3 text-sm text-gray-600'>
+          <p className='mt-3 text-sm text-gray-600 dark:text-gray-400'>
             This dashboard is a sandbox for exercising the billing primitives in{' '}
-            <code className='rounded bg-gray-100 px-1 py-0.5 text-xs'>
+            <code className='rounded bg-gray-100 dark:bg-gray-800 dark:text-gray-300 px-1 py-0.5 text-xs'>
               @beakerstack/billing
             </code>{' '}
             directly. Each section below demonstrates one capability with

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -75,7 +75,7 @@ function LoginPageContent() {
   const showPlanAside = postAuthPath !== '/dashboard';
 
   return (
-    <div className='min-h-screen bg-gray-50'>
+    <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
       <AppHeader supabaseClient={supabase} />
       <div className='max-w-[1024px] mx-auto py-12 px-4 sm:px-6 lg:px-8'>
         <div
@@ -91,7 +91,7 @@ function LoginPageContent() {
             }
           >
             <div>
-              <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900 md:mt-0 md:text-left'>
+              <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900 dark:text-white md:mt-0 md:text-left'>
                 Sign in to your account
               </h2>
             </div>
@@ -102,18 +102,20 @@ function LoginPageContent() {
 
             <div className='relative'>
               <div className='absolute inset-0 flex items-center'>
-                <div className='w-full border-t border-gray-300' />
+                <div className='w-full border-t border-gray-300 dark:border-gray-600' />
               </div>
               <div className='relative flex justify-center text-sm'>
-                <span className='px-2 bg-gray-50 text-gray-500'>
+                <span className='px-2 bg-gray-50 dark:bg-gray-900 text-gray-500 dark:text-gray-400'>
                   Or continue with email
                 </span>
               </div>
             </div>
 
             {error && (
-              <div className='rounded-md bg-red-50 p-4'>
-                <h3 className='text-sm font-medium text-red-800'>{error}</h3>
+              <div className='rounded-md bg-red-50 dark:bg-red-900/30 p-4'>
+                <h3 className='text-sm font-medium text-red-800 dark:text-red-300'>
+                  {error}
+                </h3>
               </div>
             )}
 
@@ -132,7 +134,7 @@ function LoginPageContent() {
                     value={email}
                     onChange={e => setEmail(e.target.value)}
                     disabled={isLoading}
-                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
                     placeholder='Email address'
                   />
                 </div>
@@ -149,7 +151,7 @@ function LoginPageContent() {
                     value={password}
                     onChange={e => setPassword(e.target.value)}
                     disabled={isLoading}
-                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
                     placeholder='Password'
                   />
                 </div>

--- a/apps/web/src/pages/PolicyPage.tsx
+++ b/apps/web/src/pages/PolicyPage.tsx
@@ -33,7 +33,7 @@ export default function PolicyPage({ policy }: PolicyPageProps) {
       <div className='max-w-[800px] mx-auto px-4 py-12 sm:px-6 lg:px-8'>
         {/* prose styles rendered via Tailwind Typography — html is build-time generated from our own markdown, not user input */}
         <div
-          className='prose prose-gray max-w-none'
+          className='prose prose-gray dark:prose-invert max-w-none'
           dangerouslySetInnerHTML={{ __html: html }}
         />
       </div>

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -16,7 +16,7 @@ export default function ProfilePage() {
   const profile = useProfileContext();
 
   return (
-    <div className='min-h-screen bg-gray-50'>
+    <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
       <AppHeader supabaseClient={supabase} />
 
       {/* Main Content */}
@@ -26,19 +26,21 @@ export default function ProfilePage() {
           {profile.loading && (
             <div className='text-center py-12'>
               <div className='inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600'></div>
-              <p className='mt-4 text-gray-600'>Loading profile...</p>
+              <p className='mt-4 text-gray-600 dark:text-gray-400'>
+                Loading profile...
+              </p>
             </div>
           )}
 
           {/* Error State */}
           {profile.error && !profile.loading && (
-            <div className='rounded-md bg-red-50 p-4 mb-6'>
+            <div className='rounded-md bg-red-50 dark:bg-red-900/30 p-4 mb-6'>
               <div className='flex'>
                 <div className='ml-3'>
-                  <h3 className='text-sm font-medium text-red-800'>
+                  <h3 className='text-sm font-medium text-red-800 dark:text-red-300'>
                     Error loading profile
                   </h3>
-                  <p className='mt-2 text-sm text-red-700'>
+                  <p className='mt-2 text-sm text-red-700 dark:text-red-400'>
                     {profile.error.message}
                   </p>
                 </div>
@@ -50,7 +52,7 @@ export default function ProfilePage() {
           {!profile.loading && (
             <div className='space-y-6'>
               {/* Profile Header Section */}
-              <div className='bg-white shadow rounded-lg p-6'>
+              <div className='bg-white dark:bg-gray-800 shadow rounded-lg p-6'>
                 <ProfileHeader
                   profile={profile.profile}
                   email={auth.user?.email}
@@ -59,14 +61,14 @@ export default function ProfilePage() {
 
               {/* Profile Stats Section */}
               {profile.profile && (
-                <div className='bg-white shadow rounded-lg p-6'>
+                <div className='bg-white dark:bg-gray-800 shadow rounded-lg p-6'>
                   <ProfileStats profile={profile.profile} />
                 </div>
               )}
 
               {/* Profile Editor Section */}
               {!isEditing && (
-                <div className='bg-white shadow rounded-lg p-6'>
+                <div className='bg-white dark:bg-gray-800 shadow rounded-lg p-6'>
                   <button
                     onClick={() => setIsEditing(true)}
                     className='w-full sm:w-auto px-4 py-2 bg-primary-600 text-white rounded-md text-sm font-medium hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500'
@@ -77,7 +79,7 @@ export default function ProfilePage() {
               )}
 
               {isEditing && (
-                <div className='bg-white shadow rounded-lg p-6'>
+                <div className='bg-white dark:bg-gray-800 shadow rounded-lg p-6'>
                   <ProfileEditor
                     onSuccess={() => {
                       // Refresh profile data after successful update

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -108,20 +108,20 @@ function SignupPageContent() {
 
   if (awaitingEmail) {
     return (
-      <div className='min-h-screen bg-gray-50'>
+      <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
         <AppHeader supabaseClient={supabase} />
         <div className='max-w-[1024px] mx-auto py-12 px-4 sm:px-6 lg:px-8'>
-          <div className='mx-auto max-w-md rounded-lg border border-gray-200 bg-white p-8 shadow-sm'>
-            <h2 className='text-xl font-semibold text-gray-900'>
+          <div className='mx-auto max-w-md rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-8 shadow-sm'>
+            <h2 className='text-xl font-semibold text-gray-900 dark:text-white'>
               Check your email
             </h2>
-            <p className='mt-3 text-sm text-gray-600'>
+            <p className='mt-3 text-sm text-gray-600 dark:text-gray-300'>
               We sent a confirmation link to <strong>{email}</strong>. Click the
               link in that email to finish creating your account — we&apos;ll
               take you to billing to complete your plan when you&apos;re signed
               in.
             </p>
-            <p className='mt-4 text-sm text-gray-500'>
+            <p className='mt-4 text-sm text-gray-500 dark:text-gray-400'>
               <Link to={loginTo} className='font-medium text-primary-600'>
                 Already confirmed? Sign in
               </Link>
@@ -133,7 +133,7 @@ function SignupPageContent() {
   }
 
   return (
-    <div className='min-h-screen bg-gray-50'>
+    <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
       <AppHeader supabaseClient={supabase} />
       <div className='max-w-[1024px] mx-auto py-12 px-4 sm:px-6 lg:px-8'>
         <div
@@ -149,13 +149,13 @@ function SignupPageContent() {
             }
           >
             <div>
-              <h2 className='mt-0 text-center text-3xl font-extrabold text-gray-900 md:text-left'>
+              <h2 className='mt-0 text-center text-3xl font-extrabold text-gray-900 dark:text-white md:text-left'>
                 {paidIntent && postAuthPath !== '/dashboard'
                   ? `Create your account to continue with ${displayName}`
                   : 'Create your account'}
               </h2>
               {paidIntent && postAuthPath !== '/dashboard' ? (
-                <p className='mt-2 text-center text-sm text-gray-600 md:text-left'>
+                <p className='mt-2 text-center text-sm text-gray-600 dark:text-gray-400 md:text-left'>
                   No charge until you finish checkout on the next step.
                 </p>
               ) : null}
@@ -167,18 +167,20 @@ function SignupPageContent() {
 
             <div className='relative'>
               <div className='absolute inset-0 flex items-center'>
-                <div className='w-full border-t border-gray-300' />
+                <div className='w-full border-t border-gray-300 dark:border-gray-600' />
               </div>
               <div className='relative flex justify-center text-sm'>
-                <span className='px-2 bg-gray-50 text-gray-500'>
+                <span className='px-2 bg-gray-50 dark:bg-gray-900 text-gray-500 dark:text-gray-400'>
                   Or continue with email
                 </span>
               </div>
             </div>
 
             {error && (
-              <div className='rounded-md bg-red-50 p-4'>
-                <h3 className='text-sm font-medium text-red-800'>{error}</h3>
+              <div className='rounded-md bg-red-50 dark:bg-red-900/30 p-4'>
+                <h3 className='text-sm font-medium text-red-800 dark:text-red-300'>
+                  {error}
+                </h3>
               </div>
             )}
 
@@ -197,7 +199,7 @@ function SignupPageContent() {
                     value={email}
                     onChange={e => setEmail(e.target.value)}
                     disabled={isLoading}
-                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
                     placeholder='Email address'
                   />
                 </div>
@@ -214,7 +216,7 @@ function SignupPageContent() {
                     value={password}
                     onChange={e => setPassword(e.target.value)}
                     disabled={isLoading}
-                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
                     placeholder='Password'
                   />
                 </div>
@@ -231,7 +233,7 @@ function SignupPageContent() {
                     value={confirmPassword}
                     onChange={e => setConfirmPassword(e.target.value)}
                     disabled={isLoading}
-                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
                     placeholder='Confirm password'
                   />
                 </div>

--- a/apps/web/src/pages/__tests__/AuthCallbackPage.coverage.test.tsx
+++ b/apps/web/src/pages/__tests__/AuthCallbackPage.coverage.test.tsx
@@ -244,6 +244,25 @@ describe('AuthCallbackPage (URL + auth branches)', () => {
     expect(memLocal[POST_AUTH_REDIRECT_KEY]).toBeUndefined();
   });
 
+  it('does not navigate when no token is present and user is signed out', () => {
+    auth.loading = false;
+    auth.user = null;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...original,
+        hash: '',
+        search: '',
+      },
+    });
+    render(
+      <MemoryRouter>
+        <AuthCallbackPage />
+      </MemoryRouter>
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('reads localStorage when sessionStorage is empty', () => {
     const dest = '/billing/plans?plan=beakerstack_max&welcome=1';
     memLocal[POST_AUTH_REDIRECT_KEY] = serializePostAuthRedirectPayload(dest);

--- a/apps/web/src/pages/__tests__/LoginPage.test.tsx
+++ b/apps/web/src/pages/__tests__/LoginPage.test.tsx
@@ -9,6 +9,11 @@ import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+const webAuthFns = vi.hoisted(() => ({
+  signInWithPassword: vi.fn(),
+  signInWithOAuth: vi.fn(),
+}));
+
 const mockCatalogPlans = vi.hoisted(() => {
   const pro: Plan = {
     id: 'beakerstack_pro',
@@ -68,10 +73,10 @@ const createMockSupabaseClient = (): SupabaseClient => {
       onAuthStateChange: vi.fn(() => ({
         data: { subscription: { unsubscribe: vi.fn() } },
       })),
-      signInWithPassword: vi.fn(),
+      signInWithPassword: webAuthFns.signInWithPassword,
       signUp: vi.fn(),
       signOut: vi.fn(),
-      signInWithOAuth: vi.fn(),
+      signInWithOAuth: webAuthFns.signInWithOAuth,
     },
   } as unknown as SupabaseClient;
 };
@@ -105,6 +110,13 @@ const renderWithProviders = (
 describe('LoginPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    webAuthFns.signInWithPassword.mockReset();
+    webAuthFns.signInWithOAuth.mockReset();
+    webAuthFns.signInWithPassword.mockResolvedValue({
+      data: { session: null, user: null },
+      error: null,
+    });
+    webAuthFns.signInWithOAuth.mockResolvedValue({ data: {}, error: null });
   });
 
   it('renders login form', () => {
@@ -122,20 +134,13 @@ describe('LoginPage', () => {
     expect(screen.getByText('Sign in with Google')).toBeInTheDocument();
   });
 
-  it.skip('shows error when email or password is empty', async () => {
-    const user = userEvent.setup();
+  it('shows error when email or password is empty', async () => {
     renderWithProviders(<LoginPage />);
-
-    // Get the form submit button (the one in the form, not header)
     const form = screen.getByPlaceholderText('Email address').closest('form');
-    const submitButton = form?.querySelector(
-      'button[type="submit"]'
-    ) as HTMLButtonElement;
-    expect(submitButton).toBeInTheDocument();
-    if (submitButton) {
-      await user.click(submitButton);
-    }
-
+    expect(form).toBeInstanceOf(HTMLFormElement);
+    form?.dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true })
+    );
     await waitFor(() => {
       expect(screen.getByText('Please fill in all fields')).toBeInTheDocument();
     });
@@ -156,8 +161,14 @@ describe('LoginPage', () => {
     expect(passwordInput).toHaveValue('password123');
   });
 
-  it.skip('shows loading state when submitting', async () => {
+  it('shows loading state when submitting', async () => {
     const user = userEvent.setup();
+    webAuthFns.signInWithPassword.mockImplementation(
+      () =>
+        new Promise(() => {
+          /* never resolves — loading state */
+        })
+    );
     renderWithProviders(<LoginPage />);
 
     const emailInput = screen.getByPlaceholderText('Email address');
@@ -170,12 +181,10 @@ describe('LoginPage', () => {
     await user.type(emailInput, 'test@example.com');
     await user.type(passwordInput, 'password123');
 
-    // Click submit - button should show loading state
     if (submitButton) {
       await user.click(submitButton);
     }
 
-    // The button text should change to "Signing in..." when loading
     await waitFor(() => {
       expect(screen.getByText('Signing in...')).toBeInTheDocument();
     });
@@ -183,6 +192,7 @@ describe('LoginPage', () => {
 
   it('displays error message on login failure', async () => {
     const user = userEvent.setup();
+    webAuthFns.signInWithPassword.mockRejectedValue(new Error('Invalid'));
     renderWithProviders(<LoginPage />);
 
     const emailInput = screen.getByPlaceholderText('Email address');
@@ -198,10 +208,41 @@ describe('LoginPage', () => {
       await user.click(submitButton);
     }
 
-    // The form should attempt submission - error handling is tested via integration tests
-    // This test verifies the form can be filled and submitted
-    expect(emailInput).toHaveValue('test@example.com');
-    expect(passwordInput).toHaveValue('wrongpassword');
+    await waitFor(() => {
+      expect(screen.getByText('Invalid')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic copy when sign-in rejects with non-Error', async () => {
+    const user = userEvent.setup();
+    webAuthFns.signInWithPassword.mockRejectedValue('offline');
+    renderWithProviders(<LoginPage />);
+    const emailInput = screen.getByPlaceholderText('Email address');
+    await user.type(emailInput, 'a@b.com');
+    await user.type(screen.getByPlaceholderText('Password'), 'pw');
+    const form = emailInput.closest('form');
+    const submitButton = form?.querySelector('button[type="submit"]') as
+      | HTMLButtonElement
+      | undefined;
+    if (!submitButton) {
+      throw new Error('expected email/password form submit button');
+    }
+    await user.click(submitButton);
+    await waitFor(() => {
+      expect(screen.getByText('Failed to sign in')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic copy when Google sign-in rejects with non-Error', async () => {
+    const user = userEvent.setup();
+    webAuthFns.signInWithOAuth.mockRejectedValue('no oauth');
+    renderWithProviders(<LoginPage />);
+    await user.click(screen.getByText('Sign in with Google'));
+    await waitFor(() => {
+      expect(
+        screen.getByText('Failed to sign in with Google')
+      ).toBeInTheDocument();
+    });
   });
 
   it('has link to signup page', () => {
@@ -223,8 +264,14 @@ describe('LoginPage', () => {
     expect(screen.queryByText('Plan from pricing')).not.toBeInTheDocument();
   });
 
-  it.skip('disables form inputs when loading', async () => {
+  it('disables form inputs when loading', async () => {
     const user = userEvent.setup();
+    webAuthFns.signInWithPassword.mockImplementation(
+      () =>
+        new Promise(() => {
+          /* hang */
+        })
+    );
     renderWithProviders(<LoginPage />);
 
     const emailInput = screen.getByPlaceholderText('Email address');

--- a/apps/web/src/pages/__tests__/SignupPage.test.tsx
+++ b/apps/web/src/pages/__tests__/SignupPage.test.tsx
@@ -452,6 +452,22 @@ describe('SignupPage', () => {
     });
   });
 
+  it('shows generic message when email signup throws non-Error', async () => {
+    const user = userEvent.setup();
+    authClientMocks.signUp.mockRejectedValueOnce('offline');
+    renderWithProviders(<SignupPage />);
+    await user.type(screen.getByPlaceholderText('Email address'), 'x@y.com');
+    await user.type(screen.getByPlaceholderText('Password'), 'password123');
+    await user.type(
+      screen.getByPlaceholderText('Confirm password'),
+      'password123'
+    );
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create account')).toBeInTheDocument();
+    });
+  });
+
   it('clears OAuth stash and shows error when Google signup fails', async () => {
     const user = userEvent.setup();
     authClientMocks.signInWithOAuth.mockResolvedValueOnce({

--- a/apps/web/src/pages/billing/__tests__/BillingPlansPage.test.tsx
+++ b/apps/web/src/pages/billing/__tests__/BillingPlansPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import type {
@@ -48,6 +48,28 @@ const plansState = vi.hoisted(() => {
     is_public: true,
     display_order: 2,
   };
+  /** Same display tier as Pro — exercises getPrimary fallback when orders tie but ids differ. */
+  const proTwinPlan: Plan = {
+    id: 'beakerstack_pro_twin',
+    product_id: 'beakerstack',
+    display_name: 'Pro Twin',
+    description: null,
+    price_cents: 2900,
+    billing_period: 'monthly',
+    stripe_price_id_monthly: null,
+    stripe_price_id_annual: null,
+    stripe_product_id: null,
+    features: {
+      feature_a: true,
+      feature_b: false,
+      containers_per_account_max: -1,
+      items_per_container_max: 25,
+    },
+    usage_limits: { ai_summarize: 500 },
+    trial_period_days: 0,
+    is_public: true,
+    display_order: 2,
+  };
   const maxPlan: Plan = {
     id: 'beakerstack_max',
     product_id: 'beakerstack',
@@ -72,6 +94,7 @@ const plansState = vi.hoisted(() => {
   return {
     freePlan,
     proPlan,
+    proTwinPlan,
     maxPlan,
     current: proPlan,
     catLoading: false,
@@ -109,7 +132,12 @@ vi.mock('@beakerstack/billing', async importOriginal => {
     ...actual,
     useBillingConfig: () => beakerstackBillingConfig,
     usePlanCatalog: () => ({
-      plans: [plansState.freePlan, plansState.proPlan, plansState.maxPlan],
+      plans: [
+        plansState.freePlan,
+        plansState.proPlan,
+        plansState.proTwinPlan,
+        plansState.maxPlan,
+      ],
       loading: plansState.catLoading,
       error: null,
       refresh: vi.fn(),
@@ -313,6 +341,167 @@ describe('BillingPlansPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('reloads the page after cadence switch when updateSubscription returns success', async () => {
+    const user = userEvent.setup();
+    const reload = vi.fn();
+    vi.stubGlobal('location', { ...window.location, reload });
+
+    plansState.current = {
+      ...plansState.proPlan,
+      stripe_price_id_monthly: 'price_pro_monthly',
+      stripe_price_id_annual: 'price_pro_annual',
+    };
+    plansState.subscription = {
+      id: 's_paid',
+      user_id: 'u1',
+      product_id: 'beakerstack',
+      plan_id: 'beakerstack_pro',
+      stripe_customer_id: 'cus_paid',
+      stripe_subscription_id: 'sub_paid',
+      stripe_price_id: 'price_pro_monthly',
+      status: 'active',
+      current_period_start: null,
+      current_period_end: null,
+      cancel_at_period_end: false,
+      pending_target_plan_id: null,
+      canceled_at: null,
+      trial_start: null,
+      trial_end: null,
+    };
+    checkoutSpies.updateSubscription.mockResolvedValue(true);
+
+    renderPage('/billing/plans?cadence=annual');
+
+    await user.click(screen.getByRole('button', { name: 'Switch to annual' }));
+
+    await waitFor(() => {
+      expect(checkoutSpies.updateSubscription).toHaveBeenCalledWith(
+        'beakerstack_pro',
+        'annual'
+      );
+    });
+    expect(reload).toHaveBeenCalled();
+  });
+
+  it('does not reload when cadence switch returns no success flag', async () => {
+    const user = userEvent.setup();
+    const reload = vi.fn();
+    vi.stubGlobal('location', { ...window.location, reload });
+
+    plansState.current = {
+      ...plansState.proPlan,
+      stripe_price_id_monthly: 'price_pro_monthly',
+      stripe_price_id_annual: 'price_pro_annual',
+    };
+    plansState.subscription = {
+      id: 's_paid',
+      user_id: 'u1',
+      product_id: 'beakerstack',
+      plan_id: 'beakerstack_pro',
+      stripe_customer_id: 'cus_paid',
+      stripe_subscription_id: 'sub_paid',
+      stripe_price_id: 'price_pro_monthly',
+      status: 'active',
+      current_period_start: null,
+      current_period_end: null,
+      cancel_at_period_end: false,
+      pending_target_plan_id: null,
+      canceled_at: null,
+      trial_start: null,
+      trial_end: null,
+    };
+    checkoutSpies.updateSubscription.mockResolvedValue(false);
+
+    renderPage('/billing/plans?cadence=annual');
+
+    await user.click(screen.getByRole('button', { name: 'Switch to annual' }));
+
+    await waitFor(() => {
+      expect(checkoutSpies.updateSubscription).toHaveBeenCalledWith(
+        'beakerstack_pro',
+        'annual'
+      );
+    });
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('shows disabled Current plan on paid tier when toggle cadence matches subscription cadence', () => {
+    plansState.current = {
+      ...plansState.proPlan,
+      stripe_price_id_monthly: 'price_pro_monthly',
+      stripe_price_id_annual: 'price_pro_annual',
+    };
+    plansState.subscription = {
+      id: 's_paid',
+      user_id: 'u1',
+      product_id: 'beakerstack',
+      plan_id: 'beakerstack_pro',
+      stripe_customer_id: 'cus_paid',
+      stripe_subscription_id: 'sub_paid',
+      stripe_price_id: 'price_pro_monthly',
+      status: 'active',
+      current_period_start: null,
+      current_period_end: null,
+      cancel_at_period_end: false,
+      pending_target_plan_id: null,
+      canceled_at: null,
+      trial_start: null,
+      trial_end: null,
+    };
+
+    renderPage('/billing/plans');
+
+    const proSection = document.getElementById('plan-card-beakerstack_pro');
+    expect(proSection).toBeTruthy();
+    expect(
+      within(proSection as HTMLElement).getByRole('button', {
+        name: 'Current plan',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Switch to annual/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Switch to monthly/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('uses fallback Current plan CTA when paid tiers tie on display_order but ids differ', () => {
+    plansState.current = {
+      ...plansState.proPlan,
+      stripe_price_id_monthly: 'price_pro_monthly',
+      stripe_price_id_annual: 'price_pro_annual',
+    };
+    plansState.subscription = {
+      id: 's_paid',
+      user_id: 'u1',
+      product_id: 'beakerstack',
+      plan_id: 'beakerstack_pro',
+      stripe_customer_id: 'cus_paid',
+      stripe_subscription_id: 'sub_paid',
+      stripe_price_id: 'price_pro_monthly',
+      status: 'active',
+      current_period_start: null,
+      current_period_end: null,
+      cancel_at_period_end: false,
+      pending_target_plan_id: null,
+      canceled_at: null,
+      trial_start: null,
+      trial_end: null,
+    };
+
+    renderPage('/billing/plans');
+
+    const twinSection = document.getElementById(
+      'plan-card-beakerstack_pro_twin'
+    );
+    expect(twinSection).toBeTruthy();
+    const cta = within(twinSection as HTMLElement).getByRole('button', {
+      name: 'Current plan',
+    });
+    expect(cta).toBeDisabled();
+  });
+
   it('shows Scheduled on target plan when downgrade is pending', () => {
     plansState.billingKind = 'downgrade_pending';
     plansState.subscription = {
@@ -353,7 +542,7 @@ describe('BillingPlansPage', () => {
       checkoutUrl: 'https://checkout.example/session',
     });
     renderPage();
-    await user.click(screen.getByRole('button', { name: /Upgrade to Pro/i }));
+    await user.click(screen.getByRole('button', { name: /^Upgrade to Pro$/i }));
     await waitFor(() => {
       expect(hrefSpy).toHaveBeenCalledWith('https://checkout.example/session');
     });
@@ -370,6 +559,41 @@ describe('BillingPlansPage', () => {
         'monthly'
       );
     });
+  });
+
+  it('calls updateSubscription when downgrading from Max to Pro', async () => {
+    const user = userEvent.setup();
+    const reload = vi.fn();
+    vi.stubGlobal('location', { ...window.location, reload });
+    plansState.current = plansState.maxPlan;
+    plansState.subscription = {
+      id: 's_max',
+      user_id: 'u1',
+      product_id: 'beakerstack',
+      plan_id: 'beakerstack_max',
+      stripe_customer_id: 'cus',
+      stripe_subscription_id: 'sub_max',
+      stripe_price_id: 'price',
+      status: 'active',
+      current_period_start: null,
+      current_period_end: null,
+      cancel_at_period_end: false,
+      pending_target_plan_id: null,
+      canceled_at: null,
+      trial_start: null,
+      trial_end: null,
+    };
+    renderPage();
+    await user.click(
+      screen.getByRole('button', { name: /^Downgrade to Pro$/i })
+    );
+    await waitFor(() => {
+      expect(checkoutSpies.updateSubscription).toHaveBeenCalledWith(
+        'beakerstack_pro',
+        'monthly'
+      );
+    });
+    expect(reload).toHaveBeenCalled();
   });
 
   it('confirms downgrade to Free via modal', async () => {

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,1 +1,17 @@
 import '@testing-library/jest-dom';
+
+// jsdom does not implement window.matchMedia. Provide a stub so components
+// that call it (e.g. ThemeProvider OS-preference watcher) don't throw.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string): MediaQueryList => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -2,6 +2,7 @@ import typography from '@tailwindcss/typography';
 
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     './index.html',
     './src/**/*.{js,ts,jsx,tsx}',

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -66,6 +66,11 @@ export default defineConfig(({ mode }) => {
       coverage: {
         provider: 'v8',
         reporter: ['text', 'json', 'html', 'lcov'],
+        // Line/statement ~99.1% with integration-heavy pages (billing matrix, OAuth stash).
+        thresholds: {
+          statements: 99,
+          lines: 99,
+        },
         exclude: [
           'node_modules/',
           'src/test/',

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -59,6 +59,13 @@ export default defineConfig(({ mode }) => {
     define: {
       __DEV__: JSON.stringify(isDev),
     },
+    // Externalize router packages in SSR/vite-node context so both
+    // react-router-dom (ESM, used by app components) and
+    // react-router-dom/server (CJS) resolve through the same CJS
+    // require() call and share a single NavigationContext instance.
+    ssr: {
+      external: ['react-router', 'react-router-dom', '@remix-run/router'],
+    },
     test: {
       globals: true,
       environment: 'jsdom',
@@ -83,6 +90,8 @@ export default defineConfig(({ mode }) => {
           // Pure config/data files — no logic to test, always mocked in tests
           'src/config/landing.ts',
           'src/config/landing.example.alt.ts',
+          // Build-time scripts — run by vite-node at build, not part of the app test suite
+          'scripts/',
         ],
       },
     },

--- a/infra/aws/functions/PRPathRouter.js
+++ b/infra/aws/functions/PRPathRouter.js
@@ -1,62 +1,34 @@
-/**
- * CloudFront viewer-request function to map path-based PR previews to S3 prefixes.
- *
- * For deploy.beakerstack.com:
- *   - Routes `/pr-<N>/*` paths to S3 prefix `pr-<N>/*`
- *   - Handles SPA fallback: `/pr-<N>/some/route` → `pr-<N>/index.html`
- *   - Supports both file paths (with extensions) and directory-like paths
- *
- * Example URIs:
- *   - `/pr-123/` → `pr-123/index.html`
- *   - `/pr-123/static/js/main.js` → `pr-123/static/js/main.js`
- *   - `/pr-123/dashboard` → `pr-123/index.html` (SPA routing)
- *   - `/pr-123/dashboard/settings` → `pr-123/index.html` (SPA routing)
- *
- * The bootstrap script injects the values for PREVIEW_PREFIX via template substitution.
- */
 function handler(event) {
   var request = event.request;
   var uri = request.uri || '/';
-  var previewPrefixBase = '%%PREVIEW_PREFIX%%'; // e.g., "pr-"
+  var previewPrefixBase = '%%PREVIEW_PREFIX%%';
 
-  // Match /pr-<N>/ pattern at the start of the path
   var prPathPattern = new RegExp('^/(' + previewPrefixBase + '\\d+)(/.*)?$');
   var match = uri.match(prPathPattern);
 
-  function isFilePath(path) {
-    // Check if path has a file extension (e.g., .js, .css, .png)
-    // Exclude trailing slashes
-    var trimmed = path.replace(/\/$/, '');
-    return /\.[a-z0-9]+$/i.test(trimmed);
-  }
-
-  function rewritePath(prPrefix, restOfPath) {
-    var sanitizedPrefix = prPrefix.replace(/^\/+|\/+$/g, '');
-    var sanitizedPath = (restOfPath || '/').replace(/^\/+/, '');
-
-    // If no path or just a slash, serve index.html
-    if (!sanitizedPath || sanitizedPath === '' || sanitizedPath === '/') {
-      return sanitizedPrefix + '/index.html';
-    }
-
-    // If path doesn't have a file extension, treat as SPA route
-    if (!isFilePath(sanitizedPath)) {
-      return sanitizedPrefix + '/index.html';
-    }
-
-    // File path - preserve as-is
-    return sanitizedPrefix + '/' + sanitizedPath;
-  }
-
-  // If the URI matches the PR pattern, rewrite it
-  if (match) {
-    var prPrefix = match[1]; // e.g., "pr-123"
-    var restOfPath = match[2]; // e.g., "/dashboard" or "/static/js/main.js"
-    request.uri = '/' + rewritePath(prPrefix, restOfPath);
+  if (!match) {
     return request;
   }
 
-  // If URI doesn't match PR pattern, pass through unchanged
-  // (For root domain requests to deploy.beakerstack.com, this might be an error page)
+  var prPrefix = match[1];
+  var restOfPath = match[2];
+
+  // No sub-path or root slash -> pre-rendered home page (mirrors Default Root Object for prod/staging)
+  if (!restOfPath || restOfPath === '/') {
+    request.uri = '/' + prPrefix + '/prerender-home.html';
+    return request;
+  }
+
+  // Strip slashes for extension check
+  var trimmedPath = restOfPath.replace(/^\//, '').replace(/\/$/, '');
+
+  // File path (has extension) -> serve directly
+  if (/\.[a-z0-9]+$/i.test(trimmedPath)) {
+    request.uri = '/' + prPrefix + restOfPath;
+    return request;
+  }
+
+  // No extension -> SPA route, serve index.html
+  request.uri = '/' + prPrefix + '/index.html';
   return request;
 }

--- a/infra/aws/pr-preview-stack.yml
+++ b/infra/aws/pr-preview-stack.yml
@@ -339,22 +339,23 @@ Resources:
           var request = event.request;
           var uri = request.uri || '/';
           var previewPrefixBase = '${PreviewPrefix}';
-          // Match /pr-<N>/ pattern at the start of the path
           var prPathPattern = new RegExp('^/(' + previewPrefixBase + '\\d+)(/.*)?$');
           var match = uri.match(prPathPattern);
-          if (match) {
-            var prPrefix = match[1];
-            var restOfPath = match[2] || '/';
-            var trimmed = restOfPath.replace(/\/$/, '');
-            var hasExtension = /\.[a-z0-9]+$/i.test(trimmed);
-            if (!hasExtension && trimmed !== '' && trimmed !== '/') {
-              request.uri = '/' + prPrefix + '/index.html';
-            } else if (trimmed === '' || trimmed === '/') {
-              request.uri = '/' + prPrefix + '/index.html';
-            } else {
-              request.uri = '/' + prPrefix + restOfPath;
-            }
+          if (!match) {
+            return request;
           }
+          var prPrefix = match[1];
+          var restOfPath = match[2];
+          if (!restOfPath || restOfPath === '/') {
+            request.uri = '/' + prPrefix + '/prerender-home.html';
+            return request;
+          }
+          var trimmedPath = restOfPath.replace(/^\//, '').replace(/\/$/, '');
+          if (/\.[a-z0-9]+$/i.test(trimmedPath)) {
+            request.uri = '/' + prPrefix + restOfPath;
+            return request;
+          }
+          request.uri = '/' + prPrefix + '/index.html';
           return request;
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,6 +139,7 @@
         "tailwindcss": "^3.3.0",
         "typescript": "^5.3.0",
         "vite": "^6.4.2",
+        "vite-node": "^3.2.4",
         "vitest": "^3.2.4"
       }
     },

--- a/packages/shared-tests/__tests__/components/navigation/UserMenu.native.test.tsx
+++ b/packages/shared-tests/__tests__/components/navigation/UserMenu.native.test.tsx
@@ -6,39 +6,62 @@ import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import type { SupabaseClient, User } from '@supabase/supabase-js';
 import type { UserProfile } from '@beakerstack/shared/types/profile';
 
-// Mock ProfileAvatar
-jest.mock(
-  '@beakerstack/shared/components/profile/ProfileAvatar.native',
-  () => ({
-    ProfileAvatar: ({ profile }: { profile: UserProfile | null }) => (
-      <div data-testid='profile-avatar'>
-        {profile?.display_name || 'Avatar'}
-      </div>
-    ),
-  })
-);
+jest.mock('@beakerstack/shared/components/profile/ProfileAvatar.native', () => {
+  const React = require('react');
+  const RN = require('react-native');
+  return {
+    ProfileAvatar: () =>
+      React.createElement(RN.View, { testID: 'profile-avatar' }),
+  };
+});
 
-// Mock Alert and Platform
 jest.mock('react-native', () => {
   const RN = jest.requireActual('react-native');
+  /** Must match `USER_MENU_TEST_PLATFORM_OS_KEY` below. */
+  const key = '__BeakerStack_UserMenuNativeTest_platformOs';
+  const platformOsRef = (): { current: string } => {
+    const g = globalThis as Record<string, { current: string } | undefined>;
+    if (!g[key]) {
+      g[key] = { current: 'ios' };
+    }
+    return g[key]!;
+  };
   return {
     ...RN,
     Alert: {
-      alert: jest.fn((title, message, buttons) => {
-        // Simulate button press for testing
-        if (buttons && buttons[1] && buttons[1].onPress) {
-          buttons[1].onPress();
+      alert: jest.fn(
+        (
+          _title: string,
+          _message: string,
+          buttons?: { text?: string; style?: string; onPress?: () => void }[]
+        ) => {
+          const signOut = buttons?.find(b => b?.style === 'destructive');
+          void signOut?.onPress?.();
         }
-      }),
+      ),
     },
     Platform: {
-      OS: 'ios',
+      ...RN.Platform,
+      get OS() {
+        return platformOsRef().current;
+      },
     },
   };
 });
 
-const createMockSupabaseClient = (): SupabaseClient => {
-  return {
+const USER_MENU_TEST_PLATFORM_OS_KEY =
+  '__BeakerStack_UserMenuNativeTest_platformOs';
+
+function userMenuPlatformOsRef(): { current: string } {
+  const g = globalThis as Record<string, { current: string } | undefined>;
+  if (!g[USER_MENU_TEST_PLATFORM_OS_KEY]) {
+    g[USER_MENU_TEST_PLATFORM_OS_KEY] = { current: 'ios' };
+  }
+  return g[USER_MENU_TEST_PLATFORM_OS_KEY]!;
+}
+
+const createMockSupabaseClient = (): SupabaseClient =>
+  ({
     auth: {
       getSession: jest.fn().mockResolvedValue({
         data: { session: null },
@@ -55,8 +78,7 @@ const createMockSupabaseClient = (): SupabaseClient => {
       }),
       signInWithOAuth: jest.fn(),
     },
-  } as unknown as SupabaseClient;
-};
+  }) as unknown as SupabaseClient;
 
 const createMockUser = (): User =>
   ({
@@ -93,196 +115,153 @@ const renderWithProviders = (
   );
 };
 
+/** RN-web measures layout asynchronously (setTimeout in UIManager.measure). */
+const openMenu = async () => {
+  fireEvent.click(screen.getByLabelText('Open user menu'));
+  await screen.findByText('Profile');
+};
+
 describe('UserMenu (Native)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    userMenuPlatformOsRef().current = 'ios';
   });
 
   it('renders user avatar', () => {
-    const mockUser = createMockUser();
-    const mockProfile = createMockProfile();
-
     renderWithProviders(
       <UserMenu
-        user={mockUser}
-        profile={mockProfile}
+        user={createMockUser()}
+        profile={createMockProfile()}
         navigation={mockNavigation}
       />
     );
-
     expect(screen.getByTestId('profile-avatar')).toBeInTheDocument();
   });
 
-  it('opens menu when avatar is pressed', () => {
-    const mockUser = createMockUser();
-    const mockProfile = createMockProfile();
-
+  it('opens menu when avatar is pressed', async () => {
     renderWithProviders(
       <UserMenu
-        user={mockUser}
-        profile={mockProfile}
+        user={createMockUser()}
+        profile={createMockProfile()}
         navigation={mockNavigation}
       />
     );
-
-    const avatarButton = screen.getByTestId('profile-avatar').closest('button');
-    if (avatarButton) {
-      fireEvent.click(avatarButton);
-    }
-
-    // Menu should be visible - wait for it
+    await openMenu();
     expect(screen.getByText('Test User')).toBeInTheDocument();
   });
 
-  it.skip('displays user email in menu', async () => {
-    const mockUser = createMockUser();
-    const mockProfile = createMockProfile();
-
+  it('displays user email in menu', async () => {
     renderWithProviders(
       <UserMenu
-        user={mockUser}
-        profile={mockProfile}
+        user={createMockUser()}
+        profile={createMockProfile()}
         navigation={mockNavigation}
       />
     );
-
-    const avatarButton = screen.getByTestId('profile-avatar').closest('button');
-    if (avatarButton) {
-      fireEvent.click(avatarButton);
-    }
-
-    // Wait for modal to open and content to be visible
-    await screen.findByText('test@example.com', {}, { timeout: 1000 });
+    await openMenu();
     expect(screen.getByText('test@example.com')).toBeInTheDocument();
   });
 
-  it.skip('displays display name fallback to username', async () => {
-    const mockUser = createMockUser();
+  it('displays display name fallback to username', async () => {
     const mockProfile: UserProfile = {
       ...createMockProfile(),
       display_name: null,
     };
-
     renderWithProviders(
       <UserMenu
-        user={mockUser}
+        user={createMockUser()}
         profile={mockProfile}
         navigation={mockNavigation}
       />
     );
-
-    const avatarButton = screen.getByTestId('profile-avatar').closest('button');
-    if (avatarButton) {
-      fireEvent.click(avatarButton);
-    }
-
-    await screen.findByText('testuser', {}, { timeout: 1000 });
+    await openMenu();
     expect(screen.getByText('testuser')).toBeInTheDocument();
   });
 
-  it.skip('displays email prefix when no display name or username', async () => {
-    const mockUser = createMockUser();
+  it('displays email prefix when no display name or username', async () => {
     const mockProfile: UserProfile = {
       ...createMockProfile(),
       display_name: null,
       username: null,
     };
-
     renderWithProviders(
       <UserMenu
-        user={mockUser}
+        user={createMockUser()}
         profile={mockProfile}
         navigation={mockNavigation}
       />
     );
-
-    const avatarButton = screen.getByTestId('profile-avatar').closest('button');
-    if (avatarButton) {
-      fireEvent.click(avatarButton);
-    }
-
-    await screen.findByText('test', {}, { timeout: 1000 }); // email prefix
-    expect(screen.getByText('test')).toBeInTheDocument();
+    await openMenu();
+    expect(screen.getByText(/^test$/)).toBeInTheDocument();
   });
 
-  it.skip('navigates to Profile when Profile is pressed', async () => {
-    const mockUser = createMockUser();
-    const mockProfile = createMockProfile();
-
+  it('navigates to Profile when Profile is pressed', async () => {
     renderWithProviders(
       <UserMenu
-        user={mockUser}
-        profile={mockProfile}
+        user={createMockUser()}
+        profile={createMockProfile()}
         navigation={mockNavigation}
       />
     );
-
-    const avatarButton = screen.getByTestId('profile-avatar').closest('button');
-    if (avatarButton) {
-      fireEvent.click(avatarButton);
-    }
-
-    const profileButton = await screen.findByText(
-      'Profile',
-      {},
-      { timeout: 1000 }
-    );
-    fireEvent.click(profileButton);
-
+    await openMenu();
+    fireEvent.click(screen.getByText('Profile'));
     expect(mockNavigate).toHaveBeenCalledWith('Profile');
   });
 
-  it.skip('navigates to Dashboard when Dashboard is pressed', async () => {
-    const mockUser = createMockUser();
-    const mockProfile = createMockProfile();
-
+  it('navigates to Billing when Billing is pressed', async () => {
     renderWithProviders(
       <UserMenu
-        user={mockUser}
-        profile={mockProfile}
+        user={createMockUser()}
+        profile={createMockProfile()}
         navigation={mockNavigation}
       />
     );
+    await openMenu();
+    fireEvent.click(screen.getByText('Billing'));
+    expect(mockNavigate).toHaveBeenCalledWith('Billing');
+  });
 
-    const avatarButton = screen.getByTestId('profile-avatar').closest('button');
-    if (avatarButton) {
-      fireEvent.click(avatarButton);
-    }
-
-    const dashboardButton = await screen.findByText(
-      'Dashboard',
-      {},
-      { timeout: 1000 }
+  it('navigates to Dashboard when Dashboard is pressed', async () => {
+    renderWithProviders(
+      <UserMenu
+        user={createMockUser()}
+        profile={createMockProfile()}
+        navigation={mockNavigation}
+      />
     );
-    fireEvent.click(dashboardButton);
-
+    await openMenu();
+    fireEvent.click(screen.getByText('Dashboard'));
     expect(mockNavigate).toHaveBeenCalledWith('Dashboard');
   });
 
-  it.skip('handles sign out', async () => {
+  it('signs out and navigates home after confirming', async () => {
     const mockClient = createMockSupabaseClient();
-    const mockUser = createMockUser();
-    const mockProfile = createMockProfile();
-
     renderWithProviders(
       <UserMenu
-        user={mockUser}
-        profile={mockProfile}
+        user={createMockUser()}
+        profile={createMockProfile()}
         navigation={mockNavigation}
       />,
       mockClient
     );
-
-    const avatarButton = screen.getByTestId('profile-avatar').closest('button');
-    if (avatarButton) {
-      fireEvent.click(avatarButton);
-    }
-
-    const signOutButton = screen.getByText('Sign Out');
-    fireEvent.click(signOutButton);
-
+    await openMenu();
+    fireEvent.click(screen.getByText('Sign Out'));
     await waitFor(() => {
       expect(mockClient.auth.signOut).toHaveBeenCalled();
     });
+    expect(mockNavigate).toHaveBeenCalledWith('Home');
+  });
+
+  it('uses Android-style menu positioning when Platform.OS is android', async () => {
+    userMenuPlatformOsRef().current = 'android';
+    renderWithProviders(
+      <UserMenu
+        user={createMockUser()}
+        profile={createMockProfile()}
+        navigation={mockNavigation}
+      />
+    );
+    await openMenu();
+    expect(screen.getByText('Profile')).toBeInTheDocument();
   });
 });

--- a/packages/shared-tests/__tests__/components/primitives/Modal.test.tsx
+++ b/packages/shared-tests/__tests__/components/primitives/Modal.test.tsx
@@ -241,4 +241,44 @@ describe('Modal (Web)', () => {
     await user.tab();
     expect(onClose).not.toHaveBeenCalled();
   });
+
+  it('wraps Tab forward from last focusable back to first in panel', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onClose = jest.fn();
+    render(
+      <Modal open onClose={onClose} title='Wrap forward'>
+        <button type='button'>First</button>
+        <button type='button'>Last</button>
+      </Modal>
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    screen.getByRole('button', { name: 'Last' }).focus();
+    await user.tab();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', { name: 'Close dialog' })
+    );
+  });
+
+  it('wraps Shift+Tab backward from first focusable to last in panel', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onClose = jest.fn();
+    render(
+      <Modal open onClose={onClose} title='Wrap back'>
+        <button type='button'>First</button>
+        <button type='button'>Last</button>
+      </Modal>
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    screen.getByRole('button', { name: 'Close dialog' }).focus();
+    await user.tab({ shift: true });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', { name: 'Last' })
+    );
+  });
 });

--- a/packages/shared-tests/__tests__/components/profile/ProfileAvatar.native.test.tsx
+++ b/packages/shared-tests/__tests__/components/profile/ProfileAvatar.native.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { Platform } from 'react-native';
 import { ProfileAvatar } from '@beakerstack/shared/components/profile/ProfileAvatar.native';
 import type { UserProfile } from '@beakerstack/shared/types/profile';
 
@@ -127,8 +128,53 @@ describe('ProfileAvatar (Native)', () => {
     expect(screen.getByText('TU')).toBeInTheDocument();
   });
 
-  it.skip('handles image load error and shows fallback', async () => {
-    // Image error handling is complex to test with react-native-web
-    // The component handles errors internally via onError callback
+  it('merges cache buster when avatar URL already has query params', () => {
+    const profile: UserProfile = {
+      id: '1',
+      user_id: 'user-1',
+      username: 'testuser',
+      display_name: 'Test User',
+      avatar_url: 'https://example.com/a.jpg?v=1',
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+    };
+
+    render(<ProfileAvatar profile={profile} />);
+    const image = screen.getByRole('img');
+    const src = image.getAttribute('src') ?? '';
+    expect(src).toContain('?v=1');
+    expect(src).toContain('&t=');
+  });
+
+  it('rewrites localhost to Android emulator host in dev', () => {
+    const prev = Platform.OS;
+    try {
+      Object.defineProperty(Platform, 'OS', {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: 'android',
+      });
+      const profile: UserProfile = {
+        id: '1',
+        user_id: 'user-1',
+        username: 'testuser',
+        display_name: 'Test User',
+        avatar_url:
+          'http://127.0.0.1:54321/storage/v1/object/public/avatars/x.png',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      };
+      render(<ProfileAvatar profile={profile} />);
+      const image = screen.getByRole('img');
+      expect(image.getAttribute('src')).toContain('10.0.2.2');
+    } finally {
+      Object.defineProperty(Platform, 'OS', {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: prev,
+      });
+    }
   });
 });

--- a/packages/shared-tests/__tests__/components/profile/ProfileAvatar.test.tsx
+++ b/packages/shared-tests/__tests__/components/profile/ProfileAvatar.test.tsx
@@ -99,4 +99,14 @@ describe('ProfileAvatar', () => {
     expect(avatar).toBeInTheDocument();
     expect(avatar).toHaveTextContent('?');
   });
+
+  it('does not append cache-bust query when URL already has search params', () => {
+    const profileWithQuery: UserProfile = {
+      ...mockProfile,
+      avatar_url: 'https://example.com/avatar.jpg?v=1',
+    };
+    render(<ProfileAvatar profile={profileWithQuery} />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('src', 'https://example.com/avatar.jpg?v=1');
+  });
 });

--- a/packages/shared/src/components/navigation/AppHeader.web.tsx
+++ b/packages/shared/src/components/navigation/AppHeader.web.tsx
@@ -31,7 +31,7 @@ export function AppHeader({ supabaseClient: _supabaseClient }: AppHeaderProps) {
   const basePath = getBasePath();
 
   return (
-    <div className='bg-white shadow'>
+    <div className='bg-white dark:bg-gray-900 shadow dark:shadow-gray-800 border-b border-transparent dark:border-gray-700'>
       <div className='max-w-[1024px] mx-auto px-4 sm:px-6 lg:px-8'>
         <div className='flex justify-between items-center h-16'>
           {/* Left side: App icon and title */}
@@ -45,7 +45,7 @@ export function AppHeader({ supabaseClient: _supabaseClient }: AppHeaderProps) {
             </Link>
             <Link
               to='/'
-              className='text-xl font-semibold text-gray-900 hover:text-gray-700'
+              className='text-xl font-semibold text-gray-900 dark:text-white hover:text-gray-700 dark:hover:text-gray-300'
             >
               {BRANDING.displayName}
             </Link>
@@ -59,7 +59,7 @@ export function AppHeader({ supabaseClient: _supabaseClient }: AppHeaderProps) {
               <>
                 <Link
                   to='/login'
-                  className='text-gray-500 hover:text-gray-700 px-3 py-2 rounded-md text-sm font-medium'
+                  className='text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 px-3 py-2 rounded-md text-sm font-medium'
                 >
                   Sign In
                 </Link>

--- a/packages/shared/src/components/navigation/UserMenu.native.tsx
+++ b/packages/shared/src/components/navigation/UserMenu.native.tsx
@@ -90,6 +90,7 @@ export function UserMenu({ user, profile, navigation }: UserMenuProps) {
       <View style={styles.container} ref={menuRef}>
         <View ref={avatarRef} collapsable={false}>
           <TouchableOpacity
+            accessibilityLabel='Open user menu'
             onPress={handleAvatarPress}
             style={styles.avatarButton}
             activeOpacity={0.7}

--- a/packages/shared/src/components/navigation/UserMenu.web.tsx
+++ b/packages/shared/src/components/navigation/UserMenu.web.tsx
@@ -62,13 +62,17 @@ export function UserMenu({ user, profile }: UserMenuProps) {
       </button>
 
       {isOpen && (
-        <div className='absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50'>
+        <div className='absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 dark:ring-gray-700 z-50'>
           <div className='py-1'>
             {/* User name display */}
-            <div className='px-4 py-3 border-b border-gray-200'>
-              <p className='text-sm font-medium text-gray-900'>{displayName}</p>
+            <div className='px-4 py-3 border-b border-gray-200 dark:border-gray-700'>
+              <p className='text-sm font-medium text-gray-900 dark:text-white'>
+                {displayName}
+              </p>
               {user.email && (
-                <p className='text-xs text-gray-500 mt-1'>{user.email}</p>
+                <p className='text-xs text-gray-500 dark:text-gray-400 mt-1'>
+                  {user.email}
+                </p>
               )}
             </div>
 
@@ -76,14 +80,14 @@ export function UserMenu({ user, profile }: UserMenuProps) {
             <Link
               to='/profile'
               onClick={() => setIsOpen(false)}
-              className='block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100'
+              className='block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700'
             >
               Profile
             </Link>
             <Link
               to='/billing'
               onClick={() => setIsOpen(false)}
-              className='flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100'
+              className='flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700'
             >
               <CreditCard className='h-4 w-4 shrink-0' aria-hidden />
               Billing
@@ -91,14 +95,14 @@ export function UserMenu({ user, profile }: UserMenuProps) {
             <Link
               to='/dashboard'
               onClick={() => setIsOpen(false)}
-              className='block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100'
+              className='block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700'
             >
               Dashboard
             </Link>
-            <div className='my-1 border-t border-gray-200' />
+            <div className='my-1 border-t border-gray-200 dark:border-gray-700' />
             <button
               onClick={handleSignOut}
-              className='block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100'
+              className='block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700'
             >
               Sign Out
             </button>

--- a/scripts/lib/setup-google-services.mjs
+++ b/scripts/lib/setup-google-services.mjs
@@ -48,3 +48,19 @@ export async function envVarsFromGoogleServicesJson(filePath) {
   if (apiKeyCurrent) out.GOOGLE_SERVICES_API_KEY = String(apiKeyCurrent);
   return out;
 }
+
+export function clearGoogleKeysFromAcc(acc) {
+  for (const k of [
+    'GOOGLE_SERVICES_PROJECT_NUMBER',
+    'GOOGLE_SERVICES_PROJECT_ID',
+    'GOOGLE_SERVICES_STORAGE_BUCKET',
+    'GOOGLE_SERVICES_MOBILESDK_APP_ID',
+    'GOOGLE_SERVICES_ANDROID_CLIENT_ID',
+    'GOOGLE_SERVICES_ANDROID_CERTIFICATE_HASH',
+    'GOOGLE_SERVICES_WEB_CLIENT_ID',
+    'GOOGLE_SERVICES_IOS_CLIENT_ID',
+    'GOOGLE_SERVICES_API_KEY',
+  ]) {
+    delete acc[k];
+  }
+}

--- a/scripts/lib/setup-manifest.mjs
+++ b/scripts/lib/setup-manifest.mjs
@@ -305,6 +305,13 @@ export const GITHUB_VARIABLES = [
     envKeys: ['EXPO_ACCOUNT'],
     group: 'expo',
   },
+  {
+    type: 'variable',
+    name: 'MOBILE_ENABLED',
+    envKeys: ['MOBILE_ENABLED'],
+    optional: true,
+    group: 'core',
+  },
 ];
 
 /** Env keys written by setup but not listed on GitHub secret defs (local generated env only). */
@@ -346,6 +353,8 @@ export function resolveValueForGithub(env, def) {
   return '';
 }
 
+const MOBILE_GROUPS = new Set(['expo', 'google']);
+
 /**
  * @param {Record<string, string>} env
  * @param {string} [group] if set, only entries with this group
@@ -353,8 +362,10 @@ export function resolveValueForGithub(env, def) {
 export function collectGithubSecretPayload(env, group) {
   /** @type {Record<string, string>} */
   const out = {};
+  const mobileDisabled = env.MOBILE_ENABLED === 'false';
   for (const def of GITHUB_SECRETS) {
     if (group && def.group !== group) continue;
+    if (mobileDisabled && MOBILE_GROUPS.has(def.group)) continue;
     const val = resolveValueForGithub(env, def);
     if (!val && def.optional) continue;
     if (val) out[def.name] = val;
@@ -369,8 +380,10 @@ export function collectGithubSecretPayload(env, group) {
 export function collectGithubVariablePayload(env, group) {
   /** @type {Record<string, string>} */
   const out = {};
+  const mobileDisabled = env.MOBILE_ENABLED === 'false';
   for (const def of GITHUB_VARIABLES) {
     if (group && def.group !== group) continue;
+    if (mobileDisabled && MOBILE_GROUPS.has(def.group)) continue;
     const val = resolveValueForGithub(env, def);
     if (!val && def.optional) continue;
     if (val) out[def.name] = val;
@@ -403,13 +416,16 @@ export function mergeGithubSyncEnv(session, local, cloud, aws) {
 export function listMissingRequiredGithubForCi(env) {
   /** @type {{ kind: 'secret' | 'variable'; name: string; group: string }[]} */
   const missing = [];
+  const mobileDisabled = env.MOBILE_ENABLED === 'false';
   for (const def of GITHUB_SECRETS) {
     if (def.optional) continue;
+    if (mobileDisabled && MOBILE_GROUPS.has(def.group)) continue;
     if (resolveValueForGithub(env, def)) continue;
     missing.push({ kind: 'secret', name: def.name, group: def.group || 'unknown' });
   }
   for (const def of GITHUB_VARIABLES) {
     if (def.optional) continue;
+    if (mobileDisabled && MOBILE_GROUPS.has(def.group)) continue;
     if (resolveValueForGithub(env, def)) continue;
     missing.push({ kind: 'variable', name: def.name, group: def.group || 'unknown' });
   }

--- a/scripts/pr-preview/bootstrap-aws-stack.sh
+++ b/scripts/pr-preview/bootstrap-aws-stack.sh
@@ -33,6 +33,9 @@ IF_STACK_EXISTS="deploy"
 ALLOW_CONFLICTING_NAMED_BUCKETS=false
 PRINT_PREFLIGHT_JSON=false
 DELETE_FAILED_CHANGE_SETS=false
+# When 1/true, finalize_stack_outputs skips publish_pr_path_router_function (CI uses this
+# so a failed web build cannot publish edge code before assets exist).
+SKIP_CLOUDFRONT_FUNCTION_PUBLISH=""
 
 # Populated by preflight_collect_data()
 PREFLIGHT_BUCKETS_PROD=""
@@ -69,6 +72,7 @@ Optional:
                                  but the stack is missing (orphaned retained buckets; deploy will likely fail)
   --print-preflight-json         Print one JSON object to stdout (no other stdout); then exit 0. For setup tooling.
   --delete-failed-change-sets    Delete FAILED CloudFormation change sets for --stack-name; then exit 0.
+  --skip-cloudfront-function-publish   Skip CloudFront PRPathRouter publish in finalize (stack outputs + error pages still run).
   --help                         Show this help message
 
 Environment exports:
@@ -174,62 +178,78 @@ publish_pr_path_router_function() {
   local function_id="${function_arn##*/}"
   function_id="${function_id%%/*}"
 
-  local desc err update_json
+  local err
   err="$(mktemp)"
-  update_json="$(mktemp)"
-  # Prefer DEVELOPMENT stage (where update-function applies).
-  if ! desc="$("${AWS_CLI[@]}" cloudfront describe-function \
+
+  # Pre-publish validation: rendered file must be UTF-8 JS starting with `function`.
+  # Catches an unrendered `%%PREVIEW_PREFIX%%` template or a truncated/binary file before
+  # we touch the live edge code.
+  if ! RENDERED_PATH="${rendered_path}" python3 -c '
+import os, sys
+
+src_path = os.environ["RENDERED_PATH"]
+with open(src_path, "rb") as fp:
+    raw = fp.read()
+try:
+    text = raw.decode("utf-8")
+except UnicodeDecodeError as exc:
+    print(f"rendered function is not valid UTF-8: {exc}", file=sys.stderr)
+    sys.exit(1)
+if "%%PREVIEW_PREFIX%%" in text:
+    print("rendered function still contains %%PREVIEW_PREFIX%% placeholder", file=sys.stderr)
+    sys.exit(1)
+if not text.lstrip().startswith("function"):
+    print("rendered function does not start with a `function` declaration", file=sys.stderr)
+    sys.exit(1)
+' 2>"${err}"; then
+    log "ERROR" "Refusing to publish corrupt CloudFront function source: $(tr '\n' ' ' <"${err}")"
+    rm -f "${err}"
+    exit 1
+  fi
+
+  # Get current DEVELOPMENT ETag so update-function can use If-Match.
+  # Prefer DEVELOPMENT stage (where update-function applies); fall back to default.
+  local etag
+  etag="$("${AWS_CLI[@]}" cloudfront describe-function \
     --name "${function_id}" \
     --stage DEVELOPMENT \
-    --output json 2>"${err}")"; then
-    if ! desc="$("${AWS_CLI[@]}" cloudfront describe-function \
+    --query 'ETag' \
+    --output text 2>"${err}")" || etag=""
+  if [[ -z "${etag}" || "${etag}" == "None" ]]; then
+    etag="$("${AWS_CLI[@]}" cloudfront describe-function \
       --name "${function_id}" \
-      --output json 2>"${err}")"; then
-      log "WARN" "describe-function failed for ${function_id}; skipping publish. $(head -c 400 "${err}" 2>/dev/null | tr '\n' ' ')"
-      rm -f "${err}" "${update_json}"
-      return 0
-    fi
+      --query 'ETag' \
+      --output text 2>"${err}")" || etag=""
+  fi
+  if [[ -z "${etag}" || "${etag}" == "None" ]]; then
+    log "ERROR" "describe-function returned no ETag for ${function_id}: $(head -c 400 "${err}" 2>/dev/null | tr '\n' ' ')"
+    rm -f "${err}"
+    exit 1
   fi
 
-  if ! RENDERED_PATH="${rendered_path}" FUNCTION_ID="${function_id}" python3 -c '
-import json, os, sys
+  # IMPORTANT: this call deliberately avoids --cli-input-json. In AWS CLI v2, blob fields
+  # read from --cli-input-json are base64-decoded (cli_binary_format=base64), so the JS
+  # source gets corrupted into binary garbage on the live function. The supported path
+  # for raw binary blobs is `--function-code fileb://path` as a direct CLI argument,
+  # which streams the file bytes unchanged.
+  local function_config_json
+  function_config_json="$(python3 -c '
+import json
+print(json.dumps({
+    "Comment": "PR path router",
+    "Runtime": "cloudfront-js-2.0",
+    "KeyValueStoreAssociations": {"Quantity": 0},
+}))
+')"
 
-rendered_path = os.environ["RENDERED_PATH"]
-function_id = os.environ["FUNCTION_ID"]
-desc = json.loads(sys.stdin.read())
-
-etag = (desc.get("ETag") or "").strip()
-if not etag:
-    print("missing ETag from describe-function", file=sys.stderr)
-    sys.exit(1)
-fs = desc.get("FunctionSummary") or {}
-name = (fs.get("Name") or function_id).strip()
-fc = dict(fs.get("FunctionConfig") or {})
-if not fc.get("Runtime"):
-    fc["Runtime"] = "cloudfront-js-2.0"
-if "Comment" not in fc or fc.get("Comment") is None:
-    fc["Comment"] = "PR path router"
-kv = fc.get("KeyValueStoreAssociations")
-if not kv or int(kv.get("Quantity") or 0) == 0:
-    fc["KeyValueStoreAssociations"] = {"Quantity": 0}
-else:
-    fc["KeyValueStoreAssociations"] = kv
-
-with open(rendered_path, encoding="utf-8") as fp:
-    code = fp.read()
-
-body = {"Name": name, "IfMatch": etag, "FunctionConfig": fc, "FunctionCode": code}
-json.dump(body, sys.stdout)
-' <<<"${desc}" >"${update_json}" 2>"${err}"; then
-    log "WARN" "Could not build update-function payload for ${function_id}: $(tr '\n' ' ' <"${err}")"
-    rm -f "${err}" "${update_json}"
-    return 0
-  fi
-
-  if ! "${AWS_CLI[@]}" cloudfront update-function --cli-input-json "file://${update_json}" >/dev/null 2>"${err}"; then
-    log "WARN" "cloudfront update-function failed for ${function_id}: $(head -c 500 "${err}" 2>/dev/null | tr '\n' ' ')"
-    rm -f "${err}" "${update_json}"
-    return 0
+  if ! "${AWS_CLI[@]}" cloudfront update-function \
+    --name "${function_id}" \
+    --if-match "${etag}" \
+    --function-config "${function_config_json}" \
+    --function-code "fileb://${rendered_path}" >/dev/null 2>"${err}"; then
+    log "ERROR" "cloudfront update-function failed for ${function_id}: $(head -c 500 "${err}" 2>/dev/null | tr '\n' ' ')"
+    rm -f "${err}"
+    exit 1
   fi
 
   local etag_pub
@@ -247,21 +267,73 @@ json.dump(body, sys.stdout)
   fi
 
   if [[ -z "${etag_pub}" || "${etag_pub}" == "None" ]]; then
-    log "WARN" "Could not read ETag after update for ${function_id}; skipping publish-function."
-    rm -f "${err}" "${update_json}"
-    return 0
+    log "ERROR" "Could not read ETag after update for ${function_id}; aborting before publish."
+    rm -f "${err}"
+    exit 1
   fi
 
   if ! "${AWS_CLI[@]}" cloudfront publish-function \
     --name "${function_id}" \
     --if-match "${etag_pub}" >/dev/null 2>"${err}"; then
-    log "WARN" "cloudfront publish-function failed for ${function_id}: $(head -c 500 "${err}" 2>/dev/null | tr '\n' ' ')"
-    rm -f "${err}" "${update_json}"
-    return 0
+    log "ERROR" "cloudfront publish-function failed for ${function_id}: $(head -c 500 "${err}" 2>/dev/null | tr '\n' ' ')"
+    rm -f "${err}"
+    exit 1
   fi
 
-  rm -f "${err}" "${update_json}"
-  log "INFO" "Successfully published CloudFront function: ${function_id}"
+  # Post-publish verification: download what is now LIVE and refuse to call this a success
+  # unless the bytes parse as our rendered JS. Catches CLI encoding regressions (e.g. the
+  # fileb://-inside-cli-input-json bug that base64-decoded the path into binary garbage)
+  # before the broken function reaches users.
+  local live_dump live_err verify_failed
+  live_dump="$(mktemp)"
+  live_err="$(mktemp)"
+  verify_failed=0
+  if ! "${AWS_CLI[@]}" cloudfront get-function \
+    --name "${function_id}" \
+    --stage LIVE \
+    "${live_dump}" >/dev/null 2>"${live_err}"; then
+    log "ERROR" "Could not verify published CloudFront function ${function_id}: $(head -c 500 "${live_err}" 2>/dev/null | tr '\n' ' ')"
+    verify_failed=1
+  else
+    if ! LIVE_DUMP="${live_dump}" RENDERED_PATH="${rendered_path}" python3 -c '
+import os, sys
+
+live_path = os.environ["LIVE_DUMP"]
+src_path = os.environ["RENDERED_PATH"]
+
+with open(live_path, "rb") as fp:
+    live_bytes = fp.read()
+try:
+    live_text = live_bytes.decode("utf-8")
+except UnicodeDecodeError as exc:
+    print(f"LIVE function code is not valid UTF-8 ({exc}); first bytes: {live_bytes[:32]!r}", file=sys.stderr)
+    sys.exit(2)
+
+if not live_text.lstrip().startswith("function"):
+    head = live_text[:200].replace("\n", "\\n")
+    print(f"LIVE function code does not start with a function declaration; head={head!r}", file=sys.stderr)
+    sys.exit(3)
+
+with open(src_path, "r", encoding="utf-8") as fp:
+    expected = fp.read()
+if live_text.strip() != expected.strip():
+    print("LIVE function code does not match the rendered source we just published.", file=sys.stderr)
+    print(f"live_len={len(live_text)} expected_len={len(expected)}", file=sys.stderr)
+    sys.exit(4)
+' 2>"${live_err}"; then
+      log "ERROR" "Published CloudFront function ${function_id} failed verification: $(head -c 500 "${live_err}" 2>/dev/null | tr '\n' ' ')"
+      verify_failed=1
+    fi
+  fi
+
+  rm -f "${err}" "${live_dump}" "${live_err}"
+
+  if [[ "${verify_failed}" -eq 1 ]]; then
+    log "ERROR" "CloudFront function ${function_id} appears corrupted on LIVE. Aborting to surface the regression instead of leaving bad edge code."
+    exit 1
+  fi
+
+  log "INFO" "Successfully published and verified CloudFront function: ${function_id}"
 }
 
 write_exports() {
@@ -877,7 +949,12 @@ finalize_stack_outputs() {
     fi
   done
 
-  publish_pr_path_router_function
+  local skip_cf="${SKIP_CLOUDFRONT_FUNCTION_PUBLISH:-}"
+  if [[ "${skip_cf}" == "1" || "${skip_cf}" == "true" || "${skip_cf}" == "TRUE" ]]; then
+    log "INFO" "Skipping CloudFront function publish (--skip-cloudfront-function-publish or SKIP_CLOUDFRONT_FUNCTION_PUBLISH)."
+  else
+    publish_pr_path_router_function
+  fi
 
   write_exports "PR_PREVIEW_WEBSITE_BUCKET" "${deploy_bucket}"
   write_exports "PR_PREVIEW_LOGS_BUCKET" "${logs_bucket}"
@@ -962,6 +1039,10 @@ parse_args() {
         ;;
       --delete-failed-change-sets)
         DELETE_FAILED_CHANGE_SETS=true
+        shift
+        ;;
+      --skip-cloudfront-function-publish)
+        SKIP_CLOUDFRONT_FUNCTION_PUBLISH=1
         shift
         ;;
       --help|-h)

--- a/scripts/pr-preview/check-preview-deploy-needed.sh
+++ b/scripts/pr-preview/check-preview-deploy-needed.sh
@@ -3,8 +3,9 @@
 #
 # Keep the path allowlist conceptually aligned with .github/workflows/test.yml
 # (pull_request paths) plus preview-only paths (scripts/pr-preview/**,
-# pr-preview workflow file). If a change cannot affect built previews or this
-# workflow's deploy scripts, we skip the heavy deploy job to save Expo/AWS/CI.
+# infra/aws/** for CloudFormation / CloudFront preview routing, pr-preview
+# workflow file). If a change cannot affect built previews or this workflow's
+# deploy scripts, we skip the heavy deploy job to save Expo/AWS/CI.
 
 set -euo pipefail
 
@@ -27,6 +28,7 @@ preview_path_matches() {
 
   case "$f" in
     apps/* | packages/* | supabase/*) return 0 ;;
+    infra/aws/*) return 0 ;;
     package.json | package-lock.json) return 0 ;;
     .github/workflows/pr-preview-environment.yml) return 0 ;;
     scripts/pr-preview/*) return 0 ;;
@@ -94,6 +96,8 @@ self_test() {
   check_one package.json 1
   check_one package-lock.json 1
   check_one scripts/pr-preview/deploy-web.sh 1
+  check_one infra/aws/functions/PRPathRouter.js 1
+  check_one infra/aws/pr-preview-stack.yml 1
   check_one .github/workflows/pr-preview-environment.yml 1
   check_one tsconfig.json 1
   check_one apps/web/vite.config.ts 1

--- a/scripts/pr-preview/deploy-web.sh
+++ b/scripts/pr-preview/deploy-web.sh
@@ -58,6 +58,7 @@ Outputs:
 
 Environment variables for build:
   VITE_BASE_PATH                 Base path for React Router (set automatically based on --environment)
+  VITE_PUBLIC_SITE_ORIGIN        Public site origin for pre-render canonical/og:url (set automatically)
   VITE_SUPABASE_URL              Supabase API URL (should be set externally)
   VITE_SUPABASE_ANON_KEY         Supabase anon key (should be set externally)
 EOF
@@ -109,6 +110,10 @@ ensure_prereqs() {
   }
   command -v curl >/dev/null 2>&1 || {
     log "ERROR" "curl is required to verify preview URL."
+    exit 1
+  }
+  command -v python3 >/dev/null 2>&1 || {
+    log "ERROR" "python3 is required for CloudFront config parsing."
     exit 1
   }
 }
@@ -243,7 +248,21 @@ build_web_app() {
 
   # Set VITE_BASE_PATH for the build
   export VITE_BASE_PATH="${base_path}"
-  
+
+  # Pre-render canonical / og:url (scripts/prerender-home.ts)
+  case "${ENVIRONMENT}" in
+    preview)
+      export VITE_PUBLIC_SITE_ORIGIN="https://deploy.${DOMAIN_NAME}"
+      ;;
+    staging)
+      export VITE_PUBLIC_SITE_ORIGIN="https://staging.${DOMAIN_NAME}"
+      ;;
+    prod)
+      export VITE_PUBLIC_SITE_ORIGIN="https://${DOMAIN_NAME}"
+      ;;
+  esac
+  log "INFO" "Using VITE_PUBLIC_SITE_ORIGIN=${VITE_PUBLIC_SITE_ORIGIN}"
+
   run_cmd npm run --workspace web build
   
   # Verify build output contains expected files
@@ -254,7 +273,7 @@ build_web_app() {
   fi
   
   # Check for critical files that should always be present
-  local required_files=("index.html" "assets")
+  local required_files=("index.html" "prerender-home.html" "assets")
   local missing_required=()
   for file in "${required_files[@]}"; do
     if [[ ! -e "${BUILD_DIR}/${file}" ]]; then
@@ -303,7 +322,7 @@ sync_to_s3() {
       ;;
   esac
 
-  log "INFO" "Syncing assets (excluding index.html) to ${s3_uri} with long cache TTL..."
+  log "INFO" "Syncing assets (excluding HTML entry points) to ${s3_uri} with long cache TTL..."
   log "INFO" "Build directory contents:"
   if [[ -d "${BUILD_DIR}" ]]; then
     find "${BUILD_DIR}" -maxdepth 1 -type f -printf '%f\n' 2>/dev/null | while read -r file; do
@@ -316,36 +335,45 @@ sync_to_s3() {
     exit 1
   fi
   
+  # Exclude both HTML entry points from long-TTL sync; they are uploaded
+  # separately below with a short TTL so deploys take effect promptly.
   run_cmd aws s3 sync "${BUILD_DIR}/" "${s3_uri}/" \
     --delete \
     --exclude "index.html" \
+    --exclude "prerender-home.html" \
     --cache-control "public,max-age=31536000,immutable" \
     --region "${AWS_REGION}" \
     --exact-timestamps
 
-  log "INFO" "Ensuring SPA fallback (index.html) is cached with short TTL..."
+  log "INFO" "Uploading index.html (SPA fallback) with short TTL..."
   run_cmd aws s3 cp "${BUILD_DIR}/index.html" "${s3_uri}/index.html" \
+    --cache-control "public,max-age=60" \
+    --content-type "text/html; charset=utf-8" \
+    --region "${AWS_REGION}"
+
+  log "INFO" "Uploading prerender-home.html (home page pre-render) with short TTL..."
+  run_cmd aws s3 cp "${BUILD_DIR}/prerender-home.html" "${s3_uri}/prerender-home.html" \
     --cache-control "public,max-age=60" \
     --content-type "text/html; charset=utf-8" \
     --region "${AWS_REGION}"
   
   log "INFO" "Verifying all static assets are deployed..."
   
-  # Dynamically discover all static files in build output (excluding index.html and assets directory)
+  # Dynamically discover all static files in build output (excluding HTML entry points and assets directory)
   local missing_files=()
   local verified_count=0
   local files_to_verify=()
   
   if [[ "${DRY_RUN}" != true ]]; then
-    # First, collect all files to verify (excluding index.html and assets directory)
+    # First, collect all files to verify (excluding HTML entry points and assets directory)
     # Use a more robust approach that handles edge cases
     if [[ -d "${BUILD_DIR}" ]]; then
       while IFS= read -r -d '' file; do
         # Get relative path from BUILD_DIR
         local rel_path="${file#${BUILD_DIR}/}"
         
-        # Skip index.html (handled separately) and anything in assets/ directory
-        if [[ "${rel_path}" == "index.html" ]] || [[ "${rel_path}" == assets/* ]]; then
+        # Skip HTML entry points (handled separately) and anything in assets/ directory
+        if [[ "${rel_path}" == "index.html" ]] || [[ "${rel_path}" == "prerender-home.html" ]] || [[ "${rel_path}" == assets/* ]]; then
           continue
         fi
         
@@ -375,7 +403,7 @@ sync_to_s3() {
         fi
       done
     else
-      log "WARN" "No files found to verify (excluding index.html and assets)"
+      log "WARN" "No files found to verify (excluding HTML entry points and assets)"
     fi
     
     if [[ ${#missing_files[@]} -gt 0 ]]; then
@@ -388,6 +416,69 @@ sync_to_s3() {
   fi
 
   write_output "PREVIEW_S3_PREFIX" "${prefix:-/}"
+}
+
+# Ensures the CloudFront distribution's default root object is set to
+# prerender-home.html so that bare / requests receive pre-rendered HTML.
+# Only applies to prod and staging; preview environments use path prefixes.
+configure_cloudfront_root_object() {
+  if [[ "${ENVIRONMENT}" != "prod" && "${ENVIRONMENT}" != "staging" ]]; then
+    return 0
+  fi
+
+  local expected_root="prerender-home.html"
+  log "INFO" "Ensuring CloudFront default root object is '${expected_root}'..."
+
+  if [[ "${DRY_RUN}" == true ]]; then
+    log "DRY" "aws cloudfront update-distribution --id ${CLOUDFRONT_DISTRIBUTION_ID} (set DefaultRootObject=${expected_root})"
+    return 0
+  fi
+
+  local config_json current_root etag
+  config_json="$(aws cloudfront get-distribution-config \
+    --id "${CLOUDFRONT_DISTRIBUTION_ID}" \
+    --output json)"
+
+  current_root="$(echo "${config_json}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data['DistributionConfig'].get('DefaultRootObject', ''))
+")"
+
+  if [[ "${current_root}" == "${expected_root}" ]]; then
+    log "INFO" "CloudFront default root object is already '${expected_root}'."
+    return 0
+  fi
+
+  log "INFO" "Updating CloudFront default root object from '${current_root}' to '${expected_root}'..."
+
+  etag="$(echo "${config_json}" | python3 -c "
+import sys, json
+print(json.load(sys.stdin)['ETag'])
+")"
+
+  local updated_config
+  updated_config="$(echo "${config_json}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+data['DistributionConfig']['DefaultRootObject'] = '${expected_root}'
+print(json.dumps(data['DistributionConfig']))
+")"
+
+  local tmp_config
+  tmp_config="$(mktemp "${TMPDIR:-/tmp}/cloudfront-dist-config.XXXXXX.json")"
+  trap 'rm -f "${tmp_config}"' EXIT
+  echo "${updated_config}" > "${tmp_config}"
+
+  run_cmd aws cloudfront update-distribution \
+    --id "${CLOUDFRONT_DISTRIBUTION_ID}" \
+    --distribution-config "file://${tmp_config}" \
+    --if-match "${etag}" \
+    --output text > /dev/null
+
+  trap - EXIT
+  rm -f "${tmp_config}"
+  log "INFO" "CloudFront default root object updated to '${expected_root}'."
 }
 
 create_invalidation() {
@@ -483,6 +574,7 @@ main() {
 
   build_web_app
   sync_to_s3
+  configure_cloudfront_root_object
   create_invalidation
   verify_preview_url
 
@@ -490,4 +582,3 @@ main() {
 }
 
 main "$@"
-

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -36,7 +36,7 @@ import {
 } from './lib/setup-manifest.mjs';
 import { escapeDotEnvDoubleQuotedValue, parseDotEnv } from './lib/setup-dotenv.mjs';
 import { readMaskedLineIfTty, resolveSecretInputLine } from './lib/setup-secret-input.mjs';
-import { envVarsFromGoogleServicesJson } from './lib/setup-google-services.mjs';
+import { clearGoogleKeysFromAcc, envVarsFromGoogleServicesJson } from './lib/setup-google-services.mjs';
 import {
   printIntroBanner,
   printPhaseIntro,
@@ -80,7 +80,7 @@ const PHASE_ORDER = ['prereqs', 'identity', 'supabase', 'aws', 'expo', 'google',
 /** Merged from dotenv-style secret files / pastes (allowlisted keys only). */
 const MERGEABLE_SETUP_ENV_KEYS = mergeableSetupEnvKeys();
 
-/** @typedef {{ dryRun: boolean; fromPhase: string; skipRename: boolean; awsProfile: string; skipGithub: boolean; plainSecretPrompts: boolean }} CliFlags */
+/** @typedef {{ dryRun: boolean; fromPhase: string; skipRename: boolean; awsProfile: string; skipGithub: boolean; mobileEnabled: boolean; plainSecretPrompts: boolean }} CliFlags */
 
 function printHelp() {
   console.log(`Usage: node scripts/setup-full.mjs [options]
@@ -93,6 +93,7 @@ Options:
                          merges existing .env*.local first when resuming)
   --skip-rename          Skip the identity / rename phase entirely
   --skip-github          Skip GitHub Actions secret/variable sync
+  --skip-mobile          Skip Expo, EAS, and Google Services setup (web-only repos)
   --aws-profile=NAME     Pass through to bootstrap-aws-stack.sh
   --plain-secret-prompts Echo secret prompts in plain text (default: mask typed secrets on a TTY)
 
@@ -130,12 +131,14 @@ function parseArgv(argv) {
     skipRename: false,
     awsProfile: '',
     skipGithub: false,
+    mobileEnabled: true,
     plainSecretPrompts: false,
   };
   for (const a of argv) {
     if (a === '--dry-run') flags.dryRun = true;
     else if (a === '--skip-rename') flags.skipRename = true;
     else if (a === '--skip-github') flags.skipGithub = true;
+    else if (a === '--skip-mobile') flags.mobileEnabled = false;
     else if (a === '--plain-secret-prompts') flags.plainSecretPrompts = true;
     else if (a.startsWith('--from=')) flags.fromPhase = resolveSetupFromPhase(a.slice('--from='.length));
     else if (a.startsWith('--aws-profile=')) flags.awsProfile = a.slice('--aws-profile='.length);
@@ -1744,6 +1747,7 @@ async function phaseWrite(acc, flags) {
       {
         lastRun: new Date().toISOString(),
         phases: PHASE_ORDER,
+        mobileEnabled: acc.MOBILE_ENABLED !== 'false',
         note: 'No secrets stored in this file.',
       },
       null,
@@ -1936,6 +1940,28 @@ async function main() {
     }
   }
 
+  if (!flags.mobileEnabled) {
+    acc.MOBILE_ENABLED = 'false';
+    logInfo('Mobile disabled (--skip-mobile) — skipping Expo, EAS, and Google Services setup.');
+  } else if (startIdx <= PHASE_ORDER.indexOf('expo')) {
+    if (acc.MOBILE_ENABLED) {
+      // Resume: honour the stored choice instead of re-prompting with a true default.
+      flags.mobileEnabled = acc.MOBILE_ENABLED !== 'false';
+      logInfo(`Resuming with mobile ${flags.mobileEnabled ? 'enabled' : 'disabled'} (stored MOBILE_ENABLED=${acc.MOBILE_ENABLED}).`);
+    } else if (!flags.dryRun) {
+      const mobileAns = (await rlQuestion(rl, 'Enable mobile (Expo / EAS) builds? [Y/n]: ')).trim().toLowerCase();
+      if (mobileAns === 'n' || mobileAns === 'no') {
+        flags.mobileEnabled = false;
+        logInfo('Mobile disabled — skipping Expo, EAS, and Google Services setup.');
+      }
+    } else {
+      logInfo('[dry-run] would prompt for mobile setup choice (defaulting to enabled).');
+    }
+    acc.MOBILE_ENABLED = flags.mobileEnabled ? 'true' : 'false';
+  } else {
+    if (!acc.MOBILE_ENABLED) acc.MOBILE_ENABLED = 'true';
+  }
+
   try {
     for (let i = startIdx; i < PHASE_ORDER.length; i += 1) {
       const phase = PHASE_ORDER[i];
@@ -1956,6 +1982,12 @@ async function main() {
       }
       if (phase === 'github' && flags.skipGithub) {
         logInfo('Skipping GitHub sync (--skip-github).');
+        continue;
+      }
+      if ((phase === 'expo' || phase === 'google') && acc.MOBILE_ENABLED === 'false') {
+        logInfo(`Skipping ${phase} phase (mobile disabled).`);
+        if (phase === 'expo') clearExpoKeysFromAcc(acc);
+        if (phase === 'google') clearGoogleKeysFromAcc(acc);
         continue;
       }
 


### PR DESCRIPTION
## Release overview

This promotion merges the latest **`develop` (staging)** into **`main` (production)**. Below is what shipped on staging and is included in this release.

---

### Dark mode (web)

Full light / dark / system theme support for the web app, with persistence and OS preference detection.

- **Theme controls:** Light, System, and Dark options (footer toggle), with `localStorage` persistence and `matchMedia` for system preference.
- **UX:** Dark-oriented base styles, anti-FOUC handling on load, and dark variants across marketing pages, billing UI, header, and user menu.
- **Quality:** Dedicated tests for theme context and toggle; app and footer tests run with `ThemeProvider`.

*Merged via [#79](https://github.com/Artificer-Innovations/BeakerStack/pull/79) — closes [#75](https://github.com/Artificer-Innovations/BeakerStack/issues/75).*

---

### Marketing home: pre-render for SEO and social

The public landing page is **pre-rendered at build time** so crawlers and link previews get real HTML and Open Graph metadata on first response, without turning the whole app into SSR.

- Build pipeline runs a pre-render step after `vite build`; production/staging use a dedicated `prerender-home.html` as the CloudFront default root object for `/`, while the SPA shell continues to serve other routes as before.
- Site-wide OG / Twitter defaults in `index.html`; canonical and `og:url` applied only on the pre-rendered home document.
- Supabase env placeholders use safe fallbacks in build contexts (with dev warnings when placeholders are active).

*Merged via [#72](https://github.com/Artificer-Innovations/BeakerStack/pull/72) — closes [#71](https://github.com/Artificer-Innovations/BeakerStack/issues/71).*

---

### Web-only / mobile-optional template

Repos can run **web-only** or **web + mobile** from one template, driven by GitHub Actions variables and setup scripts.

- **`MOBILE_ENABLED`:** When set to `false`, Expo/Google setup and mobile deploy jobs are skipped; web deploys and PR comments stay unblocked by mobile builds.
- **Setup:** `--skip-mobile` and interactive prompts in `setup-full.mjs`; manifest sync respects mobile-disabled mode for secrets/variables.
- **Workflows:** Staging, production, and PR preview split web vs mobile jobs; CloudFront function publish ordering preserved so a failed web build cannot update routing ahead of assets.

*Merged via [#76](https://github.com/Artificer-Innovations/BeakerStack/pull/76) — closes [#74](https://github.com/Artificer-Innovations/BeakerStack/issues/74).*

---

### Tests and CI hygiene

Broader automated coverage and fixes so thresholds stay green (billing flows, invoices, plans, login, shared `Modal` / `ProfileAvatar` / `UserMenu`, Vitest coverage config).

*Merged via [#73](https://github.com/Artificer-Innovations/BeakerStack/pull/73).*

---

## Deploy note

When merging this PR into `main`, use **Create a merge commit** (not squash), to keep `develop` → `main` history straightforward for future promotions.