### PR TITLE
fix(code-quality): address AI findings from issue #91

### DIFF
--- a/packages/billing/src/components/__tests__/PricingTable.web.test.tsx
+++ b/packages/billing/src/components/__tests__/PricingTable.web.test.tsx
@@ -3,28 +3,47 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PricingTable } from '../PricingTable.web';
 
+const MOCK_PLANS = [
+  {
+    id: 'plan_free',
+    product_id: 'prod_test',
+    display_name: 'Free',
+    description: null,
+    price_cents: 0,
+    billing_period: 'free',
+    stripe_price_id_monthly: null,
+    stripe_price_id_annual: null,
+    stripe_product_id: null,
+    features: { ai_summarize: false },
+    usage_limits: { collections: 3 },
+    trial_period_days: 0,
+    is_public: true,
+    display_order: 0,
+  },
+  {
+    id: 'plan_pro',
+    product_id: 'prod_test',
+    display_name: 'Pro',
+    description: 'Full access',
+    price_cents: 1900,
+    billing_period: 'monthly',
+    stripe_price_id_monthly: 'price_pro_monthly',
+    stripe_price_id_annual: null,
+    stripe_product_id: 'prod_pro',
+    features: { ai_summarize: true },
+    usage_limits: { collections: 100 },
+    trial_period_days: 0,
+    is_public: true,
+    display_order: 1,
+  },
+];
+
 vi.mock('../../hooks/usePlanCatalog.js', () => ({
-  usePlanCatalog: () => ({
-    plans: [
-      {
-        id: 'plan_free',
-        display_name: 'Free',
-        price_cents: 0,
-        billing_period: 'free',
-      },
-      {
-        id: 'plan_pro',
-        display_name: 'Pro',
-        price_cents: 1900,
-        billing_period: 'monthly',
-      },
-    ],
-    loading: false,
-  }),
+  usePlanCatalog: () => ({ plans: MOCK_PLANS, loading: false, error: null }),
 }));
 
 vi.mock('../../hooks/usePlan.js', () => ({
-  usePlan: () => ({ data: { id: 'plan_pro' } }),
+  usePlan: () => ({ data: MOCK_PLANS[1] }),
 }));
 
 describe('PricingTable', () => {

--- a/packages/shared/src/components/navigation/UserMenu.native.tsx
+++ b/packages/shared/src/components/navigation/UserMenu.native.tsx
@@ -38,7 +38,6 @@ export interface UserMenuProps {
  */
 export function UserMenu({ user, profile, navigation }: UserMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const menuRef = useRef<View>(null);
   const avatarRef = useRef<View>(null);
   const [avatarLayout, setAvatarLayout] = useState({
     x: 0,
@@ -87,7 +86,7 @@ export function UserMenu({ user, profile, navigation }: UserMenuProps) {
 
   return (
     <>
-      <View style={styles.container} ref={menuRef}>
+      <View style={styles.container}>
         <View ref={avatarRef} collapsable={false}>
           <TouchableOpacity
             accessibilityLabel='Open user menu'
@@ -157,9 +156,7 @@ export function UserMenu({ user, profile, navigation }: UserMenuProps) {
                 style={[styles.menuItem, styles.menuItemDanger]}
                 activeOpacity={0.7}
               >
-                <Text style={[styles.menuItemText, styles.menuItemDangerText]}>
-                  Sign Out
-                </Text>
+                <Text style={styles.menuItemText}>Sign Out</Text>
               </TouchableOpacity>
             </View>
           </View>
@@ -222,8 +219,5 @@ const styles = StyleSheet.create({
   menuItemText: {
     fontSize: 14,
     color: '#374151',
-  },
-  menuItemDangerText: {
-    color: '#374151', // Keep same color as web for consistency
   },
 });

--- a/packages/shared/src/components/navigation/UserMenu.web.tsx
+++ b/packages/shared/src/components/navigation/UserMenu.web.tsx
@@ -89,7 +89,7 @@ export function UserMenu({ user, profile }: UserMenuProps) {
               onClick={() => setIsOpen(false)}
               className='flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700'
             >
-              <CreditCard className='h-4 w-4 shrink-0' aria-hidden />
+              <CreditCard className='h-4 w-4 shrink-0' aria-hidden={true} />
               Billing
             </Link>
             <Link

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -374,7 +374,7 @@ function mergeRecords(base, patch) {
 /**
  * @param {string} cmd
  * @param {string[]} args
- * @param {{ cwd?: string; stdin?: string }} opts
+ * @param {{ cwd?: string; stdin?: string; env?: NodeJS.ProcessEnv }} opts
  */
 function runInteractive(cmd, args, opts = {}) {
   const res = spawnSync(cmd, args, {
@@ -1023,6 +1023,7 @@ function resolveGhRepo() {
   const r = spawnSync('gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], {
     cwd: REPO_ROOT,
     encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
   });
   if (r.status !== 0) return '';
   return (r.stdout || '').trim();
@@ -1257,8 +1258,8 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
           acc.SUPABASE_PREVIEW_PROJECT_REF = 'dry-run-ref';
           acc.SUPABASE_PREVIEW_DB_PASSWORD = dbPlaceholder;
           acc.SUPABASE_PREVIEW_DB_URL = 'postgresql://postgres:[redacted]@db.dry-run-ref.supabase.co:5432/postgres';
-          acc.PR_TESTING_SUPABASE_URL = acc.PREVIEW_SUPABASE_URL;
-          acc.PR_TESTING_SUPABASE_ANON_KEY = acc.PREVIEW_SUPABASE_ANON_KEY;
+          acc.PR_TESTING_SUPABASE_URL = 'https://dry-run.supabase.co';
+          acc.PR_TESTING_SUPABASE_ANON_KEY = 'dry-run-anon';
           acc.PR_TESTING_SUPABASE_PROJECT_REF = 'dry-run-ref';
           acc.PR_TESTING_SUPABASE_SERVICE_ROLE_KEY = 'dry-run-service';
         }


### PR DESCRIPTION
Closes #91

Addresses all 8 findings from the AI code review batch:

**`UserMenu.web.tsx`**
- Fix `aria-hidden` from attribute-only to `aria-hidden={true}` (boolean value required)

**`UserMenu.native.tsx`**
- Remove unused `menuRef` ref (declared, applied to container View, but never read)
- Remove `menuItemDangerText` from StyleSheet — it was identical to `menuItemText` (`color: '#374151'`) with only a stale comment explaining it; Sign Out now uses `menuItemText` directly

**`PricingTable.web.test.tsx`**
- Expand `usePlanCatalog` mock to full `Plan` shape (`product_id`, `description`, `stripe_price_id_monthly`, `stripe_price_id_annual`, `stripe_product_id`, `features`, `usage_limits`, `trial_period_days`, `is_public`, `display_order`)
- Expand `usePlan` mock to return the same complete object instead of `{ id }` only
- Both mocks now share `MOCK_PLANS` constant to keep them in sync

**`scripts/setup-full.mjs`**
- Add `env?: NodeJS.ProcessEnv` to `runInteractive` opts JSDoc (parameter was used but not typed)
- Pipe all stdio in `resolveGhRepo` (`['pipe', 'pipe', 'pipe']`) to prevent stderr leaking to console
- In dry-run preview block: replace `acc.PREVIEW_SUPABASE_URL` / `acc.PREVIEW_SUPABASE_ANON_KEY` reads with literal placeholder strings — the same values the preceding lines set, but more direct and consistent with the "select existing" dry-run path at line 1345