### PR TITLE
fix: dark mode for auth, billing, dashboard, and profile components

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -111,14 +111,14 @@ npm run setup:full
 
 Options (see also `npm run setup:full -- --help`):
 
-| Flag                 | Meaning                              |
-| -------------------- | ------------------------------------ |
-| `--dry-run`          | No file writes; log-only GitHub sync |
-| `--from=PHASE`       | Resume at a phase (see table below)  |
-| `--skip-rename`      | Skip template rename                 |
-| `--skip-github`      | Do not push secrets with `gh`        |
+| Flag                 | Meaning                                     |
+| -------------------- | ------------------------------------------- |
+| `--dry-run`          | No file writes; log-only GitHub sync        |
+| `--from=PHASE`       | Resume at a phase (see table below)         |
+| `--skip-rename`      | Skip template rename                        |
+| `--skip-github`      | Do not push secrets with `gh`               |
 | `--skip-mobile`      | Skip Expo/EAS/Google setup (web-only repos) |
-| `--aws-profile=NAME` | Pass through to AWS bootstrap script |
+| `--aws-profile=NAME` | Pass through to AWS bootstrap script        |
 
 **Phase names** for `--from=` (order matters; later phases assume earlier work or merged `.env*` files):
 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Details: [docs/pr-preview-setup.md](docs/pr-preview-setup.md).
 
 Template snapshots are tagged on `main` using **CalVer** (`2026.001`, `2026.002`, …). Each release includes generated notes covering what changed and whether there are any breaking steps. `@beakerstack/*` packages use independent **semver** on npm.
 
-| Trigger | Workflow |
-| ------- | -------- |
+| Trigger             | Workflow                                                                                                  |
+| ------------------- | --------------------------------------------------------------------------------------------------------- |
 | **Manual dispatch** | [release-template.yml](.github/workflows/release-template.yml) — cuts a new CalVer tag and GitHub Release |
 
 See [VERSIONING.md](VERSIONING.md) for what counts as a breaking change and [UPGRADING.md](UPGRADING.md) for how to pull template changes into an existing fork.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -25,9 +25,11 @@ git merge 2026.003
 ```
 
 > **"Use this template" users:** If you created your repo using GitHub's "Use this template" button, git treats the histories as unrelated. Your first merge will need `--allow-unrelated-histories`:
+>
 > ```bash
 > git merge --allow-unrelated-histories 2026.003
 > ```
+>
 > Subsequent merges work without the flag.
 
 Resolve any conflicts, then review the release notes for that tag on GitHub for any breaking changes that need manual follow-up (new secrets, renamed variables, migration steps).

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -30,10 +30,10 @@ Breaking changes are called out explicitly in the release notes generated for th
 
 ### `main` vs. tagged releases
 
-| Ref | What it is | Recommended for |
-|-----|-----------|-----------------|
-| `main` | Current stable HEAD | Following along with active development |
-| `2026.NNN` | Snapshot tag | Starting a new fork; upgrading an existing fork in a controlled way |
+| Ref        | What it is          | Recommended for                                                     |
+| ---------- | ------------------- | ------------------------------------------------------------------- |
+| `main`     | Current stable HEAD | Following along with active development                             |
+| `2026.NNN` | Snapshot tag        | Starting a new fork; upgrading an existing fork in a controlled way |
 
 If you are forking BeakerStack to build a product, start from a tagged release so your upgrade story is clear from day one.
 

--- a/apps/web/src/__tests__/dark-mode-coverage.test.ts
+++ b/apps/web/src/__tests__/dark-mode-coverage.test.ts
@@ -22,10 +22,18 @@ function walk(dir: string, ext: string, skip: string[] = []): string[] {
 }
 
 const SCAN_FILES = [
-  ...walk(join(MONOREPO_ROOT, 'packages/shared/src/components'), '.web.tsx', ['__tests__']),
-  ...walk(join(MONOREPO_ROOT, 'packages/billing/src/components'), '.web.tsx', ['__tests__']),
-  ...walk(join(MONOREPO_ROOT, 'apps/web/src/components/billing'), '.tsx', ['__tests__']),
-  ...walk(join(MONOREPO_ROOT, 'apps/web/src/pages/billing'), '.tsx', ['__tests__']),
+  ...walk(join(MONOREPO_ROOT, 'packages/shared/src/components'), '.web.tsx', [
+    '__tests__',
+  ]),
+  ...walk(join(MONOREPO_ROOT, 'packages/billing/src/components'), '.web.tsx', [
+    '__tests__',
+  ]),
+  ...walk(join(MONOREPO_ROOT, 'apps/web/src/components/billing'), '.tsx', [
+    '__tests__',
+  ]),
+  ...walk(join(MONOREPO_ROOT, 'apps/web/src/pages/billing'), '.tsx', [
+    '__tests__',
+  ]),
 ];
 
 // Extract string literals that look like they contain Tailwind class names.
@@ -37,7 +45,11 @@ function extractClassLikeStrings(src: string): string[] {
   let m;
   while ((m = re.exec(src)) !== null) {
     const s = m[1];
-    if (/\b(?:text|bg|border|rounded|flex|grid|font|shadow|hover|dark)[-:][a-zA-Z0-9/[\].]+/.test(s)) {
+    if (
+      /\b(?:text|bg|border|rounded|flex|grid|font|shadow|hover|dark)[-:][a-zA-Z0-9/[\].]+/.test(
+        s
+      )
+    ) {
       results.add(s);
     }
   }
@@ -45,7 +57,8 @@ function extractClassLikeStrings(src: string): string[] {
 }
 
 // Light text shades that are hard to read on dark backgrounds
-const NEEDS_DARK_TEXT = /\btext-(?:gray|slate|zinc|neutral|stone)-(?:600|700|800|900|950)\b/;
+const NEEDS_DARK_TEXT =
+  /\btext-(?:gray|slate|zinc|neutral|stone)-(?:600|700|800|900|950)\b/;
 // Light backgrounds that are painful in dark mode
 const NEEDS_DARK_BG = /\bbg-(?:white|(?:gray|slate|zinc)-(?:50|100|200|300))\b/;
 
@@ -60,7 +73,9 @@ describe('dark mode coverage', () => {
       const src = readFileSync(file, 'utf8');
       for (const cls of extractClassLikeStrings(src)) {
         if (NEEDS_DARK_TEXT.test(cls) && !/\bdark:text-/.test(cls)) {
-          violations.push(`${file.replace(MONOREPO_ROOT + '/', '')}: "${cls.slice(0, 80)}"`);
+          violations.push(
+            `${file.replace(MONOREPO_ROOT + '/', '')}: "${cls.slice(0, 80)}"`
+          );
         }
       }
     }
@@ -73,7 +88,9 @@ describe('dark mode coverage', () => {
       const src = readFileSync(file, 'utf8');
       for (const cls of extractClassLikeStrings(src)) {
         if (NEEDS_DARK_BG.test(cls) && !/\bdark:bg-/.test(cls)) {
-          violations.push(`${file.replace(MONOREPO_ROOT + '/', '')}: "${cls.slice(0, 80)}"`);
+          violations.push(
+            `${file.replace(MONOREPO_ROOT + '/', '')}: "${cls.slice(0, 80)}"`
+          );
         }
       }
     }

--- a/apps/web/src/__tests__/dark-mode-coverage.test.ts
+++ b/apps/web/src/__tests__/dark-mode-coverage.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const MONOREPO_ROOT = resolve(__dirname, '../../../..');
+
+function walk(dir: string, ext: string, skip: string[] = []): string[] {
+  const results: string[] = [];
+  try {
+    for (const entry of readdirSync(dir)) {
+      if (skip.includes(entry)) continue;
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        results.push(...walk(full, ext, skip));
+      } else if (entry.endsWith(ext)) {
+        results.push(full);
+      }
+    }
+  } catch {
+    // directory doesn't exist — skip
+  }
+  return results;
+}
+
+const SCAN_FILES = [
+  ...walk(join(MONOREPO_ROOT, 'packages/shared/src/components'), '.web.tsx', ['__tests__']),
+  ...walk(join(MONOREPO_ROOT, 'packages/billing/src/components'), '.web.tsx', ['__tests__']),
+  ...walk(join(MONOREPO_ROOT, 'apps/web/src/components/billing'), '.tsx', ['__tests__']),
+  ...walk(join(MONOREPO_ROOT, 'apps/web/src/pages/billing'), '.tsx', ['__tests__']),
+];
+
+// Extract string literals that look like they contain Tailwind class names.
+// Scans ALL quoted strings in the file (not just className=) to catch dynamic
+// class strings built via template literals and variable assignments.
+function extractClassLikeStrings(src: string): string[] {
+  const results = new Set<string>();
+  const re = /['"]([^'"]{4,})['"]/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    const s = m[1];
+    if (/\b(?:text|bg|border|rounded|flex|grid|font|shadow|hover|dark)[-:][a-zA-Z0-9/[\].]+/.test(s)) {
+      results.add(s);
+    }
+  }
+  return [...results];
+}
+
+// Light text shades that are hard to read on dark backgrounds
+const NEEDS_DARK_TEXT = /\btext-(?:gray|slate|zinc|neutral|stone)-(?:600|700|800|900|950)\b/;
+// Light backgrounds that are painful in dark mode
+const NEEDS_DARK_BG = /\bbg-(?:white|(?:gray|slate|zinc)-(?:50|100|200|300))\b/;
+
+describe('dark mode coverage', () => {
+  it('scans at least one file', () => {
+    expect(SCAN_FILES.length).toBeGreaterThan(0);
+  });
+
+  it('class strings with light text colors have a dark:text- counterpart', () => {
+    const violations: string[] = [];
+    for (const file of SCAN_FILES) {
+      const src = readFileSync(file, 'utf8');
+      for (const cls of extractClassLikeStrings(src)) {
+        if (NEEDS_DARK_TEXT.test(cls) && !/\bdark:text-/.test(cls)) {
+          violations.push(`${file.replace(MONOREPO_ROOT + '/', '')}: "${cls.slice(0, 80)}"`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('class strings with light backgrounds have a dark:bg- counterpart', () => {
+    const violations: string[] = [];
+    for (const file of SCAN_FILES) {
+      const src = readFileSync(file, 'utf8');
+      for (const cls of extractClassLikeStrings(src)) {
+        if (NEEDS_DARK_BG.test(cls) && !/\bdark:bg-/.test(cls)) {
+          violations.push(`${file.replace(MONOREPO_ROOT + '/', '')}: "${cls.slice(0, 80)}"`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/apps/web/src/auth/__tests__/postAuthRedirect.test.ts
+++ b/apps/web/src/auth/__tests__/postAuthRedirect.test.ts
@@ -140,6 +140,9 @@ function storageMock(store: Record<string, string>) {
     removeItem: (k: string) => {
       delete store[k];
     },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+    },
   };
 }
 

--- a/apps/web/src/components/SocialLoginButton.tsx
+++ b/apps/web/src/components/SocialLoginButton.tsx
@@ -33,8 +33,8 @@ export function SocialLoginButton({
       disabled={isLoading}
       className={`
         w-full flex items-center justify-center gap-3 px-4 py-2 
-        border border-gray-300 rounded-md shadow-sm
-        bg-white hover:bg-gray-50 text-gray-700
+        border border-gray-300 dark:border-gray-600 rounded-md shadow-sm
+        bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200
         text-sm font-medium
         focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500
         disabled:opacity-50 disabled:cursor-not-allowed

