### PR TITLE
fix(ci): handle PR base-branch retargeting via pull_request edited event

### DIFF
--- a/.github/workflows/check-merge-strategy.yml
+++ b/.github/workflows/check-merge-strategy.yml
@@ -2,7 +2,7 @@ name: Check Merge Strategy
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/check-merge-strategy.yml
+++ b/.github/workflows/check-merge-strategy.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   check-merge-strategy:
-    if: github.base_ref == 'main'
+    if: github.base_ref == 'main' && (github.event.action != 'edited' || github.event.changes.base)
     runs-on: ubuntu-latest
     steps:
       - name: Add merge strategy reminder comment

--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -29,7 +29,7 @@ jobs:
     if: >-
       github.event.action != 'closed' &&
       (github.base_ref != 'develop' || github.head_ref != 'main') &&
-      (github.event.action != 'edited' || github.event.changes.base.ref.from != '')
+      (github.event.action != 'edited' || github.event.changes.base)
     runs-on: ubuntu-latest
     outputs:
       run_deploy: ${{ steps.check.outputs.run_deploy }}

--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -10,6 +10,7 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+      - edited
       - closed
 
 permissions:
@@ -23,8 +24,12 @@ concurrency:
 
 jobs:
   preview-scope:
-    # Skip main→develop sync PRs (no feature preview; diff would match everything on develop).
-    if: github.event.action != 'closed' && (github.base_ref != 'develop' || github.head_ref != 'main')
+    # Skip main→develop sync PRs, closed events not followed by teardown, and edited events
+    # that only changed the PR title/body (not the base branch — those should redeploy).
+    if: >-
+      github.event.action != 'closed' &&
+      (github.base_ref != 'develop' || github.head_ref != 'main') &&
+      (github.event.action != 'edited' || github.event.changes.base.ref.from != '')
     runs-on: ubuntu-latest
     outputs:
       run_deploy: ${{ steps.check.outputs.run_deploy }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   tests:
     # On edited events, only run when the base branch was retargeted (not title/body-only edits).
-    if: github.event.action != 'edited' || github.event.changes.base.ref.from != ''
+    if: github.event.action != 'edited' || github.event.changes.base
     runs-on: ubuntu-latest
     timeout-minutes: 45
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - main
       - develop
   pull_request:
+    types: [opened, synchronize, reopened, edited]
     paths:
       # Application code and tests
       - 'apps/**'
@@ -39,6 +40,8 @@ permissions:
 
 jobs:
   tests:
+    # On edited events, only run when the base branch was retargeted (not title/body-only edits).
+    if: github.event.action != 'edited' || github.event.changes.base.ref.from != ''
     runs-on: ubuntu-latest
     timeout-minutes: 45
 


### PR DESCRIPTION
Closes #94

## What changed

When a PR is retargeted to a different base branch, GitHub fires a `pull_request` event with action `edited` and a `changes.base.ref.from` payload. Without `edited` in the workflow `types`, none of the PR workflows fire on retargeting — so previews never appear and tests run against a stale merge base.

### `pr-preview-environment.yml`

- Added `edited` to `types`
- Added a guard on the `preview-scope` job: skip when `edited` but `changes.base.ref.from` is empty (title/body-only edits). Only real base-branch retargets redeploy.
- All downstream jobs (`deploy-preview`, `comment`, `teardown`) are already gated on `preview-scope` so they inherit this filter.

### `test.yml`

- Added explicit `types: [opened, synchronize, reopened, edited]` (previously omitted, defaulting to the first three without `edited`)
- Added `if: github.event.action != 'edited' || github.event.changes.base.ref.from != ''` on the `tests` job so title/body-only edits don't trigger a full test run

### `check-merge-strategy.yml`

- Added `edited` to `types`
- The existing `if: github.base_ref == 'main'` already correctly routes:
  - develop → main retargeting: `edited` event, `base_ref == 'main'` → reminder runs ✅
  - main → develop retargeting: `edited` event, `base_ref == 'develop'` → job skipped ✅

## Testing

The `edited` event with `changes.base` can be verified by opening a PR against `main`, then retargeting it to `develop` via the GitHub UI and confirming the preview and test workflows appear in the Checks tab.