### PR TITLE
feat: CalVer template releases with git-cliff changelog (issue #82)

### DIFF
--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -1,0 +1,59 @@
+name: Release Template
+
+on:
+  workflow_dispatch:
+    inputs:
+      override_tag:
+        description: 'Override computed tag (e.g. 2026.003) — leave blank to auto-compute'
+        required: false
+
+jobs:
+  release:
+    name: Cut CalVer release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute next CalVer tag
+        id: tag
+        run: |
+          if [[ -n "${{ inputs.override_tag }}" ]]; then
+            echo "tag=${{ inputs.override_tag }}" >> $GITHUB_OUTPUT
+          else
+            YEAR=$(date +%Y)
+            LAST_N=$(git tag -l "${YEAR}.*" | sed "s/${YEAR}\.//" | sort -n | tail -1)
+            NEXT_N=$(( ${LAST_N:-0} + 1 ))
+            printf -v PADDED_N "%03d" $NEXT_N
+            echo "tag=${YEAR}.${PADDED_N}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate release notes
+        uses: orhun/git-cliff-action@v3
+        with:
+          config: cliff.toml
+          args: >-
+            --tag-pattern '^[0-9]{4}\.'
+            --tag ${{ steps.tag.outputs.tag }}
+            --latest
+        env:
+          OUTPUT: RELEASE_NOTES.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Create annotated tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a ${{ steps.tag.outputs.tag }} -m "Release ${{ steps.tag.outputs.tag }}"
+          git push origin ${{ steps.tag.outputs.tag }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
+          body_path: RELEASE_NOTES.md

--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -19,6 +19,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Validate override tag format
+        if: inputs.override_tag != ''
+        run: |
+          if [[ ! "${{ inputs.override_tag }}" =~ ^[0-9]{4}\.[0-9]{3}$ ]]; then
+            echo "Invalid tag format '${{ inputs.override_tag }}' — must match YYYY.NNN (e.g. 2026.003)"
+            exit 1
+          fi
+
       - name: Compute next CalVer tag
         id: tag
         run: |

--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ For **native clean rebuilds**, simulator uninstall, and `prebuild --clean`, see 
 
 Details: [docs/pr-preview-setup.md](docs/pr-preview-setup.md).
 
+## Releases and versioning
+
+Template snapshots are tagged on `main` using **CalVer** (`2026.001`, `2026.002`, …). Each release includes generated notes covering what changed and whether there are any breaking steps. `@beakerstack/*` packages use independent **semver** on npm.
+
+| Trigger | Workflow |
+| ------- | -------- |
+| **Manual dispatch** | [release-template.yml](.github/workflows/release-template.yml) — cuts a new CalVer tag and GitHub Release |
+
+See [VERSIONING.md](VERSIONING.md) for what counts as a breaking change and [UPGRADING.md](UPGRADING.md) for how to pull template changes into an existing fork.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,55 @@
+# Upgrading
+
+This guide covers how to pull BeakerStack changes into a fork you have already set up. See [VERSIONING.md](VERSIONING.md) for how template tags and package versions work.
+
+## Prerequisites
+
+Add the BeakerStack repo as an upstream remote if you have not already:
+
+```bash
+git remote add upstream https://github.com/Artificer-Innovations/BeakerStack.git
+```
+
+---
+
+## Option A — Upgrade to a full template snapshot
+
+Use this when you want to pull in everything from a specific tagged release as a single merge commit.
+
+```bash
+# Fetch upstream commits and tags (tags land as local refs, not as upstream/TAG)
+git fetch upstream --tags
+
+# Merge the snapshot tag into your branch
+git merge 2026.003
+```
+
+Resolve any conflicts, then review the release notes for that tag on GitHub for any breaking changes that need manual follow-up (new secrets, renamed variables, migration steps).
+
+## Option B — Cherry-pick specific changes
+
+Use this when you only want selected commits, not the full snapshot:
+
+```bash
+git fetch upstream
+git log upstream/main --oneline  # find the commit(s) you want
+git cherry-pick <sha>
+```
+
+## Option C — Upgrade an individual `@beakerstack/*` package
+
+Use this when a package dependency has shipped a new version and you want to update it in isolation:
+
+```bash
+npm install @beakerstack/billing@x.y.z
+```
+
+Read the package's GitHub Release notes for that version — package release notes describe what changed at the API level, not the broader template context.
+
+---
+
+## After any upgrade
+
+1. Re-run `npm install` to sync lockfile.
+2. Check the release notes for any new required GitHub Actions secrets or variables.
+3. Run `npm run type-check && npm run test` to catch regressions before pushing.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,6 +24,12 @@ git fetch upstream --tags
 git merge 2026.003
 ```
 
+> **"Use this template" users:** If you created your repo using GitHub's "Use this template" button, git treats the histories as unrelated. Your first merge will need `--allow-unrelated-histories`:
+> ```bash
+> git merge --allow-unrelated-histories 2026.003
+> ```
+> Subsequent merges work without the flag.
+
 Resolve any conflicts, then review the release notes for that tag on GitHub for any breaking changes that need manual follow-up (new secrets, renamed variables, migration steps).
 
 ## Option B — Cherry-pick specific changes

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,44 @@
+# Versioning
+
+BeakerStack uses two parallel versioning schemes — one for the monorepo template and one for its published packages.
+
+## Template releases — `YYYY.NNN`
+
+Template releases are **monorepo snapshot tags** on `main`. A tag like `2026.003` means: _this is what BeakerStack looked like at that point in time, and it is a good base to fork from._
+
+Tags use **CalVer with a zero-padded sequence number** within the year:
+
+```
+2026.001   first release of 2026
+2026.002   second release of 2026
+2026.013   thirteenth release of 2026
+```
+
+`NNN` increments arbitrarily — there is no meaning to how much time passes between releases.
+
+### What counts as a breaking change
+
+A template release is **breaking** if adopters who have forked the template need to take manual action before upgrading. That includes:
+
+- A new required GitHub Actions secret or repository variable
+- A renamed or removed secret / variable that CI depends on
+- A changed top-level folder structure (e.g. a directory moved or renamed)
+- A changed setup script behavior (flags renamed, phases reordered, outputs changed)
+- A new migration step needed to align an existing fork with the updated baseline
+
+Breaking changes are called out explicitly in the release notes generated for that tag.
+
+### `main` vs. tagged releases
+
+| Ref | What it is | Recommended for |
+|-----|-----------|-----------------|
+| `main` | Current stable HEAD | Following along with active development |
+| `2026.NNN` | Snapshot tag | Starting a new fork; upgrading an existing fork in a controlled way |
+
+If you are forking BeakerStack to build a product, start from a tagged release so your upgrade story is clear from day one.
+
+## Package releases — semver
+
+`@beakerstack/*` packages published to npm use standard **semantic versioning** (`MAJOR.MINOR.PATCH`). Each package is versioned independently via changesets. Release notes for package releases live on the package's GitHub Release page.
+
+Package versions are independent of template CalVer tags.

--- a/cliff.toml
+++ b/cliff.toml
@@ -20,9 +20,9 @@ footer = ""
 
 [git]
 conventional_commits = true
-filter_unconventional = false
 
 commit_parsers = [
+  { breaking = true, group = "### ⚠️ Breaking Changes" },
   { body = ".*BREAKING CHANGE.*", group = "### ⚠️ Breaking Changes" },
   { message = "^feat", group = "### Features" },
   { message = "^fix", group = "### Fixes" },

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,35 @@
+[changelog]
+header = ""
+body = """
+{% if version %}\
+## {{ version }} — {{ timestamp | date(format="%Y-%m-%d") }}\n
+{% else %}\
+## [Unreleased]\n
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+{{ group }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }}\
+{% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}]({{ commit.remote.link }})){% endif %}
+
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+
+commit_parsers = [
+  { body = ".*BREAKING CHANGE.*", group = "### ⚠️ Breaking Changes" },
+  { message = "^feat", group = "### Features" },
+  { message = "^fix", group = "### Fixes" },
+  { message = "^chore\\(deps", group = "### Dependencies" },
+  { message = "^chore|^ci|^docs|^test|^refactor|^style|^perf", skip = true },
+]
+
+filter_commits = true
+# Scope tag matching to CalVer template tags only — prevents anchoring to @beakerstack/* package tags
+tag_pattern = "^[0-9]{4}\\."


### PR DESCRIPTION
Closes #82

Implements the approved CalVer release plan for BeakerStack — template snapshot tags (`YYYY.NNN`) with git-cliff generated release notes, separate from the existing changeset-based package release workflow.

## Changes

- **`cliff.toml`** — git-cliff config scoped to `^[0-9]{4}\.` tag pattern (avoids anchoring to `@beakerstack/*` package tags); groups by Features / Fixes / Dependencies / Breaking Changes; skips chore/ci/docs/test/refactor commits
- **`VERSIONING.md`** — explains YYYY.NNN CalVer for template tags vs. semver for packages; defines what counts as a breaking change; `main` vs. tagged release guidance
- **`UPGRADING.md`** — three upgrade paths: full snapshot merge, cherry-pick, individual package update; note on why `git merge 2026.003` not `upstream/2026.003`
- **`README.md`** — new "Releases and versioning" section between Deployment table and Contributing

## Workflow file (manual step required)

My token lacks the `workflow` scope needed to write to `.github/workflows/` via the API. Please add this file as `.github/workflows/release-template.yml`:

```yaml
name: Release Template

on:
  workflow_dispatch:
    inputs:
      override_tag:
        description: 'Override computed tag (e.g. 2026.003) — leave blank to auto-compute'
        required: false

jobs:
  release:
    name: Cut CalVer release
    runs-on: ubuntu-latest
    permissions:
      contents: write

    steps:
      - uses: actions/checkout@v4
        with:
          fetch-depth: 0

      - name: Compute next CalVer tag
        id: tag
        run: |
          if [[ -n "${{ inputs.override_tag }}" ]]; then
            echo "tag=${{ inputs.override_tag }}" >> $GITHUB_OUTPUT
          else
            YEAR=$(date +%Y)
            LAST_N=$(git tag -l "${YEAR}.*" | sed "s/${YEAR}\.//" | sort -n | tail -1)
            NEXT_N=$(( ${LAST_N:-0} + 1 ))
            printf -v PADDED_N "%03d" $NEXT_N
            echo "tag=${YEAR}.${PADDED_N}" >> $GITHUB_OUTPUT
          fi

      - name: Generate release notes
        uses: orhun/git-cliff-action@v3
        with:
          config: cliff.toml
          args: >-
            --tag-pattern '^[0-9]{4}\.'
            --tag ${{ steps.tag.outputs.tag }}
            --latest
        env:
          OUTPUT: RELEASE_NOTES.md
          GITHUB_REPO: ${{ github.repository }}

      - name: Create annotated tag
        run: |
          git config user.name "github-actions[bot]"
          git config user.email "github-actions[bot]@users.noreply.github.com"
          git tag -a ${{ steps.tag.outputs.tag }} -m "Release ${{ steps.tag.outputs.tag }}"
          git push origin ${{ steps.tag.outputs.tag }}

      - name: Create GitHub Release
        uses: softprops/action-gh-release@v2
        with:
          tag_name: ${{ steps.tag.outputs.tag }}
          name: ${{ steps.tag.outputs.tag }}
          body_path: RELEASE_NOTES.md

```

## Notes

- The existing `release.yml` (changeset-based package releases) is unchanged
- First real CalVer tag will be `2026.001` — workflow auto-computes next `NNN` from existing tags in the current year
- `--tag-pattern '^[0-9]{4}\\.'` on the CLI line in the workflow is belt-and-suspenders alongside the `tag_pattern` in `cliff.toml`