--- a/apps/web/src/components/auth/SignupPlanSummary.tsx
+++ b/apps/web/src/components/auth/SignupPlanSummary.tsx
@@ -37,7 +37,9 @@ export function PlanIntentSummary({
   if (loading) {
     return (
       <div className='rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm'>
-        <p className='text-sm text-gray-500 dark:text-gray-400'>Loading plan…</p>
+        <p className='text-sm text-gray-500 dark:text-gray-400'>
+          Loading plan…
+        </p>
       </div>
     );
   }
@@ -117,7 +119,9 @@ export function PlanIntentSummary({
         >
           {priceHeadline}
         </p>
-        <p className='text-sm text-gray-600 dark:text-gray-400'>{priceSubline}</p>
+        <p className='text-sm text-gray-600 dark:text-gray-400'>
+          {priceSubline}
+        </p>
       </div>
       {bullets.length > 0 ? (
         <ul className='mt-4 list-inside list-disc space-y-1 text-sm text-gray-700 dark:text-gray-300'>

--- a/apps/web/src/components/auth/SignupPlanSummary.tsx
+++ b/apps/web/src/components/auth/SignupPlanSummary.tsx
@@ -36,8 +36,8 @@ export function PlanIntentSummary({
 
   if (loading) {
     return (
-      <div className='rounded-xl border border-gray-200 bg-white p-6 shadow-sm'>
-        <p className='text-sm text-gray-500'>Loading plan…</p>
+      <div className='rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm'>
+        <p className='text-sm text-gray-500 dark:text-gray-400'>Loading plan…</p>
       </div>
     );
   }
@@ -80,15 +80,15 @@ export function PlanIntentSummary({
     <div
       className={
         mode === 'login'
-          ? 'rounded-lg border border-gray-200 bg-white p-4 shadow-sm'
-          : 'rounded-xl border border-indigo-100 bg-indigo-50/80 p-6 shadow-sm ring-1 ring-indigo-100'
+          ? 'rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm'
+          : 'rounded-xl border border-indigo-200 dark:border-indigo-700 bg-indigo-50/80 dark:bg-indigo-900/30 p-6 shadow-sm ring-1 ring-indigo-100 dark:ring-indigo-800'
       }
     >
       <p
         className={
           mode === 'login'
-            ? 'text-xs font-medium uppercase tracking-wide text-gray-500'
-            : 'text-xs font-semibold uppercase tracking-wide text-indigo-800'
+            ? 'text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400'
+            : 'text-xs font-semibold uppercase tracking-wide text-indigo-800 dark:text-indigo-300'
         }
       >
         {mode === 'login' ? 'Plan from pricing' : 'Your selection'}
@@ -96,14 +96,14 @@ export function PlanIntentSummary({
       <h3
         className={
           mode === 'login'
-            ? 'mt-1 text-lg font-semibold text-gray-900'
-            : 'mt-1 text-xl font-bold text-gray-900'
+            ? 'mt-1 text-lg font-semibold text-gray-900 dark:text-white'
+            : 'mt-1 text-xl font-bold text-gray-900 dark:text-white'
         }
       >
         {catalogPlan.display_name}
       </h3>
       {savingsCallout ? (
-        <p className='mt-1 text-xs font-semibold text-amber-900'>
+        <p className='mt-1 text-xs font-semibold text-amber-900 dark:text-amber-300'>
           {savingsCallout}
         </p>
       ) : null}
@@ -111,16 +111,16 @@ export function PlanIntentSummary({
         <p
           className={
             mode === 'login'
-              ? 'text-xl font-bold text-gray-900'
-              : 'text-2xl font-bold text-gray-900'
+              ? 'text-xl font-bold text-gray-900 dark:text-white'
+              : 'text-2xl font-bold text-gray-900 dark:text-white'
           }
         >
           {priceHeadline}
         </p>
-        <p className='text-sm text-gray-600'>{priceSubline}</p>
+        <p className='text-sm text-gray-600 dark:text-gray-400'>{priceSubline}</p>
       </div>
       {bullets.length > 0 ? (
-        <ul className='mt-4 list-inside list-disc space-y-1 text-sm text-gray-700'>
+        <ul className='mt-4 list-inside list-disc space-y-1 text-sm text-gray-700 dark:text-gray-300'>
           {bullets.map((line, i) => (
             <li key={`${mode}-bullet-${i}`}>{line}</li>
           ))}

--- a/apps/web/src/components/billing/BillingTabs.web.tsx
+++ b/apps/web/src/components/billing/BillingTabs.web.tsx
@@ -13,7 +13,7 @@ const tabs: { to: string; end?: boolean; label: string }[] = [
 export function BillingTabs() {
   return (
     <nav
-      className='-mb-px flex gap-0 overflow-x-auto border-b border-gray-200 sm:overflow-visible'
+      className='-mb-px flex gap-0 overflow-x-auto border-b border-gray-200 dark:border-gray-700 sm:overflow-visible'
       aria-label='Billing sections'
     >
       {tabs.map(t => (
@@ -26,7 +26,7 @@ export function BillingTabs() {
               'shrink-0 px-4 py-3 text-sm font-medium',
               isActive
                 ? 'border-b-2 border-indigo-600 text-indigo-600'
-                : 'text-gray-600 hover:text-gray-900',
+                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white',
             ].join(' ')
           }
         >

--- a/apps/web/src/components/billing/BillingTabs.web.tsx
+++ b/apps/web/src/components/billing/BillingTabs.web.tsx
@@ -25,7 +25,7 @@ export function BillingTabs() {
             [
               'shrink-0 px-4 py-3 text-sm font-medium',
               isActive
-                ? 'border-b-2 border-indigo-600 text-indigo-600'
+                ? 'border-b-2 border-indigo-600 dark:border-indigo-400 text-indigo-600 dark:text-indigo-400'
                 : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white',
             ].join(' ')
           }

--- a/apps/web/src/components/billing/ConfirmDowngradeModal.web.tsx
+++ b/apps/web/src/components/billing/ConfirmDowngradeModal.web.tsx
@@ -24,8 +24,8 @@ export function ConfirmDowngradeModal({
       size='md'
       contentClassName=''
     >
-      <p className='text-sm text-gray-600'>{bodyText}</p>
-      <p className='mt-2 text-sm text-gray-500'>
+      <p className='text-sm text-gray-600 dark:text-gray-300'>{bodyText}</p>
+      <p className='mt-2 text-sm text-gray-500 dark:text-gray-400'>
         Changes that reduce your entitlements take effect at the end of the
         current billing period, unless your payment provider processes them
         sooner. Proration is handled by Stripe.

--- a/apps/web/src/components/billing/ConstraintWarning.web.tsx
+++ b/apps/web/src/components/billing/ConstraintWarning.web.tsx
@@ -1,7 +1,7 @@
 export function ConstraintWarning({ message }: { message: string }) {
   return (
     <div
-      className='mb-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900'
+      className='mb-3 rounded-md border border-amber-200 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 p-3 text-sm text-amber-900 dark:text-amber-200'
       role='status'
     >
       {message}

--- a/apps/web/src/components/billing/FeatureLimitRow.web.tsx
+++ b/apps/web/src/components/billing/FeatureLimitRow.web.tsx
@@ -24,7 +24,7 @@ export function FeatureLimitRow({
   return (
     <div
       className={`flex items-center justify-between border-b border-gray-100 dark:border-gray-700 py-2 text-sm ${
-        at ? 'text-red-700 dark:text-red-400' : heavy ? 'text-amber-800 dark:text-amber-400' : 'text-gray-600'
+        at ? 'text-red-700 dark:text-red-400' : heavy ? 'text-amber-800 dark:text-amber-400' : 'text-gray-600 dark:text-gray-400'
       }`}
     >
       <span className='text-gray-900 dark:text-white'>{name}</span>

--- a/apps/web/src/components/billing/FeatureLimitRow.web.tsx
+++ b/apps/web/src/components/billing/FeatureLimitRow.web.tsx
@@ -14,7 +14,9 @@ export function FeatureLimitRow({
     return (
       <div className='flex items-center justify-between border-b border-gray-100 dark:border-gray-700 py-2 text-sm'>
         <span className='text-gray-900 dark:text-white'>{name}</span>
-        <span className='text-gray-600 dark:text-gray-400'>{u} of unlimited</span>
+        <span className='text-gray-600 dark:text-gray-400'>
+          {u} of unlimited
+        </span>
       </div>
     );
   }
@@ -24,7 +26,11 @@ export function FeatureLimitRow({
   return (
     <div
       className={`flex items-center justify-between border-b border-gray-100 dark:border-gray-700 py-2 text-sm ${
-        at ? 'text-red-700 dark:text-red-400' : heavy ? 'text-amber-800 dark:text-amber-400' : 'text-gray-600 dark:text-gray-400'
+        at
+          ? 'text-red-700 dark:text-red-400'
+          : heavy
+            ? 'text-amber-800 dark:text-amber-400'
+            : 'text-gray-600 dark:text-gray-400'
       }`}
     >
       <span className='text-gray-900 dark:text-white'>{name}</span>

--- a/apps/web/src/components/billing/FeatureLimitRow.web.tsx
+++ b/apps/web/src/components/billing/FeatureLimitRow.web.tsx
@@ -12,9 +12,9 @@ export function FeatureLimitRow({
   const u = used ?? 0;
   if (capIsUnlimited) {
     return (
-      <div className='flex items-center justify-between border-b border-gray-100 py-2 text-sm'>
-        <span className='text-gray-900'>{name}</span>
-        <span className='text-gray-600'>{u} of unlimited</span>
+      <div className='flex items-center justify-between border-b border-gray-100 dark:border-gray-700 py-2 text-sm'>
+        <span className='text-gray-900 dark:text-white'>{name}</span>
+        <span className='text-gray-600 dark:text-gray-400'>{u} of unlimited</span>
       </div>
     );
   }
@@ -23,11 +23,11 @@ export function FeatureLimitRow({
   const at = u >= cap;
   return (
     <div
-      className={`flex items-center justify-between border-b border-gray-100 py-2 text-sm ${
-        at ? 'text-red-700' : heavy ? 'text-amber-800' : 'text-gray-600'
+      className={`flex items-center justify-between border-b border-gray-100 dark:border-gray-700 py-2 text-sm ${
+        at ? 'text-red-700 dark:text-red-400' : heavy ? 'text-amber-800 dark:text-amber-400' : 'text-gray-600'
       }`}
     >
-      <span className='text-gray-900'>{name}</span>
+      <span className='text-gray-900 dark:text-white'>{name}</span>
       <span>
         {u} of {cap}
       </span>

--- a/apps/web/src/components/billing/InvoiceList.web.tsx
+++ b/apps/web/src/components/billing/InvoiceList.web.tsx
@@ -51,7 +51,7 @@ export function InvoiceList({
         <div className='mt-4 text-right'>
           <Link
             to='/billing/invoices'
-            className='text-sm font-medium text-indigo-600 hover:text-indigo-500'
+            className='text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-300'
           >
             View all invoices →
           </Link>

--- a/apps/web/src/components/billing/InvoiceTable.web.tsx
+++ b/apps/web/src/components/billing/InvoiceTable.web.tsx
@@ -30,7 +30,7 @@ export function InvoiceTable({
         </p>
         <Link
           to='/billing/plans'
-          className='mt-4 inline-block text-sm font-medium text-indigo-600 hover:text-indigo-500'
+          className='mt-4 inline-block text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-300'
         >
           View plans
         </Link>
@@ -84,7 +84,7 @@ export function InvoiceTable({
                       href={inv.hosted_invoice_url}
                       target='_blank'
                       rel='noreferrer'
-                      className='mr-3 text-indigo-600 hover:text-indigo-500'
+                      className='mr-3 text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-300'
                     >
                       View
                     </a>
@@ -94,7 +94,7 @@ export function InvoiceTable({
                       href={inv.invoice_pdf_url}
                       target='_blank'
                       rel='noreferrer'
-                      className='text-indigo-600 hover:text-indigo-500'
+                      className='text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-300'
                     >
                       PDF
                     </a>

--- a/apps/web/src/components/billing/PlanFeatureList.web.tsx
+++ b/apps/web/src/components/billing/PlanFeatureList.web.tsx
@@ -40,7 +40,7 @@ export function PlanFeatureList({
                 />
               ) : (
                 <X
-                  className='mt-0.5 h-4 w-4 shrink-0 text-gray-300 dark:text-gray-600'
+                  className='mt-0.5 h-4 w-4 shrink-0 text-gray-300 dark:text-gray-500'
                   aria-hidden
                 />
               )}

--- a/apps/web/src/components/billing/PlanFeatureList.web.tsx
+++ b/apps/web/src/components/billing/PlanFeatureList.web.tsx
@@ -25,10 +25,10 @@ export function PlanFeatureList({
 
   return (
     <div>
-      <p className='mb-2 text-sm font-medium text-gray-900'>
+      <p className='mb-2 text-sm font-medium text-gray-900 dark:text-white'>
         What&apos;s included
       </p>
-      <ul className='space-y-1.5 text-sm text-gray-600'>
+      <ul className='space-y-1.5 text-sm text-gray-600 dark:text-gray-400'>
         {rows.map(row => {
           const { ok, text } = planFeatureLine(plan, row);
           return (
@@ -40,7 +40,7 @@ export function PlanFeatureList({
                 />
               ) : (
                 <X
-                  className='mt-0.5 h-4 w-4 shrink-0 text-gray-300'
+                  className='mt-0.5 h-4 w-4 shrink-0 text-gray-300 dark:text-gray-600'
                   aria-hidden
                 />
               )}

--- a/apps/web/src/components/billing/PlanFeatureRow.web.tsx
+++ b/apps/web/src/components/billing/PlanFeatureRow.web.tsx
@@ -11,8 +11,8 @@ export function PlanFeatureRow({
   showUpgradeLink?: boolean;
 }): JSX.Element {
   return (
-    <div className='flex items-center justify-between border-b border-gray-100 py-2 text-sm'>
-      <div className='flex items-center gap-2 text-gray-900'>
+    <div className='flex items-center justify-between border-b border-gray-100 dark:border-gray-700 py-2 text-sm'>
+      <div className='flex items-center gap-2 text-gray-900 dark:text-white'>
         {available ? (
           <Check className='h-4 w-4 text-green-600' aria-hidden />
         ) : (
@@ -20,7 +20,7 @@ export function PlanFeatureRow({
         )}
         <span>{name}</span>
       </div>
-      <div className='text-right text-gray-600'>
+      <div className='text-right text-gray-600 dark:text-gray-400'>
         {available ? (
           'Available'
         ) : (

--- a/apps/web/src/components/billing/StatusBadge.web.tsx
+++ b/apps/web/src/components/billing/StatusBadge.web.tsx
@@ -4,12 +4,12 @@ const base =
   'inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium capitalize';
 
 const styles: Record<string, { label: string; cls: string }> = {
-  paid: { label: 'Paid', cls: 'bg-green-100 text-green-800' },
-  open: { label: 'Open', cls: 'bg-blue-100 text-blue-800' },
-  uncollectible: { label: 'Failed', cls: 'bg-red-100 text-red-800' },
-  void: { label: 'Void', cls: 'bg-gray-100 text-gray-800' },
-  draft: { label: 'Draft', cls: 'bg-gray-100 text-gray-800' },
-  refunded: { label: 'Refunded', cls: 'bg-gray-100 text-gray-800' },
+  paid: { label: 'Paid', cls: 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-300' },
+  open: { label: 'Open', cls: 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300' },
+  uncollectible: { label: 'Failed', cls: 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-300' },
+  void: { label: 'Void', cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300' },
+  draft: { label: 'Draft', cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300' },
+  refunded: { label: 'Refunded', cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300' },
 };
 
 export function StatusBadge({
@@ -20,7 +20,7 @@ export function StatusBadge({
   className?: string;
 }): JSX.Element {
   const s = (status || '').toLowerCase();
-  const m = styles[s] ?? { label: status, cls: 'bg-gray-100 text-gray-800' };
+  const m = styles[s] ?? { label: status, cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300' };
   return (
     <span className={`${base} ${m.cls} ${className}`.trim()}>{m.label}</span>
   );

--- a/apps/web/src/components/billing/StatusBadge.web.tsx
+++ b/apps/web/src/components/billing/StatusBadge.web.tsx
@@ -4,12 +4,30 @@ const base =
   'inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium capitalize';
 
 const styles: Record<string, { label: string; cls: string }> = {
-  paid: { label: 'Paid', cls: 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-300' },
-  open: { label: 'Open', cls: 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300' },
-  uncollectible: { label: 'Failed', cls: 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-300' },
-  void: { label: 'Void', cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300' },
-  draft: { label: 'Draft', cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300' },
-  refunded: { label: 'Refunded', cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300' },
+  paid: {
+    label: 'Paid',
+    cls: 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-300',
+  },
+  open: {
+    label: 'Open',
+    cls: 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300',
+  },
+  uncollectible: {
+    label: 'Failed',
+    cls: 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-300',
+  },
+  void: {
+    label: 'Void',
+    cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300',
+  },
+  draft: {
+    label: 'Draft',
+    cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300',
+  },
+  refunded: {
+    label: 'Refunded',
+    cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300',
+  },
 };
 
 export function StatusBadge({
@@ -20,7 +38,10 @@ export function StatusBadge({
   className?: string;
 }): JSX.Element {
   const s = (status || '').toLowerCase();
-  const m = styles[s] ?? { label: status, cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300' };
+  const m = styles[s] ?? {
+    label: status,
+    cls: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300',
+  };
   return (
     <span className={`${base} ${m.cls} ${className}`.trim()}>{m.label}</span>
   );

--- a/apps/web/src/components/dashboard/AISummarizeResult.tsx
+++ b/apps/web/src/components/dashboard/AISummarizeResult.tsx
@@ -10,9 +10,9 @@ type Props = {
 
 export function AISummarizeResult({ entries }: Props) {
   return (
-    <div className='mt-4 rounded-lg border border-gray-200 bg-gray-50 p-4'>
+    <div className='mt-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 p-4'>
       {entries.length === 0 ? (
-        <p className='text-sm text-gray-500'>
+        <p className='text-sm text-gray-500 dark:text-gray-400'>
           Click &apos;Simulate AI summarize&apos; to generate a result.
         </p>
       ) : (
@@ -20,12 +20,12 @@ export function AISummarizeResult({ entries }: Props) {
           {entries.map(e => (
             <li
               key={e.id}
-              className='border-b border-gray-200 pb-3 last:border-0 last:pb-0'
+              className='border-b border-gray-200 dark:border-gray-700 pb-3 last:border-0 last:pb-0'
             >
-              <p className='text-xs text-gray-500'>
+              <p className='text-xs text-gray-500 dark:text-gray-400'>
                 {new Date(e.at).toLocaleString()}
               </p>
-              <p className='mt-1 whitespace-pre-wrap text-sm text-gray-800'>
+              <p className='mt-1 whitespace-pre-wrap text-sm text-gray-800 dark:text-gray-200'>
                 {e.text}
               </p>
             </li>

--- a/apps/web/src/components/dashboard/BooleanGatesDemo.tsx
+++ b/apps/web/src/components/dashboard/BooleanGatesDemo.tsx
@@ -6,7 +6,7 @@ import { beakerstackBillingConfig } from '../../billing/beakerstackBillingConfig
 
 function UpgradeLine({ name }: { name: string }) {
   return (
-    <p className='text-sm text-gray-600'>
+    <p className='text-sm text-gray-600 dark:text-gray-400'>
       {name} requires a higher plan.{' '}
       <Link
         to='/billing/plans'
@@ -30,7 +30,7 @@ export function BooleanGatesDemo() {
   return (
     <div className='space-y-6'>
       <div>
-        <p className='text-sm font-medium text-gray-800'>
+        <p className='text-sm font-medium text-gray-800 dark:text-gray-200'>
           Feature A (requires Pro)
         </p>
         <div className='mt-2'>
@@ -50,7 +50,7 @@ export function BooleanGatesDemo() {
         </div>
       </div>
       <div>
-        <p className='text-sm font-medium text-gray-800'>
+        <p className='text-sm font-medium text-gray-800 dark:text-gray-200'>
           Feature B (requires Max)
         </p>
         <div className='mt-2'>
@@ -71,19 +71,19 @@ export function BooleanGatesDemo() {
       </div>
       <p className='text-sm text-gray-600'>
         Imperative equivalent:{' '}
-        <code className='text-xs text-gray-800'>
+        <code className='text-xs text-gray-800 dark:text-gray-200'>
           const {'{'} enabled {'}'} = useFeature(&quot;feature_a&quot;)
         </code>{' '}
         → currently{' '}
-        <span className='font-mono text-gray-900'>
+        <span className='font-mono text-gray-900 dark:text-white'>
           {imperativeA.loading ? '…' : String(imperativeA.enabled)}
         </span>
         {' · '}
-        <code className='text-xs text-gray-800'>
+        <code className='text-xs text-gray-800 dark:text-gray-200'>
           useFeature(&quot;feature_b&quot;)
         </code>{' '}
         →{' '}
-        <span className='font-mono text-gray-900'>
+        <span className='font-mono text-gray-900 dark:text-white'>
           {imperativeB.loading ? '…' : String(imperativeB.enabled)}
         </span>
       </p>

--- a/apps/web/src/components/dashboard/DashboardDemoSection.tsx
+++ b/apps/web/src/components/dashboard/DashboardDemoSection.tsx
@@ -30,16 +30,22 @@ export function DashboardDemoSection({
           Demo mode only
         </span>
       )}
-      <h2 className='pr-32 text-lg font-semibold text-gray-900 dark:text-white'>{title}</h2>
+      <h2 className='pr-32 text-lg font-semibold text-gray-900 dark:text-white'>
+        {title}
+      </h2>
       <p className='mt-1 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400'>
         Demonstrates:{' '}
         <span className='font-mono text-sm font-normal text-gray-700 dark:text-gray-300'>
           {demonstrates}
         </span>
       </p>
-      <p className='mt-2 text-sm text-gray-600 dark:text-gray-400'>{description}</p>
+      <p className='mt-2 text-sm text-gray-600 dark:text-gray-400'>
+        {description}
+      </p>
       <div className='mt-4'>{children}</div>
-      <p className='mt-4 text-xs font-mono text-gray-500 dark:text-gray-400'>// {codeReference}</p>
+      <p className='mt-4 text-xs font-mono text-gray-500 dark:text-gray-400'>
+        // {codeReference}
+      </p>
     </div>
   );
 }

--- a/apps/web/src/components/dashboard/DashboardDemoSection.tsx
+++ b/apps/web/src/components/dashboard/DashboardDemoSection.tsx
@@ -19,27 +19,27 @@ export function DashboardDemoSection({
 }: DashboardDemoSectionProps) {
   const borderClass =
     variant === 'demo-mode'
-      ? 'border-dashed border-gray-300'
-      : 'border-gray-200';
+      ? 'border-dashed border-gray-300 dark:border-gray-600'
+      : 'border-gray-200 dark:border-gray-700';
   return (
     <div
-      className={`relative rounded-xl border ${borderClass} bg-white p-6 shadow-sm`}
+      className={`relative rounded-xl border ${borderClass} bg-white dark:bg-gray-800 p-6 shadow-sm`}
     >
       {variant === 'demo-mode' && (
-        <span className='absolute right-4 top-3 rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800'>
+        <span className='absolute right-4 top-3 rounded bg-amber-100 dark:bg-amber-900/40 px-2 py-0.5 text-xs font-medium text-amber-800 dark:text-amber-300'>
           Demo mode only
         </span>
       )}
-      <h2 className='pr-32 text-lg font-semibold text-gray-900'>{title}</h2>
-      <p className='mt-1 text-xs font-medium uppercase tracking-wide text-gray-500'>
+      <h2 className='pr-32 text-lg font-semibold text-gray-900 dark:text-white'>{title}</h2>
+      <p className='mt-1 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400'>
         Demonstrates:{' '}
-        <span className='font-mono text-sm font-normal text-gray-700'>
+        <span className='font-mono text-sm font-normal text-gray-700 dark:text-gray-300'>
           {demonstrates}
         </span>
       </p>
-      <p className='mt-2 text-sm text-gray-600'>{description}</p>
+      <p className='mt-2 text-sm text-gray-600 dark:text-gray-400'>{description}</p>
       <div className='mt-4'>{children}</div>
-      <p className='mt-4 text-xs font-mono text-gray-500'>// {codeReference}</p>
+      <p className='mt-4 text-xs font-mono text-gray-500 dark:text-gray-400'>// {codeReference}</p>
     </div>
   );
 }

--- a/apps/web/src/components/dashboard/DemoControlsPanel.tsx
+++ b/apps/web/src/components/dashboard/DemoControlsPanel.tsx
@@ -85,7 +85,7 @@ export function DemoControlsPanel() {
       codeReference='await supabaseRpc.rpc("billing_demo_simulate_upgrade", { p_product_id, p_plan_id })'
       variant='demo-mode'
     >
-      <p className='text-sm text-gray-700'>
+      <p className='text-sm text-gray-700 dark:text-gray-300'>
         Current plan:{' '}
         <span className='font-medium text-gray-900'>
           {planLoading ? '…' : (plan?.display_name ?? '—')}
@@ -99,7 +99,7 @@ export function DemoControlsPanel() {
             type='button'
             disabled={plan?.id === p.id || pending != null}
             onClick={() => onSimulatePlan(p.id)}
-            className='rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-800 shadow-sm hover:bg-gray-50 disabled:opacity-50'
+            className='rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-800 dark:text-gray-200 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50'
           >
             {pending === `plan:${p.id}` ? '…' : `Switch to ${p.label}`}
           </button>
@@ -111,19 +111,19 @@ export function DemoControlsPanel() {
           type='button'
           disabled={pending != null}
           onClick={onResetUsage}
-          className='rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-800 shadow-sm hover:bg-gray-50 disabled:opacity-50'
+          className='rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm font-medium text-gray-800 dark:text-gray-200 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50'
         >
           {pending === 'reset' ? '…' : 'Reset all usage counters'}
         </button>
       </div>
 
       {message && (
-        <p className='mt-2 text-sm text-gray-600' role='status'>
+        <p className='mt-2 text-sm text-gray-600 dark:text-gray-300' role='status'>
           {message}
         </p>
       )}
 
-      <p className='mt-3 text-xs text-gray-500'>
+      <p className='mt-3 text-xs text-gray-500 dark:text-gray-400'>
         These actions take effect immediately and bypass Stripe. Do not deploy
         to production.
       </p>

--- a/apps/web/src/components/dashboard/DemoControlsPanel.tsx
+++ b/apps/web/src/components/dashboard/DemoControlsPanel.tsx
@@ -118,7 +118,10 @@ export function DemoControlsPanel() {
       </div>
 
       {message && (
-        <p className='mt-2 text-sm text-gray-600 dark:text-gray-300' role='status'>
+        <p
+          className='mt-2 text-sm text-gray-600 dark:text-gray-300'
+          role='status'
+        >
           {message}
         </p>
       )}

--- a/apps/web/src/components/dashboard/DemoControlsPanel.tsx
+++ b/apps/web/src/components/dashboard/DemoControlsPanel.tsx
@@ -87,7 +87,7 @@ export function DemoControlsPanel() {
     >
       <p className='text-sm text-gray-700 dark:text-gray-300'>
         Current plan:{' '}
-        <span className='font-medium text-gray-900'>
+        <span className='font-medium text-gray-900 dark:text-white'>
           {planLoading ? '…' : (plan?.display_name ?? '—')}
         </span>
       </p>

--- a/apps/web/src/components/dashboard/MeteredUsageDemo.tsx
+++ b/apps/web/src/components/dashboard/MeteredUsageDemo.tsx
@@ -113,21 +113,14 @@ export function MeteredUsageDemo() {
     <div>
       <div className='mt-0' data-testid='usage-indicator-expanded'>
         {limit != null && (
-          <div
-            className='mt-2'
-            style={{ height: 8, background: '#e5e7eb', borderRadius: 4 }}
-          >
+          <div className='mt-2 h-2 w-full rounded-full bg-gray-200 dark:bg-gray-700'>
             <div
-              style={{
-                width: `${pct}%`,
-                height: 8,
-                background: '#4f46e5',
-                borderRadius: 4,
-              }}
+              className='h-2 rounded-full bg-indigo-600 dark:bg-indigo-500'
+              style={{ width: `${pct}%` }}
             />
           </div>
         )}
-        <div className='mt-2 text-sm text-gray-600'>
+        <div className='mt-2 text-sm text-gray-600 dark:text-gray-400'>
           {loading ? '…' : capLine}
         </div>
       </div>
@@ -135,7 +128,7 @@ export function MeteredUsageDemo() {
         {exceeded ? (
           <>
             <span
-              className='inline-flex items-center rounded-md bg-gray-100 px-3 py-2 text-sm text-gray-500'
+              className='inline-flex items-center rounded-md bg-gray-100 dark:bg-gray-700 px-3 py-2 text-sm text-gray-500 dark:text-gray-400'
               title='Usage cap reached for this period'
             >
               Limit reached

--- a/apps/web/src/components/dashboard/NumericCapsDemo.tsx
+++ b/apps/web/src/components/dashboard/NumericCapsDemo.tsx
@@ -59,7 +59,10 @@ export function NumericCapsDemo() {
   return (
     <div>
       {error && (
-        <p className='mb-2 text-sm text-amber-800 dark:text-amber-300' role='alert'>
+        <p
+          className='mb-2 text-sm text-amber-800 dark:text-amber-300'
+          role='alert'
+        >
           {error}{' '}
           <span className='text-gray-600 dark:text-gray-400'>
             (Requires demo billing RPCs and{' '}

--- a/apps/web/src/components/dashboard/NumericCapsDemo.tsx
+++ b/apps/web/src/components/dashboard/NumericCapsDemo.tsx
@@ -59,16 +59,16 @@ export function NumericCapsDemo() {
   return (
     <div>
       {error && (
-        <p className='mb-2 text-sm text-amber-800' role='alert'>
+        <p className='mb-2 text-sm text-amber-800 dark:text-amber-300' role='alert'>
           {error}{' '}
-          <span className='text-gray-600'>
+          <span className='text-gray-600 dark:text-gray-400'>
             (Requires demo billing RPCs and{' '}
             <code className='text-xs'>demo_billing_mode</code> in the database.)
           </span>
         </p>
       )}
       <div className='flex flex-wrap items-center justify-between gap-2'>
-        <p className='text-sm text-gray-700'>
+        <p className='text-sm text-gray-700 dark:text-gray-300'>
           Collections:{' '}
           <span className='font-medium'>
             {loading || featLoading ? '…' : count} of {limLabel(maxCollections)}
@@ -106,7 +106,7 @@ export function NumericCapsDemo() {
       )}
 
       {!loading && collections.length === 0 ? (
-        <p className='mt-4 text-sm text-gray-500'>
+        <p className='mt-4 text-sm text-gray-500 dark:text-gray-400'>
           No collections yet. Click &apos;Add collection&apos; to start.
         </p>
       ) : (
@@ -121,14 +121,14 @@ export function NumericCapsDemo() {
             return (
               <li
                 key={row.id}
-                className='rounded-lg border border-gray-200 bg-gray-50 px-4 py-3'
+                className='rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50 px-4 py-3'
               >
                 <div className='flex flex-wrap items-start justify-between gap-2'>
                   <div>
-                    <p className='font-mono text-xs text-gray-600'>
+                    <p className='font-mono text-xs text-gray-600 dark:text-gray-400'>
                       {row.id.slice(0, 8)}…
                     </p>
-                    <p className='mt-1 text-sm text-gray-700'>
+                    <p className='mt-1 text-sm text-gray-700 dark:text-gray-300'>
                       Items: {row.item_count} of {limLabel(maxItemsPer)}
                     </p>
                   </div>
@@ -148,7 +148,7 @@ export function NumericCapsDemo() {
                           await addItem(row.id);
                         })
                       }
-                      className='rounded-md border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50'
+                      className='rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50'
                     >
                       {busy === busyKey
                         ? '…'
@@ -165,7 +165,7 @@ export function NumericCapsDemo() {
                           await deleteCollection(row.id);
                         })
                       }
-                      className='rounded-md p-2 text-red-600 hover:bg-red-50 disabled:opacity-50'
+                      className='rounded-md p-2 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-50'
                     >
                       <Trash2 className='h-4 w-4' aria-hidden />
                     </button>

--- a/apps/web/src/pages/__tests__/AuthCallbackPage.coverage.test.tsx
+++ b/apps/web/src/pages/__tests__/AuthCallbackPage.coverage.test.tsx
@@ -52,6 +52,9 @@ describe('AuthCallbackPage (URL + auth branches)', () => {
       removeItem: (k: string) => {
         delete mem[k];
       },
+      clear: () => {
+        for (const k of Object.keys(mem)) delete mem[k];
+      },
     };
   }
 

--- a/apps/web/src/pages/billing/BillingInvoicesPage.tsx
+++ b/apps/web/src/pages/billing/BillingInvoicesPage.tsx
@@ -11,7 +11,9 @@ export default function BillingInvoicesPage() {
   >({ pageSize: 20 });
   return (
     <BillingPageShell maxWidthClass='max-w-[1024px]'>
-      <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>Billing</h1>
+      <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>
+        Billing
+      </h1>
       <div className='mt-4'>
         <BillingTabs />
       </div>

--- a/apps/web/src/pages/billing/BillingInvoicesPage.tsx
+++ b/apps/web/src/pages/billing/BillingInvoicesPage.tsx
@@ -11,12 +11,14 @@ export default function BillingInvoicesPage() {
   >({ pageSize: 20 });
   return (
     <BillingPageShell maxWidthClass='max-w-[1024px]'>
-      <h1 className='text-2xl font-bold text-gray-900'>Billing</h1>
+      <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>Billing</h1>
       <div className='mt-4'>
         <BillingTabs />
       </div>
-      <h2 className='mt-6 text-lg font-semibold text-gray-900'>Invoices</h2>
-      <p className='mt-1 text-sm text-gray-600'>
+      <h2 className='mt-6 text-lg font-semibold text-gray-900 dark:text-white'>
+        Invoices
+      </h2>
+      <p className='mt-1 text-sm text-gray-600 dark:text-gray-400'>
         Download invoices and receipts for your records.
       </p>
       {error && (

--- a/apps/web/src/pages/billing/BillingOverviewPage.tsx
+++ b/apps/web/src/pages/billing/BillingOverviewPage.tsx
@@ -77,7 +77,9 @@ export default function BillingOverviewPage() {
 
   return (
     <BillingPageShell>
-      <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>Billing</h1>
+      <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>
+        Billing
+      </h1>
       <div className='mt-4'>
         <BillingTabs />
       </div>

--- a/apps/web/src/pages/billing/BillingOverviewPage.tsx
+++ b/apps/web/src/pages/billing/BillingOverviewPage.tsx
@@ -77,7 +77,7 @@ export default function BillingOverviewPage() {
 
   return (
     <BillingPageShell>
-      <h1 className='text-2xl font-bold text-gray-900'>Billing</h1>
+      <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>Billing</h1>
       <div className='mt-4'>
         <BillingTabs />
       </div>

--- a/apps/web/src/pages/billing/BillingPlansPage.tsx
+++ b/apps/web/src/pages/billing/BillingPlansPage.tsx
@@ -263,7 +263,9 @@ export default function BillingPlansPage() {
 
   return (
     <BillingPageShell maxWidthClass='max-w-[1024px]'>
-      <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>Billing</h1>
+      <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>
+        Billing
+      </h1>
       <div className='mt-4'>
         <BillingTabs />
       </div>
@@ -293,7 +295,9 @@ export default function BillingPlansPage() {
         </div>
       ) : null}
       {catLoad ? (
-        <p className='mt-8 text-sm text-gray-500 dark:text-gray-400'>Loading plans…</p>
+        <p className='mt-8 text-sm text-gray-500 dark:text-gray-400'>
+          Loading plans…
+        </p>
       ) : (
         <div className='mt-8 grid grid-cols-1 gap-6 md:grid-cols-3'>
           {plans.map(p => {

--- a/apps/web/src/pages/billing/BillingPlansPage.tsx
+++ b/apps/web/src/pages/billing/BillingPlansPage.tsx
@@ -263,14 +263,14 @@ export default function BillingPlansPage() {
 
   return (
     <BillingPageShell maxWidthClass='max-w-[1024px]'>
-      <h1 className='text-2xl font-bold text-gray-900'>Billing</h1>
+      <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>Billing</h1>
       <div className='mt-4'>
         <BillingTabs />
       </div>
-      <h2 className='mt-6 text-xl font-semibold text-gray-900'>
+      <h2 className='mt-6 text-xl font-semibold text-gray-900 dark:text-white'>
         Choose a plan
       </h2>
-      <p className='mt-1 text-sm text-gray-600'>
+      <p className='mt-1 text-sm text-gray-600 dark:text-gray-400'>
         Switch plans or update your billing cadence anytime.
       </p>
       <div className='mt-6'>
@@ -279,13 +279,13 @@ export default function BillingPlansPage() {
       {welcomeFromPricing && welcomePlanMeta ? (
         <div
           role='status'
-          className='mt-6 rounded-lg border border-indigo-200 bg-indigo-50 px-4 py-3 text-sm text-indigo-950'
+          className='mt-6 rounded-lg border border-indigo-200 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/30 px-4 py-3 text-sm text-indigo-950 dark:text-indigo-100'
         >
           <p className='font-medium'>
             You&apos;re almost there — finish checkout for{' '}
             {welcomePlanMeta.display_name}
           </p>
-          <p className='mt-1 text-indigo-900/90'>
+          <p className='mt-1 text-indigo-900/90 dark:text-indigo-200'>
             {cadence === 'annual'
               ? 'Annual billing is selected below. Use Upgrade to start checkout when you are ready.'
               : 'Monthly billing is selected below. Use Upgrade to start checkout when you are ready.'}
@@ -293,7 +293,7 @@ export default function BillingPlansPage() {
         </div>
       ) : null}
       {catLoad ? (
-        <p className='mt-8 text-sm text-gray-500'>Loading plans…</p>
+        <p className='mt-8 text-sm text-gray-500 dark:text-gray-400'>Loading plans…</p>
       ) : (
         <div className='mt-8 grid grid-cols-1 gap-6 md:grid-cols-3'>
           {plans.map(p => {
@@ -346,7 +346,7 @@ export default function BillingPlansPage() {
           })}
         </div>
       )}
-      <p className='mt-8 text-center text-xs text-gray-500'>
+      <p className='mt-8 text-center text-xs text-gray-500 dark:text-gray-400'>
         All plans billed in USD. Taxes calculated at checkout where applicable.
         Cancel anytime. Plans with a trial convert to paid at trial end unless
         you cancel before then (manage in Stripe customer portal).

--- a/apps/web/src/pages/billing/BillingUsagePage.tsx
+++ b/apps/web/src/pages/billing/BillingUsagePage.tsx
@@ -34,11 +34,15 @@ export default function BillingUsagePage() {
   if (!plan) {
     return (
       <BillingPageShell>
-        <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>Billing</h1>
+        <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>
+          Billing
+        </h1>
         <div className='mt-4'>
           <BillingTabs />
         </div>
-        <p className='mt-6 text-sm text-gray-600 dark:text-gray-400'>Loading plan…</p>
+        <p className='mt-6 text-sm text-gray-600 dark:text-gray-400'>
+          Loading plan…
+        </p>
       </BillingPageShell>
     );
   }
@@ -46,7 +50,9 @@ export default function BillingUsagePage() {
   const itemsCap = plan.features.items_per_container_max as number;
   return (
     <BillingPageShell>
-      <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>Billing</h1>
+      <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>
+        Billing
+      </h1>
       <div className='mt-4'>
         <BillingTabs />
       </div>
@@ -63,7 +69,9 @@ export default function BillingUsagePage() {
             : 'Your usage resets on your next billing date (see Usage below for the exact reset date for meters).'}
         </div>
         <section>
-          <h2 className='text-lg font-semibold text-gray-900 dark:text-white'>Usage</h2>
+          <h2 className='text-lg font-semibold text-gray-900 dark:text-white'>
+            Usage
+          </h2>
           {Object.keys(plan.usage_limits).map(m => (
             <div key={m} className='mt-3'>
               <UsageIndicator<typeof beakerstackBillingConfig>
@@ -76,7 +84,9 @@ export default function BillingUsagePage() {
           ))}
         </section>
         <section>
-          <h2 className='text-lg font-semibold text-gray-900 dark:text-white'>Limits</h2>
+          <h2 className='text-lg font-semibold text-gray-900 dark:text-white'>
+            Limits
+          </h2>
           <div className='mt-2 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm'>
             <FeatureLimitRow
               name={limitsCopy.collectionsRowName}
@@ -96,7 +106,9 @@ export default function BillingUsagePage() {
           </div>
         </section>
         <section>
-          <h2 className='text-lg font-semibold text-gray-900 dark:text-white'>Plan features</h2>
+          <h2 className='text-lg font-semibold text-gray-900 dark:text-white'>
+            Plan features
+          </h2>
           <div className='mt-2 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm'>
             <PlanFeatureRow
               name={featureALabel}

--- a/apps/web/src/pages/billing/BillingUsagePage.tsx
+++ b/apps/web/src/pages/billing/BillingUsagePage.tsx
@@ -34,11 +34,11 @@ export default function BillingUsagePage() {
   if (!plan) {
     return (
       <BillingPageShell>
-        <h1 className='text-2xl font-bold text-gray-900'>Billing</h1>
+        <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>Billing</h1>
         <div className='mt-4'>
           <BillingTabs />
         </div>
-        <p className='mt-6 text-sm text-gray-600'>Loading plan…</p>
+        <p className='mt-6 text-sm text-gray-600 dark:text-gray-400'>Loading plan…</p>
       </BillingPageShell>
     );
   }
@@ -46,7 +46,7 @@ export default function BillingUsagePage() {
   const itemsCap = plan.features.items_per_container_max as number;
   return (
     <BillingPageShell>
-      <h1 className='text-2xl font-bold text-gray-900'>Billing</h1>
+      <h1 className='text-2xl font-bold text-gray-900 dark:text-white'>Billing</h1>
       <div className='mt-4'>
         <BillingTabs />
       </div>
@@ -56,14 +56,14 @@ export default function BillingUsagePage() {
             Payment failed. Limits may change if your plan lapses.
           </Banner>
         )}
-        <div className='rounded-xl border border-gray-200 bg-white p-4 text-sm text-gray-700 shadow-sm'>
+        <div className='rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 text-sm text-gray-700 dark:text-gray-300 shadow-sm'>
           {subscription?.status === 'free' ||
           !subscription?.stripe_subscription_id
             ? `Your usage resets at the start of the next calendar month (free tier).`
             : 'Your usage resets on your next billing date (see Usage below for the exact reset date for meters).'}
         </div>
         <section>
-          <h2 className='text-lg font-semibold text-gray-900'>Usage</h2>
+          <h2 className='text-lg font-semibold text-gray-900 dark:text-white'>Usage</h2>
           {Object.keys(plan.usage_limits).map(m => (
             <div key={m} className='mt-3'>
               <UsageIndicator<typeof beakerstackBillingConfig>
@@ -76,8 +76,8 @@ export default function BillingUsagePage() {
           ))}
         </section>
         <section>
-          <h2 className='text-lg font-semibold text-gray-900'>Limits</h2>
-          <div className='mt-2 rounded-xl border border-gray-200 bg-white p-4 shadow-sm'>
+          <h2 className='text-lg font-semibold text-gray-900 dark:text-white'>Limits</h2>
+          <div className='mt-2 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm'>
             <FeatureLimitRow
               name={limitsCopy.collectionsRowName}
               used={colCount}
@@ -90,14 +90,14 @@ export default function BillingUsagePage() {
               cap={itemsCap === -1 ? 0 : itemsCap}
               capIsUnlimited={itemsCap === -1}
             />
-            <p className='pt-2 text-xs text-gray-500'>
+            <p className='pt-2 text-xs text-gray-500 dark:text-gray-400'>
               {limitsCopy.collectionsFootnote}
             </p>
           </div>
         </section>
         <section>
-          <h2 className='text-lg font-semibold text-gray-900'>Plan features</h2>
-          <div className='mt-2 rounded-xl border border-gray-200 bg-white p-4 shadow-sm'>
+          <h2 className='text-lg font-semibold text-gray-900 dark:text-white'>Plan features</h2>
+          <div className='mt-2 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm'>
             <PlanFeatureRow
               name={featureALabel}
               available={!!plan.features.feature_a}

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,5 +1,51 @@
 import '@testing-library/jest-dom';
 
+/** Node's experimental `--localstorage-file` / partial mocks can expose a broken Storage. */
+function createMemoryLocalStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    key(index: number) {
+      return [...store.keys()][index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value));
+    },
+  };
+}
+
+function localStorageIsUsable(ls: unknown): ls is Storage {
+  if (!ls || typeof ls !== 'object') return false;
+  const s = ls as Storage;
+  return (
+    typeof s.getItem === 'function' &&
+    typeof s.setItem === 'function' &&
+    typeof s.removeItem === 'function' &&
+    typeof s.clear === 'function' &&
+    typeof s.key === 'function' &&
+    typeof s.length === 'number'
+  );
+}
+
+if (!localStorageIsUsable(globalThis.localStorage)) {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: createMemoryLocalStorage(),
+    configurable: true,
+    writable: true,
+  });
+}
+
 // jsdom does not implement window.matchMedia. Provide a stub so components
 // that call it (e.g. ThemeProvider OS-preference watcher) don't throw.
 Object.defineProperty(window, 'matchMedia', {

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -11,7 +11,8 @@ function createMemoryLocalStorage(): Storage {
       store.clear();
     },
     getItem(key: string) {
-      return store.has(key) ? store.get(key)! : null;
+      const v = store.get(key);
+      return v === undefined ? null : v;
     },
     key(index: number) {
       return [...store.keys()][index] ?? null;

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,16 +4,16 @@ Start on the repo root **[README.md](../README.md)** and **[QUICKSTART.md](../QU
 
 ## Setup and infrastructure
 
-| Document                                                                     | Purpose                                                                        |
-| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| [QUICKSTART.md](../QUICKSTART.md)                                            | First run: local hello-world vs full cloud + CI checklist                      |
-| [pr-preview-setup.md](pr-preview-setup.md)                                   | AWS PR previews, DNS, CloudFormation                                           |
-| [supabase-staging-production-setup.md](supabase-staging-production-setup.md) | Remote staging/production Supabase projects                                    |
-| [supabase-preview-setup.md](supabase-preview-setup.md)                       | Shared PR preview database and redirects                                       |
-| [stripe-billing-setup.md](stripe-billing-setup.md)                           | Stripe + Supabase Edge billing (keys, webhooks, sync, local vs hosted)         |
-| [reference/github-actions-secrets.md](reference/github-actions-secrets.md)   | Actions secret/variable names (regenerate with `npm run docs:actions-secrets`) |
+| Document                                                                     | Purpose                                                                                      |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [QUICKSTART.md](../QUICKSTART.md)                                            | First run: local hello-world vs full cloud + CI checklist                                    |
+| [pr-preview-setup.md](pr-preview-setup.md)                                   | AWS PR previews, DNS, CloudFormation                                                         |
+| [supabase-staging-production-setup.md](supabase-staging-production-setup.md) | Remote staging/production Supabase projects                                                  |
+| [supabase-preview-setup.md](supabase-preview-setup.md)                       | Shared PR preview database and redirects                                                     |
+| [stripe-billing-setup.md](stripe-billing-setup.md)                           | Stripe + Supabase Edge billing (keys, webhooks, sync, local vs hosted)                       |
+| [reference/github-actions-secrets.md](reference/github-actions-secrets.md)   | Actions secret/variable names (regenerate with `npm run docs:actions-secrets`)               |
 | [project-label-bridge.md](project-label-bridge.md)                           | **Optional:** label-driven org GitHub Project updates (`npm run setup:project-label-bridge`) |
-| [branch-protection-setup.md](branch-protection-setup.md)                     | Branch rules                                                                   |
+| [branch-protection-setup.md](branch-protection-setup.md)                     | Branch rules                                                                                 |
 
 ## OAuth (canonical order)
 

--- a/docs/preview-access-control.md
+++ b/docs/preview-access-control.md
@@ -49,6 +49,7 @@ The `/_preview-auth` path uses a **separate cache behavior** with no `TrustedKey
 ```
 
 The script:
+
 1. Generates an RSA-2048 key pair
 2. Uploads the public key to CloudFront and retrieves its ID
 3. Updates the CloudFormation stack (`PreviewAccessControl`, `StagingAccessControl`, `CloudFrontSigningPublicKeyId` parameters) — this creates the key group and applies `TrustedKeyGroups` to the appropriate distributions
@@ -72,19 +73,19 @@ If you've already generated a key pair for another reason:
 
 The following parameters control access on the shared infrastructure stack (`infra/aws/pr-preview-stack.yml`):
 
-| Parameter | Values | Default | Description |
-|---|---|---|---|
-| `PreviewAccessControl` | `public`, `signed-cookies` | `public` | Access mode for PR preview (deploy) distribution |
-| `StagingAccessControl` | `public`, `signed-cookies` | `public` | Access mode for staging distribution |
-| `CloudFrontSigningPublicKeyId` | string | `''` | CloudFront public key ID; required when either is `signed-cookies` |
+| Parameter                      | Values                     | Default  | Description                                                        |
+| ------------------------------ | -------------------------- | -------- | ------------------------------------------------------------------ |
+| `PreviewAccessControl`         | `public`, `signed-cookies` | `public` | Access mode for PR preview (deploy) distribution                   |
+| `StagingAccessControl`         | `public`, `signed-cookies` | `public` | Access mode for staging distribution                               |
+| `CloudFrontSigningPublicKeyId` | string                     | `''`     | CloudFront public key ID; required when either is `signed-cookies` |
 
 ## GitHub Actions secrets
 
 Two optional secrets control CI signing behavior:
 
-| Secret | Description |
-|---|---|
-| `CLOUDFRONT_SIGNING_KEY` | RSA private key PEM. Set by `setup-signed-cookies.sh`. |
+| Secret                      | Description                                                 |
+| --------------------------- | ----------------------------------------------------------- |
+| `CLOUDFRONT_SIGNING_KEY`    | RSA private key PEM. Set by `setup-signed-cookies.sh`.      |
 | `CLOUDFRONT_SIGNING_KEY_ID` | CloudFront public key ID. Set by `setup-signed-cookies.sh`. |
 
 When these secrets are absent, CI skips cookie signing and posts plain URLs (public mode). No workflow change is needed when switching modes — the presence of the secrets determines behavior.
@@ -93,15 +94,16 @@ When these secrets are absent, CI skips cookie signing and posts plain URLs (pub
 
 Three cookies are set on the preview domain:
 
-| Cookie | Description |
-|---|---|
-| `CloudFront-Policy` | Base64-encoded custom policy (resource + expiry) |
-| `CloudFront-Signature` | RSA-SHA1 signature of the policy, signed with the private key |
+| Cookie                   | Description                                                   |
+| ------------------------ | ------------------------------------------------------------- |
+| `CloudFront-Policy`      | Base64-encoded custom policy (resource + expiry)              |
+| `CloudFront-Signature`   | RSA-SHA1 signature of the policy, signed with the private key |
 | `CloudFront-Key-Pair-Id` | CloudFront public key ID, used to locate the verification key |
 
 All cookies use `HttpOnly; Secure; SameSite=Lax; Path=/`. `SameSite=Lax` allows cookies to be sent on top-level cross-site navigation (clicking a link from a GitHub PR comment).
 
 **Cookie TTL:**
+
 - PR previews: 7 days
 - Staging: 30 days
 
@@ -135,20 +137,24 @@ The following are executed **indirectly via CloudFormation** (not by the script 
 - `cloudfront:CreateFunction` / `cloudfront:UpdateFunction` / `cloudfront:PublishFunction` — manages the `PreviewAuthFunction` CloudFront Function
 
 The CI workflows (PR preview and staging deploy) only need:
+
 - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` for S3 deploy and CloudFront invalidation
 - `CLOUDFRONT_SIGNING_KEY` / `CLOUDFRONT_SIGNING_KEY_ID` for cookie signing (no AWS calls needed for signing)
 
 ## How stakeholders access the preview
 
 After a PR preview deploy, CI posts the bootstrap URL to:
+
 1. **PR comment** — tagged with `<!-- pr-preview-links -->`, updated on each push
 2. **GitHub Deployments** — visible in the PR's "Deployments" section and the repo's Environments tab
 
 After a staging deploy, CI posts to:
+
 1. **GitHub Deployments** — `staging` environment, updated on each merge to `develop`
 2. **Actions run summary** — visible directly in the workflow run without navigating to Environments
 
 **Access flow:**
+
 1. Stakeholder clicks the bootstrap link from GitHub
 2. Browser hits `/_preview-auth?policy=...&sig=...&kid=...&dest=/pr-42/`
 3. CloudFront Function sets all three cookies and redirects to `dest`

--- a/docs/project-label-bridge.md
+++ b/docs/project-label-bridge.md
@@ -42,23 +42,22 @@ The helper is [`scripts/github/setup-project-label-bridge.mjs`](../scripts/githu
 ### Manual setup (GitHub UI)
 
 1. **Repository variable (required)**  
-   In GitHub: **Settings → Secrets and variables → Actions → Variables**  
+   In GitHub: **Settings → Secrets and variables → Actions → Variables**
    - **`PROJECT_NUMBER`** — the number in the project URL, e.g. `https://github.com/orgs/YourOrg/projects/5` → `5`.
 
    > **Naming:** GitHub reserves the `GITHUB_` prefix for built-in workflow context. Repository/configuration variables **must not** start with `GITHUB_` (they can be rejected or ineffective). Do not use `GITHUB_PROJECT_NUMBER`.
 
-2. **Repository variable (optional)**  
+2. **Repository variable (optional)**
    - **`PROJECT_ORG`** — organization login owning the project. If omitted, the workflow default is `Artificer-Innovations` (change the default in the workflow file if your org differs and you prefer not to set a variable).
 
    If you previously created **`GITHUB_PROJECT_NUMBER`** / **`GITHUB_PROJECT_ORG`**, delete them and recreate as **`PROJECT_NUMBER`** / **`PROJECT_ORG`**, or run `npm run setup:project-label-bridge` again so `gh variable set` uses the correct names.
 
 3. **Repository secret (required for the bridge to do anything)**  
-   **Settings → Secrets and variables → Actions → Secrets**  
+   **Settings → Secrets and variables → Actions → Secrets**
    - **`ORG_PROJECT_GITHUB_TOKEN`** — a **classic** personal access token with at least **`repo`** and **`project`** (and whatever your org requires for SSO). Fine-grained PATs are often insufficient for org Projects; see GitHub’s [Automating Projects using Actions](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions) note about `GITHUB_TOKEN` vs PAT/App for org projects.
 
 4. **Labels and Status names**  
    Use labels **`project/status-<kebab>`** where `<kebab>` is lowercase letters, digits, and hyphens (for example `project/status-ready-for-qa`). The workflow derives the GitHub Project **Status** option name automatically:
-
    - Hyphens become spaces.
    - **Default:** each word is **title-cased** (first letter uppercase, rest lowercase), e.g. `project/status-backlog` → `Backlog`, `project/status-ready` → `Ready`, `project/status-planning` → `Planning`, `project/status-done` → `Done`.
    - **Exception:** if the slug starts with **`in-`** and has more segments (`in-*`), the result is **`In`** plus a space, then the **remaining words in all lowercase** — so `project/status-in-progress` → **`In progress`** and `project/status-in-review` → **`In review`** (matching this repo’s Kanban wording).
@@ -67,14 +66,14 @@ The helper is [`scripts/github/setup-project-label-bridge.mjs`](../scripts/githu
 
    Examples for this board:
 
-   | Label | Derived Status |
-   | ----- | ---------------- |
-   | `project/status-backlog` | Backlog |
-   | `project/status-ready` | Ready |
-   | `project/status-planning` | Planning |
-   | `project/status-in-progress` | In progress |
-   | `project/status-in-review` | In review |
-   | `project/status-done` | Done |
+   | Label                        | Derived Status |
+   | ---------------------------- | -------------- |
+   | `project/status-backlog`     | Backlog        |
+   | `project/status-ready`       | Ready          |
+   | `project/status-planning`    | Planning       |
+   | `project/status-in-progress` | In progress    |
+   | `project/status-in-review`   | In review      |
+   | `project/status-done`        | Done           |
 
 5. **Items not yet on the board**  
    If an issue or PR is not already on the project, the workflow adds it, then sets **Status**.

--- a/infra/aws/functions/PreviewAuthFunction.js
+++ b/infra/aws/functions/PreviewAuthFunction.js
@@ -10,15 +10,15 @@ function handler(event) {
   var request = event.request;
   var qs = request.querystring;
   var policy = qs.policy ? qs.policy.value : null;
-  var sig    = qs.sig    ? qs.sig.value    : null;
-  var kid    = qs.kid    ? qs.kid.value    : null;
+  var sig = qs.sig ? qs.sig.value : null;
+  var kid = qs.kid ? qs.kid.value : null;
 
   if (!policy || !sig || !kid) {
     return {
       statusCode: 400,
       statusDescription: 'Bad Request',
       headers: { 'content-type': { value: 'text/plain' } },
-      body: 'Missing required parameters: policy, sig, kid.'
+      body: 'Missing required parameters: policy, sig, kid.',
     };
   }
 
@@ -26,20 +26,33 @@ function handler(event) {
   // decodeURIComponent throws on malformed % sequences — fall back to '/'.
   // Also block protocol-relative URLs like //evil.com which startsWith('/') but are external.
   var dest;
-  try { dest = qs.dest ? decodeURIComponent(qs.dest.value) : '/'; } catch (e) { dest = '/'; }
+  try {
+    dest = qs.dest ? decodeURIComponent(qs.dest.value) : '/';
+  } catch (e) {
+    dest = '/';
+  }
   if (!dest.startsWith('/') || dest.startsWith('//')) dest = '/';
 
   return {
     statusCode: 302,
     statusDescription: 'Found',
     headers: {
-      location:      { value: dest },
-      'cache-control': { value: 'no-store, no-cache, must-revalidate' }
+      location: { value: dest },
+      'cache-control': { value: 'no-store, no-cache, must-revalidate' },
     },
     cookies: {
-      'CloudFront-Policy':      { value: policy, attributes: 'HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=604800' },
-      'CloudFront-Signature':   { value: sig,    attributes: 'HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=604800' },
-      'CloudFront-Key-Pair-Id': { value: kid,    attributes: 'HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=604800' }
-    }
+      'CloudFront-Policy': {
+        value: policy,
+        attributes: 'HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=604800',
+      },
+      'CloudFront-Signature': {
+        value: sig,
+        attributes: 'HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=604800',
+      },
+      'CloudFront-Key-Pair-Id': {
+        value: kid,
+        attributes: 'HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=604800',
+      },
+    },
   };
 }

--- a/packages/billing/src/components/UsageIndicator.web.tsx
+++ b/packages/billing/src/components/UsageIndicator.web.tsx
@@ -49,27 +49,20 @@ export function UsageIndicator<P extends ProductBillingConfig>(
         data-testid='usage-indicator-expanded'
       >
         {label && (
-          <div className='text-sm font-medium text-gray-900'>{label}</div>
+          <div className='text-sm font-medium text-gray-900 dark:text-white'>{label}</div>
         )}
         {description && (
-          <p className='text-xs text-gray-500 mt-0.5'>{description}</p>
+          <p className='text-xs text-gray-500 dark:text-gray-400 mt-0.5'>{description}</p>
         )}
         {limit != null && (
-          <div
-            className='mt-2'
-            style={{ height: 8, background: '#e5e7eb', borderRadius: 4 }}
-          >
+          <div className='mt-2 h-2 w-full rounded-full bg-gray-200 dark:bg-gray-700'>
             <div
-              style={{
-                width: `${pct}%`,
-                height: 8,
-                background: '#4f46e5',
-                borderRadius: 4,
-              }}
+              className='h-2 rounded-full bg-indigo-600 dark:bg-indigo-500'
+              style={{ width: `${pct}%` }}
             />
           </div>
         )}
-        <div className='text-sm text-gray-600 mt-2'>{capLine}</div>
+        <div className='text-sm text-gray-600 dark:text-gray-400 mt-2'>{capLine}</div>
       </div>
     );
   }

--- a/packages/billing/src/components/UsageIndicator.web.tsx
+++ b/packages/billing/src/components/UsageIndicator.web.tsx
@@ -49,10 +49,14 @@ export function UsageIndicator<P extends ProductBillingConfig>(
         data-testid='usage-indicator-expanded'
       >
         {label && (
-          <div className='text-sm font-medium text-gray-900 dark:text-white'>{label}</div>
+          <div className='text-sm font-medium text-gray-900 dark:text-white'>
+            {label}
+          </div>
         )}
         {description && (
-          <p className='text-xs text-gray-500 dark:text-gray-400 mt-0.5'>{description}</p>
+          <p className='text-xs text-gray-500 dark:text-gray-400 mt-0.5'>
+            {description}
+          </p>
         )}
         {limit != null && (
           <div className='mt-2 h-2 w-full rounded-full bg-gray-200 dark:bg-gray-700'>
@@ -62,7 +66,9 @@ export function UsageIndicator<P extends ProductBillingConfig>(
             />
           </div>
         )}
-        <div className='text-sm text-gray-600 dark:text-gray-400 mt-2'>{capLine}</div>
+        <div className='text-sm text-gray-600 dark:text-gray-400 mt-2'>
+          {capLine}
+        </div>
       </div>
     );
   }

--- a/packages/shared/src/components/forms/FormError.web.tsx
+++ b/packages/shared/src/components/forms/FormError.web.tsx
@@ -14,7 +14,7 @@ export function FormError({ message, className = '' }: FormErrorProps) {
 
   return (
     <div
-      className={`rounded-md bg-red-50 border border-red-200 p-4 ${className}`}
+      className={`rounded-md bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 p-4 ${className}`}
       role='alert'
       aria-live='polite'
     >
@@ -34,7 +34,7 @@ export function FormError({ message, className = '' }: FormErrorProps) {
           </svg>
         </div>
         <div className='ml-3'>
-          <p className='text-sm font-medium text-red-800'>{message}</p>
+          <p className='text-sm font-medium text-red-800 dark:text-red-300'>{message}</p>
         </div>
       </div>
     </div>

--- a/packages/shared/src/components/forms/FormInput.web.tsx
+++ b/packages/shared/src/components/forms/FormInput.web.tsx
@@ -43,7 +43,9 @@ export function FormInput({
   } ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`;
 
   const labelClasses = `block text-sm font-medium mb-1 ${
-    hasError ? 'text-red-700 dark:text-red-400' : 'text-gray-700 dark:text-gray-300'
+    hasError
+      ? 'text-red-700 dark:text-red-400'
+      : 'text-gray-700 dark:text-gray-300'
   }`;
 
   return (

--- a/packages/shared/src/components/forms/FormInput.web.tsx
+++ b/packages/shared/src/components/forms/FormInput.web.tsx
@@ -39,7 +39,7 @@ export function FormInput({
   const baseInputClasses = `w-full px-3 py-2 border rounded-md text-sm transition-colors dark:text-gray-100 ${
     hasError
       ? 'border-red-500 bg-red-50 dark:border-red-400 dark:bg-red-900/20 focus:border-red-600 focus:ring-red-500'
-      : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-800 focus:border-primary-500 focus:ring-primary-500'
+      : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-700 focus:border-primary-500 focus:ring-primary-500'
   } ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`;
 
   const labelClasses = `block text-sm font-medium mb-1 ${

--- a/packages/shared/src/components/forms/FormInput.web.tsx
+++ b/packages/shared/src/components/forms/FormInput.web.tsx
@@ -36,14 +36,14 @@ export function FormInput({
   const inputId = `form-input-${label.toLowerCase().replace(/\s+/g, '-')}`;
   const hasError = !!error;
 
-  const baseInputClasses = `w-full px-3 py-2 border rounded-md text-sm transition-colors ${
+  const baseInputClasses = `w-full px-3 py-2 border rounded-md text-sm transition-colors dark:text-gray-100 ${
     hasError
-      ? 'border-red-500 bg-red-50 focus:border-red-600 focus:ring-red-500'
-      : 'border-gray-300 bg-white focus:border-primary-500 focus:ring-primary-500'
+      ? 'border-red-500 bg-red-50 dark:border-red-400 dark:bg-red-900/20 focus:border-red-600 focus:ring-red-500'
+      : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-800 focus:border-primary-500 focus:ring-primary-500'
   } ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`;
 
   const labelClasses = `block text-sm font-medium mb-1 ${
-    hasError ? 'text-red-700' : 'text-gray-700'
+    hasError ? 'text-red-700 dark:text-red-400' : 'text-gray-700 dark:text-gray-300'
   }`;
 
   return (

--- a/packages/shared/src/components/primitives/Button.web.tsx
+++ b/packages/shared/src/components/primitives/Button.web.tsx
@@ -30,11 +30,11 @@ const variantClasses: Record<ButtonVariant, string> = {
   primary:
     'bg-indigo-600 text-white hover:bg-indigo-700 focus:ring-indigo-500 border border-transparent',
   secondary:
-    'bg-white text-gray-900 border border-gray-200 hover:bg-gray-50 focus:ring-gray-400',
+    'bg-white text-gray-900 border border-gray-200 hover:bg-gray-50 focus:ring-gray-400 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-500',
   destructive:
     'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500 border border-transparent',
   ghost:
-    'bg-transparent text-gray-700 hover:bg-gray-100 focus:ring-gray-400 border border-transparent',
+    'bg-transparent text-gray-700 hover:bg-gray-100 focus:ring-gray-400 border border-transparent dark:bg-transparent dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:ring-gray-500',
 };
 
 /**

--- a/packages/shared/src/components/primitives/Modal.web.tsx
+++ b/packages/shared/src/components/primitives/Modal.web.tsx
@@ -169,7 +169,10 @@ export function Modal({
       >
         {title && (
           <div className='mb-4 flex items-start justify-between gap-4'>
-            <h2 id={titleId} className='text-lg font-semibold text-gray-900 dark:text-white'>
+            <h2
+              id={titleId}
+              className='text-lg font-semibold text-gray-900 dark:text-white'
+            >
               {title}
             </h2>
             {showCloseButton && (

--- a/packages/shared/src/components/primitives/Modal.web.tsx
+++ b/packages/shared/src/components/primitives/Modal.web.tsx
@@ -159,7 +159,7 @@ export function Modal({
         ref={panelRef}
         tabIndex={-1}
         className={[
-          'relative w-full rounded-xl border border-gray-200 bg-white p-6 shadow-xl focus:outline-none',
+          'relative w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-xl focus:outline-none',
           sizeToMax[size],
           className,
         ]
@@ -169,14 +169,14 @@ export function Modal({
       >
         {title && (
           <div className='mb-4 flex items-start justify-between gap-4'>
-            <h2 id={titleId} className='text-lg font-semibold text-gray-900'>
+            <h2 id={titleId} className='text-lg font-semibold text-gray-900 dark:text-white'>
               {title}
             </h2>
             {showCloseButton && (
               <button
                 type='button'
                 onClick={onClose}
-                className='rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-800'
+                className='rounded p-1 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-800 dark:hover:text-gray-200'
                 aria-label='Close dialog'
               >
                 <span aria-hidden className='text-xl leading-none'>

--- a/packages/shared/src/components/profile/AvatarUpload.web.tsx
+++ b/packages/shared/src/components/profile/AvatarUpload.web.tsx
@@ -137,7 +137,9 @@ export function AvatarUpload({
 
   return (
     <div className={`space-y-2 ${className}`}>
-      <label className='block text-sm font-medium text-gray-700 dark:text-gray-300'>Avatar</label>
+      <label className='block text-sm font-medium text-gray-700 dark:text-gray-300'>
+        Avatar
+      </label>
 
       <div className='flex items-center space-x-4'>
         {/* Avatar Preview */}
@@ -221,10 +223,16 @@ export function AvatarUpload({
           )}
 
           {/* Error Message */}
-          {error && <div className='text-sm text-red-600 dark:text-red-400'>{error.message}</div>}
+          {error && (
+            <div className='text-sm text-red-600 dark:text-red-400'>
+              {error.message}
+            </div>
+          )}
 
           {/* Help Text */}
-          <p className='text-xs text-gray-500 dark:text-gray-400'>JPEG, PNG, or WebP. Max 2MB.</p>
+          <p className='text-xs text-gray-500 dark:text-gray-400'>
+            JPEG, PNG, or WebP. Max 2MB.
+          </p>
         </div>
       </div>
     </div>

--- a/packages/shared/src/components/profile/AvatarUpload.web.tsx
+++ b/packages/shared/src/components/profile/AvatarUpload.web.tsx
@@ -221,7 +221,7 @@ export function AvatarUpload({
           )}
 
           {/* Error Message */}
-          {error && <div className='text-sm text-red-600'>{error.message}</div>}
+          {error && <div className='text-sm text-red-600 dark:text-red-400'>{error.message}</div>}
 
           {/* Help Text */}
           <p className='text-xs text-gray-500 dark:text-gray-400'>JPEG, PNG, or WebP. Max 2MB.</p>

--- a/packages/shared/src/components/profile/AvatarUpload.web.tsx
+++ b/packages/shared/src/components/profile/AvatarUpload.web.tsx
@@ -137,12 +137,12 @@ export function AvatarUpload({
 
   return (
     <div className={`space-y-2 ${className}`}>
-      <label className='block text-sm font-medium text-gray-700'>Avatar</label>
+      <label className='block text-sm font-medium text-gray-700 dark:text-gray-300'>Avatar</label>
 
       <div className='flex items-center space-x-4'>
         {/* Avatar Preview */}
         <div className='relative'>
-          <div className='w-24 h-24 rounded-full overflow-hidden bg-gray-200 border-2 border-gray-300'>
+          <div className='w-24 h-24 rounded-full overflow-hidden bg-gray-200 dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-600'>
             {displayUrl ? (
               <img
                 key={`${displayUrl}-${imageKey}`} // Include imageKey to force re-render
@@ -193,7 +193,7 @@ export function AvatarUpload({
               type='button'
               onClick={handleClick}
               disabled={uploading}
-              className='px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed'
+              className='px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed'
             >
               {uploading ? 'Uploading...' : 'Choose File'}
             </button>
@@ -203,7 +203,7 @@ export function AvatarUpload({
                 type='button'
                 onClick={handleRemove}
                 disabled={uploading}
-                className='px-3 py-1.5 text-sm font-medium text-red-700 bg-white border border-red-300 rounded-md hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50 disabled:cursor-not-allowed'
+                className='px-3 py-1.5 text-sm font-medium text-red-700 dark:text-red-400 bg-white dark:bg-gray-700 border border-red-300 dark:border-red-500 rounded-md hover:bg-red-50 dark:hover:bg-red-900/30 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50 disabled:cursor-not-allowed'
               >
                 Remove
               </button>
@@ -212,7 +212,7 @@ export function AvatarUpload({
 
           {/* Progress Bar */}
           {uploading && progress > 0 && (
-            <div className='w-full bg-gray-200 rounded-full h-2'>
+            <div className='w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2'>
               <div
                 className='bg-primary-600 h-2 rounded-full transition-all duration-300'
                 style={{ width: `${progress}%` }}
@@ -224,7 +224,7 @@ export function AvatarUpload({
           {error && <div className='text-sm text-red-600'>{error.message}</div>}
 
           {/* Help Text */}
-          <p className='text-xs text-gray-500'>JPEG, PNG, or WebP. Max 2MB.</p>
+          <p className='text-xs text-gray-500 dark:text-gray-400'>JPEG, PNG, or WebP. Max 2MB.</p>
         </div>
       </div>
     </div>

--- a/packages/shared/src/components/profile/ProfileAvatar.web.tsx
+++ b/packages/shared/src/components/profile/ProfileAvatar.web.tsx
@@ -68,7 +68,7 @@ export function ProfileAvatar({
           target.style.display = 'none';
           const parent = target.parentElement;
           if (parent) {
-            parent.innerHTML = `<div class="${sizeClasses[size]} rounded-full bg-gray-300 flex items-center justify-center text-gray-600 font-semibold">${getInitials()}</div>`;
+            parent.innerHTML = `<div class="${sizeClasses[size]} rounded-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center text-gray-600 dark:text-gray-300 font-semibold">${getInitials()}</div>`;
           }
         }}
       />
@@ -77,7 +77,7 @@ export function ProfileAvatar({
 
   return (
     <div
-      className={`${sizeClasses[size]} rounded-full bg-gray-300 flex items-center justify-center text-gray-600 font-semibold ${className}`}
+      className={`${sizeClasses[size]} rounded-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center text-gray-600 dark:text-gray-300 font-semibold ${className}`}
       role='img'
       aria-label={`Avatar for ${profile?.display_name || profile?.username || 'user'}`}
     >

--- a/packages/shared/src/components/profile/ProfileEditor.web.tsx
+++ b/packages/shared/src/components/profile/ProfileEditor.web.tsx
@@ -133,7 +133,9 @@ export function ProfileEditor({
 
   if (!currentUser) {
     return (
-      <div className={`rounded-md bg-yellow-50 dark:bg-yellow-900/30 p-4 ${className}`}>
+      <div
+        className={`rounded-md bg-yellow-50 dark:bg-yellow-900/30 p-4 ${className}`}
+      >
         <p className='text-sm text-yellow-800 dark:text-yellow-300'>
           Please sign in to edit your profile.
         </p>
@@ -143,15 +145,21 @@ export function ProfileEditor({
 
   if (loading && !profileData) {
     return (
-      <div className={`rounded-md bg-gray-50 dark:bg-gray-800 p-4 ${className}`}>
-        <p className='text-sm text-gray-600 dark:text-gray-400'>Loading profile...</p>
+      <div
+        className={`rounded-md bg-gray-50 dark:bg-gray-800 p-4 ${className}`}
+      >
+        <p className='text-sm text-gray-600 dark:text-gray-400'>
+          Loading profile...
+        </p>
       </div>
     );
   }
 
   return (
     <div className={`space-y-4 ${className}`}>
-      <h3 className='text-lg font-semibold text-gray-900 dark:text-white'>Edit Profile</h3>
+      <h3 className='text-lg font-semibold text-gray-900 dark:text-white'>
+        Edit Profile
+      </h3>
 
       <div className='space-y-4'>
         <FormInput

--- a/packages/shared/src/components/profile/ProfileEditor.web.tsx
+++ b/packages/shared/src/components/profile/ProfileEditor.web.tsx
@@ -133,8 +133,8 @@ export function ProfileEditor({
 
   if (!currentUser) {
     return (
-      <div className={`rounded-md bg-yellow-50 p-4 ${className}`}>
-        <p className='text-sm text-yellow-800'>
+      <div className={`rounded-md bg-yellow-50 dark:bg-yellow-900/30 p-4 ${className}`}>
+        <p className='text-sm text-yellow-800 dark:text-yellow-300'>
           Please sign in to edit your profile.
         </p>
       </div>
@@ -143,15 +143,15 @@ export function ProfileEditor({
 
   if (loading && !profileData) {
     return (
-      <div className={`rounded-md bg-gray-50 p-4 ${className}`}>
-        <p className='text-sm text-gray-600'>Loading profile...</p>
+      <div className={`rounded-md bg-gray-50 dark:bg-gray-800 p-4 ${className}`}>
+        <p className='text-sm text-gray-600 dark:text-gray-400'>Loading profile...</p>
       </div>
     );
   }
 
   return (
     <div className={`space-y-4 ${className}`}>
-      <h3 className='text-lg font-semibold text-gray-900'>Edit Profile</h3>
+      <h3 className='text-lg font-semibold text-gray-900 dark:text-white'>Edit Profile</h3>
 
       <div className='space-y-4'>
         <FormInput

--- a/packages/shared/src/components/profile/ProfileHeader.web.tsx
+++ b/packages/shared/src/components/profile/ProfileHeader.web.tsx
@@ -18,8 +18,12 @@ export function ProfileHeader({
 }: ProfileHeaderProps) {
   if (!profile) {
     return (
-      <div className={`rounded-md bg-gray-50 dark:bg-gray-800 p-4 ${className}`}>
-        <p className='text-sm text-gray-600 dark:text-gray-400'>No profile data available.</p>
+      <div
+        className={`rounded-md bg-gray-50 dark:bg-gray-800 p-4 ${className}`}
+      >
+        <p className='text-sm text-gray-600 dark:text-gray-400'>
+          No profile data available.
+        </p>
       </div>
     );
   }
@@ -37,7 +41,11 @@ export function ProfileHeader({
           <h2 className='text-2xl font-bold text-gray-900 dark:text-white truncate'>
             {displayName}
           </h2>
-          {username && <p className='text-sm text-gray-500 dark:text-gray-400 mt-1'>{username}</p>}
+          {username && (
+            <p className='text-sm text-gray-500 dark:text-gray-400 mt-1'>
+              {username}
+            </p>
+          )}
           {hasMetadata && (
             <div className='flex flex-wrap gap-4 mt-2 text-sm text-gray-600 dark:text-gray-400'>
               {email && (
@@ -112,7 +120,9 @@ export function ProfileHeader({
         </div>
       </div>
       {profile.bio && (
-        <p className='text-gray-700 dark:text-gray-300 whitespace-pre-wrap'>{profile.bio}</p>
+        <p className='text-gray-700 dark:text-gray-300 whitespace-pre-wrap'>
+          {profile.bio}
+        </p>
       )}
     </div>
   );

--- a/packages/shared/src/components/profile/ProfileHeader.web.tsx
+++ b/packages/shared/src/components/profile/ProfileHeader.web.tsx
@@ -18,8 +18,8 @@ export function ProfileHeader({
 }: ProfileHeaderProps) {
   if (!profile) {
     return (
-      <div className={`rounded-md bg-gray-50 p-4 ${className}`}>
-        <p className='text-sm text-gray-600'>No profile data available.</p>
+      <div className={`rounded-md bg-gray-50 dark:bg-gray-800 p-4 ${className}`}>
+        <p className='text-sm text-gray-600 dark:text-gray-400'>No profile data available.</p>
       </div>
     );
   }
@@ -34,12 +34,12 @@ export function ProfileHeader({
       <div className='flex items-start space-x-4'>
         <ProfileAvatar profile={profile} size='large' />
         <div className='flex-1 min-w-0'>
-          <h2 className='text-2xl font-bold text-gray-900 truncate'>
+          <h2 className='text-2xl font-bold text-gray-900 dark:text-white truncate'>
             {displayName}
           </h2>
-          {username && <p className='text-sm text-gray-500 mt-1'>{username}</p>}
+          {username && <p className='text-sm text-gray-500 dark:text-gray-400 mt-1'>{username}</p>}
           {hasMetadata && (
-            <div className='flex flex-wrap gap-4 mt-2 text-sm text-gray-600'>
+            <div className='flex flex-wrap gap-4 mt-2 text-sm text-gray-600 dark:text-gray-400'>
               {email && (
                 <span className='flex items-center'>
                   <svg
@@ -87,7 +87,7 @@ export function ProfileHeader({
                   href={profile.website}
                   target='_blank'
                   rel='noopener noreferrer'
-                  className='flex items-center text-blue-600 hover:text-blue-800 hover:underline'
+                  className='flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline'
                 >
                   <svg
                     className='w-4 h-4 mr-1'
@@ -112,7 +112,7 @@ export function ProfileHeader({
         </div>
       </div>
       {profile.bio && (
-        <p className='text-gray-700 whitespace-pre-wrap'>{profile.bio}</p>
+        <p className='text-gray-700 dark:text-gray-300 whitespace-pre-wrap'>{profile.bio}</p>
       )}
     </div>
   );

--- a/packages/shared/src/components/profile/ProfileStats.web.tsx
+++ b/packages/shared/src/components/profile/ProfileStats.web.tsx
@@ -58,7 +58,7 @@ export function ProfileStats({ profile, className = '' }: ProfileStatsProps) {
   return (
     <div className={`space-y-2 ${className}`}>
       {memberSince && (
-        <div className='text-sm text-gray-600'>
+        <div className='text-sm text-gray-600 dark:text-gray-400'>
           <span className='font-medium'>Member since:</span> {memberSince}
         </div>
       )}

--- a/packages/shared/src/components/profile/ProfileStats.web.tsx
+++ b/packages/shared/src/components/profile/ProfileStats.web.tsx
@@ -63,7 +63,7 @@ export function ProfileStats({ profile, className = '' }: ProfileStatsProps) {
         </div>
       )}
       {completion > 0 && (
-        <div className='text-sm text-gray-600'>
+        <div className='text-sm text-gray-600 dark:text-gray-400'>
           <span className='font-medium'>Profile completion:</span> {completion}%
         </div>
       )}


### PR DESCRIPTION
## Summary

- Adds `dark:` Tailwind variants to 18 components that had no dark mode support: sign-up plan summary, social login button, billing tabs/badges/feature rows/confirm modal, all dashboard demo sections, and shared profile header/stats/editor.
- Converts `MeteredUsageDemo` progress bar from hardcoded inline `style` hex colours to Tailwind classes so dark mode works correctly.

## Files changed (18)
`apps/web`: SignupPlanSummary, SocialLoginButton, BillingTabs, ConstraintWarning, PlanFeatureList, PlanFeatureRow, StatusBadge, FeatureLimitRow, ConfirmDowngradeModal, DashboardDemoSection, DemoControlsPanel, MeteredUsageDemo, BooleanGatesDemo, NumericCapsDemo, AISummarizeResult  
`packages/shared`: ProfileHeader, ProfileStats, ProfileEditor

## Test plan
- [ ] Toggle dark mode on `/dashboard` — all demo sections render correctly
- [ ] Toggle dark mode on `/billing` — tabs, badges, feature rows, confirm-downgrade modal render correctly
- [ ] Toggle dark mode on `/signup?plan=...` and `/login?plan=...` — plan summary card renders correctly
- [ ] Toggle dark mode on profile page — header, stats, editor render correctly

Closes #93