### PR TITLE
fix: dark mode for auth, billing, dashboard, and profile components

### DIFF
--- a/apps/web/src/components/SocialLoginButton.tsx
+++ b/apps/web/src/components/SocialLoginButton.tsx
@@ -33,8 +33,8 @@ export function SocialLoginButton({
       disabled={isLoading}
       className={`
         w-full flex items-center justify-center gap-3 px-4 py-2 
-        border border-gray-300 rounded-md shadow-sm
-        bg-white hover:bg-gray-50 text-gray-700
+        border border-gray-300 dark:border-gray-600 rounded-md shadow-sm
+        bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200
         text-sm font-medium
         focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500
         disabled:opacity-50 disabled:cursor-not-allowed

--- a/apps/web/src/components/auth/SignupPlanSummary.tsx
+++ b/apps/web/src/components/auth/SignupPlanSummary.tsx
@@ -36,8 +36,8 @@ export function PlanIntentSummary({
 
   if (loading) {
     return (
-      <div className='rounded-xl border border-gray-200 bg-white p-6 shadow-sm'>
-        <p className='text-sm text-gray-500'>Loading plan…</p>
+      <div className='rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm'>
+        <p className='text-sm text-gray-500 dark:text-gray-400'>Loading plan…</p>
       </div>
     );
   }
@@ -80,15 +80,15 @@ export function PlanIntentSummary({
     <div
       className={
         mode === 'login'
-          ? 'rounded-lg border border-gray-200 bg-white p-4 shadow-sm'
-          : 'rounded-xl border border-indigo-100 bg-indigo-50/80 p-6 shadow-sm ring-1 ring-indigo-100'
+          ? 'rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm'
+          : 'rounded-xl border border-indigo-200 dark:border-indigo-700 bg-indigo-50/80 dark:bg-indigo-900/30 p-6 shadow-sm ring-1 ring-indigo-100 dark:ring-indigo-800'
       }
     >
       <p
         className={
           mode === 'login'
-            ? 'text-xs font-medium uppercase tracking-wide text-gray-500'
-            : 'text-xs font-semibold uppercase tracking-wide text-indigo-800'
+            ? 'text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400'
+            : 'text-xs font-semibold uppercase tracking-wide text-indigo-800 dark:text-indigo-300'
         }
       >
         {mode === 'login' ? 'Plan from pricing' : 'Your selection'}
@@ -96,14 +96,14 @@ export function PlanIntentSummary({
       <h3
         className={
           mode === 'login'
-            ? 'mt-1 text-lg font-semibold text-gray-900'
-            : 'mt-1 text-xl font-bold text-gray-900'
+            ? 'mt-1 text-lg font-semibold text-gray-900 dark:text-white'
+            : 'mt-1 text-xl font-bold text-gray-900 dark:text-white'
         }
       >
         {catalogPlan.display_name}
       </h3>
       {savingsCallout ? (
-        <p className='mt-1 text-xs font-semibold text-amber-900'>
+        <p className='mt-1 text-xs font-semibold text-amber-900 dark:text-amber-300'>
           {savingsCallout}
         </p>
       ) : null}
@@ -111,16 +111,16 @@ export function PlanIntentSummary({
         <p
           className={
             mode === 'login'
-              ? 'text-xl font-bold text-gray-900'
-              : 'text-2xl font-bold text-gray-900'
+              ? 'text-xl font-bold text-gray-900 dark:text-white'
+              : 'text-2xl font-bold text-gray-900 dark:text-white'
           }
         >
           {priceHeadline}
         </p>
-        <p className='text-sm text-gray-600'>{priceSubline}</p>
+        <p className='text-sm text-gray-600 dark:text-gray-400'>{priceSubline}</p>
       </div>
       {bullets.length > 0 ? (
-        <ul className='mt-4 list-inside list-disc space-y-1 text-sm text-gray-700'>
+        <ul className='mt-4 list-inside list-disc space-y-1 text-sm text-gray-700 dark:text-gray-300'>
           {bullets.map((line, i) => (
             <li key={`${mode}-bullet-${i}`}>{line}</li>
           ))}

--- a/apps/web/src/components/billing/BillingTabs.web.tsx
+++ b/apps/web/src/components/billing/BillingTabs.web.tsx
@@ -13,7 +13,7 @@ const tabs: { to: string; end?: boolean; label: string }[] = [
 export function BillingTabs() {
   return (
     <nav
-      className='-mb-px flex gap-0 overflow-x-auto border-b border-gray-200 sm:overflow-visible'
+      className='-mb-px flex gap-0 overflow-x-auto border-b border-gray-200 dark:border-gray-700 sm:overflow-visible'
       aria-label='Billing sections'
     >
       {tabs.map(t => (
@@ -26,7 +26,7 @@ export function BillingTabs() {
               'shrink-0 px-4 py-3 text-sm font-medium',
               isActive
                 ? 'border-b-2 border-indigo-600 text-indigo-600'
-                : 'text-gray-600 hover:text-gray-900',
+                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white',
             ].join(' ')
           }
         >

--- a/apps/web/src/components/billing/ConfirmDowngradeModal.web.tsx
+++ b/apps/web/src/components/billing/ConfirmDowngradeModal.web.tsx
@@ -24,8 +24,8 @@ export function ConfirmDowngradeModal({
       size='md'
       contentClassName=''
     >
-      <p className='text-sm text-gray-600'>{bodyText}</p>
-      <p className='mt-2 text-sm text-gray-500'>
+      <p className='text-sm text-gray-600 dark:text-gray-300'>{bodyText}</p>
+      <p className='mt-2 text-sm text-gray-500 dark:text-gray-400'>
         Changes that reduce your entitlements take effect at the end of the
         current billing period, unless your payment provider processes them
         sooner. Proration is handled by Stripe.

--- a/apps/web/src/components/billing/ConstraintWarning.web.tsx
+++ b/apps/web/src/components/billing/ConstraintWarning.web.tsx
@@ -1,7 +1,7 @@
 export function ConstraintWarning({ message }: { message: string }) {
   return (
     <div
-      className='mb-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900'
+      className='mb-3 rounded-md border border-amber-200 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 p-3 text-sm text-amber-900 dark:text-amber-200'
       role='status'
     >
       {message}

--- a/apps/web/src/components/billing/FeatureLimitRow.web.tsx
+++ b/apps/web/src/components/billing/FeatureLimitRow.web.tsx
@@ -12,9 +12,9 @@ export function FeatureLimitRow({
   const u = used ?? 0;
   if (capIsUnlimited) {
     return (
-      <div className='flex items-center justify-between border-b border-gray-100 py-2 text-sm'>
-        <span className='text-gray-900'>{name}</span>
-        <span className='text-gray-600'>{u} of unlimited</span>
+      <div className='flex items-center justify-between border-b border-gray-100 dark:border-gray-700 py-2 text-sm'>
+        <span className='text-gray-900 dark:text-white'>{name}</span>
+        <span className='text-gray-600 dark:text-gray-400'>{u} of unlimited</span>
       </div>
     );
   }
@@ -23,11 +23,11 @@ export function FeatureLimitRow({
   const at = u >= cap;
   return (
     <div
-      className={`flex items-center justify-between border-b border-gray-100 py-2 text-sm ${
-        at ? 'text-red-700' : heavy ? 'text-amber-800' : 'text-gray-600'
+      className={`flex items-center justify-between border-b border-gray-100 dark:border-gray-700 py-2 text-sm ${
+        at ? 'text-red-700 dark:text-red-400' : heavy ? 'text-amber-800 dark:text-amber-400' : 'text-gray-600'
       }`}
     >
-      <span className='text-gray-900'>{name}</span>
+      <span className='text-gray-900 dark:text-white'>{name}</span>
       <span>
         {u} of {cap}
       </span>

--- a/apps/web/src/components/billing/PlanFeatureList.web.tsx
+++ b/apps/web/src/components/billing/PlanFeatureList.web.tsx
@@ -25,10 +25,10 @@ export function PlanFeatureList({
 
   return (
     <div>
-      <p className='mb-2 text-sm font-medium text-gray-900'>
+      <p className='mb-2 text-sm font-medium text-gray-900 dark:text-white'>
         What&apos;s included
       </p>
-      <ul className='space-y-1.5 text-sm text-gray-600'>
+      <ul className='space-y-1.5 text-sm text-gray-600 dark:text-gray-400'>
         {rows.map(row => {
           const { ok, text } = planFeatureLine(plan, row);
           return (
@@ -40,7 +40,7 @@ export function PlanFeatureList({
                 />
               ) : (
                 <X
-                  className='mt-0.5 h-4 w-4 shrink-0 text-gray-300'
+                  className='mt-0.5 h-4 w-4 shrink-0 text-gray-300 dark:text-gray-600'
                   aria-hidden
                 />
               )}

--- a/apps/web/src/components/billing/PlanFeatureRow.web.tsx
+++ b/apps/web/src/components/billing/PlanFeatureRow.web.tsx
@@ -11,8 +11,8 @@ export function PlanFeatureRow({
   showUpgradeLink?: boolean;
 }): JSX.Element {
   return (
-    <div className='flex items-center justify-between border-b border-gray-100 py-2 text-sm'>
-      <div className='flex items-center gap-2 text-gray-900'>
+    <div className='flex items-center justify-between border-b border-gray-100 dark:border-gray-700 py-2 text-sm'>
+      <div className='flex items-center gap-2 text-gray-900 dark:text-white'>
         {available ? (
           <Check className='h-4 w-4 text-green-600' aria-hidden />
         ) : (
@@ -20,7 +20,7 @@ export function PlanFeatureRow({
         )}
         <span>{name}</span>
       </div>
-      <div className='text-right text-gray-600'>
+      <div className='text-right text-gray-600 dark:text-gray-400'>
         {available ? (
           'Available'
         ) : (

--- a/apps/web/src/components/billing/StatusBadge.web.tsx
+++ b/apps/web/src/components/billing/StatusBadge.web.tsx
@@ -4,12 +4,12 @@ const base =
   'inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium capitalize';
 
 const styles: Record<string, { label: string; cls: string }> = {
-  paid: { label: 'Paid', cls: 'bg-green-100 text-green-800' },
-  open: { label: 'Open', cls: 'bg-blue-100 text-blue-800' },
-  uncollectible: { label: 'Failed', cls: 'bg-red-100 text-red-800' },
-  void: { label: 'Void', cls: 'bg-gray-100 text-gray-800' },
-  draft: { label: 'Draft', cls: 'bg-gray-100 text-gray-800' },
-  refunded: { label: 'Refunded', cls: 'bg-gray-100 text-gray-800' },
+  paid: { label: 'Paid', cls: 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-300' },
+  open: { label: 'Open', cls: 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300' },
+  uncollectible: { label: 'Failed', cls: 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-300' },
+  void: { label: 'Void', cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300' },
+  draft: { label: 'Draft', cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300' },
+  refunded: { label: 'Refunded', cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300' },
 };
 
 export function StatusBadge({
@@ -20,7 +20,7 @@ export function StatusBadge({
   className?: string;
 }): JSX.Element {
   const s = (status || '').toLowerCase();
-  const m = styles[s] ?? { label: status, cls: 'bg-gray-100 text-gray-800' };
+  const m = styles[s] ?? { label: status, cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300' };
   return (
     <span className={`${base} ${m.cls} ${className}`.trim()}>{m.label}</span>
   );

--- a/apps/web/src/components/dashboard/AISummarizeResult.tsx
+++ b/apps/web/src/components/dashboard/AISummarizeResult.tsx
@@ -10,9 +10,9 @@ type Props = {
 
 export function AISummarizeResult({ entries }: Props) {
   return (
-    <div className='mt-4 rounded-lg border border-gray-200 bg-gray-50 p-4'>
+    <div className='mt-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 p-4'>
       {entries.length === 0 ? (
-        <p className='text-sm text-gray-500'>
+        <p className='text-sm text-gray-500 dark:text-gray-400'>
           Click &apos;Simulate AI summarize&apos; to generate a result.
         </p>
       ) : (
@@ -20,12 +20,12 @@ export function AISummarizeResult({ entries }: Props) {
           {entries.map(e => (
             <li
               key={e.id}
-              className='border-b border-gray-200 pb-3 last:border-0 last:pb-0'
+              className='border-b border-gray-200 dark:border-gray-700 pb-3 last:border-0 last:pb-0'
             >
-              <p className='text-xs text-gray-500'>
+              <p className='text-xs text-gray-500 dark:text-gray-400'>
                 {new Date(e.at).toLocaleString()}
               </p>
-              <p className='mt-1 whitespace-pre-wrap text-sm text-gray-800'>
+              <p className='mt-1 whitespace-pre-wrap text-sm text-gray-800 dark:text-gray-200'>
                 {e.text}
               </p>
             </li>

--- a/apps/web/src/components/dashboard/BooleanGatesDemo.tsx
+++ b/apps/web/src/components/dashboard/BooleanGatesDemo.tsx
@@ -6,7 +6,7 @@ import { beakerstackBillingConfig } from '../../billing/beakerstackBillingConfig
 
 function UpgradeLine({ name }: { name: string }) {
   return (
-    <p className='text-sm text-gray-600'>
+    <p className='text-sm text-gray-600 dark:text-gray-400'>
       {name} requires a higher plan.{' '}
       <Link
         to='/billing/plans'
@@ -30,7 +30,7 @@ export function BooleanGatesDemo() {
   return (
     <div className='space-y-6'>
       <div>
-        <p className='text-sm font-medium text-gray-800'>
+        <p className='text-sm font-medium text-gray-800 dark:text-gray-200'>
           Feature A (requires Pro)
         </p>
         <div className='mt-2'>
@@ -50,7 +50,7 @@ export function BooleanGatesDemo() {
         </div>
       </div>
       <div>
-        <p className='text-sm font-medium text-gray-800'>
+        <p className='text-sm font-medium text-gray-800 dark:text-gray-200'>
           Feature B (requires Max)
         </p>
         <div className='mt-2'>
@@ -71,19 +71,19 @@ export function BooleanGatesDemo() {
       </div>
       <p className='text-sm text-gray-600'>
         Imperative equivalent:{' '}
-        <code className='text-xs text-gray-800'>
+        <code className='text-xs text-gray-800 dark:text-gray-200'>
           const {'{'} enabled {'}'} = useFeature(&quot;feature_a&quot;)
         </code>{' '}
         → currently{' '}
-        <span className='font-mono text-gray-900'>
+        <span className='font-mono text-gray-900 dark:text-white'>
           {imperativeA.loading ? '…' : String(imperativeA.enabled)}
         </span>
         {' · '}
-        <code className='text-xs text-gray-800'>
+        <code className='text-xs text-gray-800 dark:text-gray-200'>
           useFeature(&quot;feature_b&quot;)
         </code>{' '}
         →{' '}
-        <span className='font-mono text-gray-900'>
+        <span className='font-mono text-gray-900 dark:text-white'>
           {imperativeB.loading ? '…' : String(imperativeB.enabled)}
         </span>
       </p>

--- a/apps/web/src/components/dashboard/DashboardDemoSection.tsx
+++ b/apps/web/src/components/dashboard/DashboardDemoSection.tsx
@@ -19,27 +19,27 @@ export function DashboardDemoSection({
 }: DashboardDemoSectionProps) {
   const borderClass =
     variant === 'demo-mode'
-      ? 'border-dashed border-gray-300'
-      : 'border-gray-200';
+      ? 'border-dashed border-gray-300 dark:border-gray-600'
+      : 'border-gray-200 dark:border-gray-700';
   return (
     <div
-      className={`relative rounded-xl border ${borderClass} bg-white p-6 shadow-sm`}
+      className={`relative rounded-xl border ${borderClass} bg-white dark:bg-gray-800 p-6 shadow-sm`}
     >
       {variant === 'demo-mode' && (
-        <span className='absolute right-4 top-3 rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800'>
+        <span className='absolute right-4 top-3 rounded bg-amber-100 dark:bg-amber-900/40 px-2 py-0.5 text-xs font-medium text-amber-800 dark:text-amber-300'>
           Demo mode only
         </span>
       )}
-      <h2 className='pr-32 text-lg font-semibold text-gray-900'>{title}</h2>
-      <p className='mt-1 text-xs font-medium uppercase tracking-wide text-gray-500'>
+      <h2 className='pr-32 text-lg font-semibold text-gray-900 dark:text-white'>{title}</h2>
+      <p className='mt-1 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400'>
         Demonstrates:{' '}
-        <span className='font-mono text-sm font-normal text-gray-700'>
+        <span className='font-mono text-sm font-normal text-gray-700 dark:text-gray-300'>
           {demonstrates}
         </span>
       </p>
-      <p className='mt-2 text-sm text-gray-600'>{description}</p>
+      <p className='mt-2 text-sm text-gray-600 dark:text-gray-400'>{description}</p>
       <div className='mt-4'>{children}</div>
-      <p className='mt-4 text-xs font-mono text-gray-500'>// {codeReference}</p>
+      <p className='mt-4 text-xs font-mono text-gray-500 dark:text-gray-400'>// {codeReference}</p>
     </div>
   );
 }

--- a/apps/web/src/components/dashboard/DemoControlsPanel.tsx
+++ b/apps/web/src/components/dashboard/DemoControlsPanel.tsx
@@ -85,7 +85,7 @@ export function DemoControlsPanel() {
       codeReference='await supabaseRpc.rpc("billing_demo_simulate_upgrade", { p_product_id, p_plan_id })'
       variant='demo-mode'
     >
-      <p className='text-sm text-gray-700'>
+      <p className='text-sm text-gray-700 dark:text-gray-300'>
         Current plan:{' '}
         <span className='font-medium text-gray-900'>
           {planLoading ? '…' : (plan?.display_name ?? '—')}
@@ -99,7 +99,7 @@ export function DemoControlsPanel() {
             type='button'
             disabled={plan?.id === p.id || pending != null}
             onClick={() => onSimulatePlan(p.id)}
-            className='rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-800 shadow-sm hover:bg-gray-50 disabled:opacity-50'
+            className='rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-800 dark:text-gray-200 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50'
           >
             {pending === `plan:${p.id}` ? '…' : `Switch to ${p.label}`}
           </button>
@@ -111,19 +111,19 @@ export function DemoControlsPanel() {
           type='button'
           disabled={pending != null}
           onClick={onResetUsage}
-          className='rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-800 shadow-sm hover:bg-gray-50 disabled:opacity-50'
+          className='rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm font-medium text-gray-800 dark:text-gray-200 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50'
         >
           {pending === 'reset' ? '…' : 'Reset all usage counters'}
         </button>
       </div>
 
       {message && (
-        <p className='mt-2 text-sm text-gray-600' role='status'>
+        <p className='mt-2 text-sm text-gray-600 dark:text-gray-300' role='status'>
           {message}
         </p>
       )}
 
-      <p className='mt-3 text-xs text-gray-500'>
+      <p className='mt-3 text-xs text-gray-500 dark:text-gray-400'>
         These actions take effect immediately and bypass Stripe. Do not deploy
         to production.
       </p>

--- a/apps/web/src/components/dashboard/MeteredUsageDemo.tsx
+++ b/apps/web/src/components/dashboard/MeteredUsageDemo.tsx
@@ -113,21 +113,14 @@ export function MeteredUsageDemo() {
     <div>
       <div className='mt-0' data-testid='usage-indicator-expanded'>
         {limit != null && (
-          <div
-            className='mt-2'
-            style={{ height: 8, background: '#e5e7eb', borderRadius: 4 }}
-          >
+          <div className='mt-2 h-2 w-full rounded-full bg-gray-200 dark:bg-gray-700'>
             <div
-              style={{
-                width: `${pct}%`,
-                height: 8,
-                background: '#4f46e5',
-                borderRadius: 4,
-              }}
+              className='h-2 rounded-full bg-indigo-600 dark:bg-indigo-500'
+              style={{ width: `${pct}%` }}
             />
           </div>
         )}
-        <div className='mt-2 text-sm text-gray-600'>
+        <div className='mt-2 text-sm text-gray-600 dark:text-gray-400'>
           {loading ? '…' : capLine}
         </div>
       </div>
@@ -135,7 +128,7 @@ export function MeteredUsageDemo() {
         {exceeded ? (
           <>
             <span
-              className='inline-flex items-center rounded-md bg-gray-100 px-3 py-2 text-sm text-gray-500'
+              className='inline-flex items-center rounded-md bg-gray-100 dark:bg-gray-700 px-3 py-2 text-sm text-gray-500 dark:text-gray-400'
               title='Usage cap reached for this period'
             >
               Limit reached

--- a/apps/web/src/components/dashboard/NumericCapsDemo.tsx
+++ b/apps/web/src/components/dashboard/NumericCapsDemo.tsx
@@ -59,16 +59,16 @@ export function NumericCapsDemo() {
   return (
     <div>
       {error && (
-        <p className='mb-2 text-sm text-amber-800' role='alert'>
+        <p className='mb-2 text-sm text-amber-800 dark:text-amber-300' role='alert'>
           {error}{' '}
-          <span className='text-gray-600'>
+          <span className='text-gray-600 dark:text-gray-400'>
             (Requires demo billing RPCs and{' '}
             <code className='text-xs'>demo_billing_mode</code> in the database.)
           </span>
         </p>
       )}
       <div className='flex flex-wrap items-center justify-between gap-2'>
-        <p className='text-sm text-gray-700'>
+        <p className='text-sm text-gray-700 dark:text-gray-300'>
           Collections:{' '}
           <span className='font-medium'>
             {loading || featLoading ? '…' : count} of {limLabel(maxCollections)}
@@ -106,7 +106,7 @@ export function NumericCapsDemo() {
       )}
 
       {!loading && collections.length === 0 ? (
-        <p className='mt-4 text-sm text-gray-500'>
+        <p className='mt-4 text-sm text-gray-500 dark:text-gray-400'>
           No collections yet. Click &apos;Add collection&apos; to start.
         </p>
       ) : (
@@ -121,14 +121,14 @@ export function NumericCapsDemo() {
             return (
               <li
                 key={row.id}
-                className='rounded-lg border border-gray-200 bg-gray-50 px-4 py-3'
+                className='rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50 px-4 py-3'
               >
                 <div className='flex flex-wrap items-start justify-between gap-2'>
                   <div>
-                    <p className='font-mono text-xs text-gray-600'>
+                    <p className='font-mono text-xs text-gray-600 dark:text-gray-400'>
                       {row.id.slice(0, 8)}…
                     </p>
-                    <p className='mt-1 text-sm text-gray-700'>
+                    <p className='mt-1 text-sm text-gray-700 dark:text-gray-300'>
                       Items: {row.item_count} of {limLabel(maxItemsPer)}
                     </p>
                   </div>
@@ -148,7 +148,7 @@ export function NumericCapsDemo() {
                           await addItem(row.id);
                         })
                       }
-                      className='rounded-md border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50'
+                      className='rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50'
                     >
                       {busy === busyKey
                         ? '…'
@@ -165,7 +165,7 @@ export function NumericCapsDemo() {
                           await deleteCollection(row.id);
                         })
                       }
-                      className='rounded-md p-2 text-red-600 hover:bg-red-50 disabled:opacity-50'
+                      className='rounded-md p-2 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-50'
                     >
                       <Trash2 className='h-4 w-4' aria-hidden />
                     </button>

--- a/packages/shared/src/components/profile/ProfileEditor.web.tsx
+++ b/packages/shared/src/components/profile/ProfileEditor.web.tsx
@@ -133,8 +133,8 @@ export function ProfileEditor({
 
   if (!currentUser) {
     return (
-      <div className={`rounded-md bg-yellow-50 p-4 ${className}`}>
-        <p className='text-sm text-yellow-800'>
+      <div className={`rounded-md bg-yellow-50 dark:bg-yellow-900/30 p-4 ${className}`}>
+        <p className='text-sm text-yellow-800 dark:text-yellow-300'>
           Please sign in to edit your profile.
         </p>
       </div>
@@ -143,15 +143,15 @@ export function ProfileEditor({
 
   if (loading && !profileData) {
     return (
-      <div className={`rounded-md bg-gray-50 p-4 ${className}`}>
-        <p className='text-sm text-gray-600'>Loading profile...</p>
+      <div className={`rounded-md bg-gray-50 dark:bg-gray-800 p-4 ${className}`}>
+        <p className='text-sm text-gray-600 dark:text-gray-400'>Loading profile...</p>
       </div>
     );
   }
 
   return (
     <div className={`space-y-4 ${className}`}>
-      <h3 className='text-lg font-semibold text-gray-900'>Edit Profile</h3>
+      <h3 className='text-lg font-semibold text-gray-900 dark:text-white'>Edit Profile</h3>
 
       <div className='space-y-4'>
         <FormInput

--- a/packages/shared/src/components/profile/ProfileHeader.web.tsx
+++ b/packages/shared/src/components/profile/ProfileHeader.web.tsx
@@ -18,8 +18,8 @@ export function ProfileHeader({
 }: ProfileHeaderProps) {
   if (!profile) {
     return (
-      <div className={`rounded-md bg-gray-50 p-4 ${className}`}>
-        <p className='text-sm text-gray-600'>No profile data available.</p>
+      <div className={`rounded-md bg-gray-50 dark:bg-gray-800 p-4 ${className}`}>
+        <p className='text-sm text-gray-600 dark:text-gray-400'>No profile data available.</p>
       </div>
     );
   }
@@ -34,12 +34,12 @@ export function ProfileHeader({
       <div className='flex items-start space-x-4'>
         <ProfileAvatar profile={profile} size='large' />
         <div className='flex-1 min-w-0'>
-          <h2 className='text-2xl font-bold text-gray-900 truncate'>
+          <h2 className='text-2xl font-bold text-gray-900 dark:text-white truncate'>
             {displayName}
           </h2>
-          {username && <p className='text-sm text-gray-500 mt-1'>{username}</p>}
+          {username && <p className='text-sm text-gray-500 dark:text-gray-400 mt-1'>{username}</p>}
           {hasMetadata && (
-            <div className='flex flex-wrap gap-4 mt-2 text-sm text-gray-600'>
+            <div className='flex flex-wrap gap-4 mt-2 text-sm text-gray-600 dark:text-gray-400'>
               {email && (
                 <span className='flex items-center'>
                   <svg
@@ -87,7 +87,7 @@ export function ProfileHeader({
                   href={profile.website}
                   target='_blank'
                   rel='noopener noreferrer'
-                  className='flex items-center text-blue-600 hover:text-blue-800 hover:underline'
+                  className='flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline'
                 >
                   <svg
                     className='w-4 h-4 mr-1'
@@ -112,7 +112,7 @@ export function ProfileHeader({
         </div>
       </div>
       {profile.bio && (
-        <p className='text-gray-700 whitespace-pre-wrap'>{profile.bio}</p>
+        <p className='text-gray-700 dark:text-gray-300 whitespace-pre-wrap'>{profile.bio}</p>
       )}
     </div>
   );

--- a/packages/shared/src/components/profile/ProfileStats.web.tsx
+++ b/packages/shared/src/components/profile/ProfileStats.web.tsx
@@ -58,7 +58,7 @@ export function ProfileStats({ profile, className = '' }: ProfileStatsProps) {
   return (
     <div className={`space-y-2 ${className}`}>
       {memberSince && (
-        <div className='text-sm text-gray-600'>
+        <div className='text-sm text-gray-600 dark:text-gray-400'>
           <span className='font-medium'>Member since:</span> {memberSince}
         </div>
       )}


### PR DESCRIPTION
## Summary

- Adds `dark:` Tailwind variants to 18 components that had no dark mode support: sign-up plan summary, social login button, billing tabs/badges/feature rows/confirm modal, all dashboard demo sections, and shared profile header/stats/editor.
- Converts `MeteredUsageDemo` progress bar from hardcoded inline `style` hex colours to Tailwind classes so dark mode works correctly.

## Files changed (18)
`apps/web`: SignupPlanSummary, SocialLoginButton, BillingTabs, ConstraintWarning, PlanFeatureList, PlanFeatureRow, StatusBadge, FeatureLimitRow, ConfirmDowngradeModal, DashboardDemoSection, DemoControlsPanel, MeteredUsageDemo, BooleanGatesDemo, NumericCapsDemo, AISummarizeResult  
`packages/shared`: ProfileHeader, ProfileStats, ProfileEditor

## Test plan
- [ ] Toggle dark mode on `/dashboard` — all demo sections render correctly
- [ ] Toggle dark mode on `/billing` — tabs, badges, feature rows, confirm-downgrade modal render correctly
- [ ] Toggle dark mode on `/signup?plan=...` and `/login?plan=...` — plan summary card renders correctly
- [ ] Toggle dark mode on profile page — header, stats, editor render correctly

Closes #93