### PR TITLE
Optional label bridge: sync org GitHub Project Status from project/status labels

### DIFF
--- a/.github/workflows/project-label-bridge.yml
+++ b/.github/workflows/project-label-bridge.yml
@@ -1,6 +1,9 @@
 # Optional: moves org GitHub Project (v2) cards when issues/PRs get mapped labels.
 # The repo does not require this workflow; see docs/project-label-bridge.md for why,
 # setup (secret + variables), and how to align labels with your board.
+#
+# Repository variables must NOT use the GITHUB_ prefix (reserved for built-in context).
+# Use vars.PROJECT_NUMBER and vars.PROJECT_ORG — see docs/project-label-bridge.md.
 
 name: Project label bridge
 
@@ -20,7 +23,7 @@ jobs:
     permissions:
       contents: read
     # Secrets are not available in job-level `if`; gate on vars only (forks can skip via empty var).
-    if: vars.GITHUB_PROJECT_NUMBER != ''
+    if: vars.PROJECT_NUMBER != ''
 
     steps:
       - name: Resolve label → Status and update Project
@@ -28,8 +31,8 @@ jobs:
           GH_TOKEN: ${{ secrets.ORG_PROJECT_GITHUB_TOKEN }}
           LABEL_NAME: ${{ github.event.label.name }}
           CONTENT_NODE_ID: ${{ github.event.issue.node_id || github.event.pull_request.node_id }}
-          PROJECT_ORG: ${{ vars.GITHUB_PROJECT_ORG || 'Artificer-Innovations' }}
-          PROJECT_NUMBER: ${{ vars.GITHUB_PROJECT_NUMBER }}
+          PROJECT_ORG: ${{ vars.PROJECT_ORG || 'Artificer-Innovations' }}
+          PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER }}
         run: |
           set -euo pipefail
 
@@ -107,7 +110,7 @@ jobs:
           OPTION_ID=$(jq -r --arg s "$TARGET_STATUS" '.data.organization.projectV2.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == $s) | .id' project_meta.json)
 
           if [[ "$PROJECT_ID" == "null" || -z "$PROJECT_ID" ]]; then
-            echo "::error::Could not load project $PROJECT_ORG#$PROJECT_NUMBER (check GITHUB_PROJECT_ORG / GITHUB_PROJECT_NUMBER and token access)."
+            echo "::error::Could not load project $PROJECT_ORG#$PROJECT_NUMBER (check vars PROJECT_ORG / PROJECT_NUMBER and token access)."
             exit 1
           fi
           if [[ "$STATUS_FIELD_ID" == "null" || -z "$STATUS_FIELD_ID" ]]; then

--- a/.github/workflows/project-label-bridge.yml
+++ b/.github/workflows/project-label-bridge.yml
@@ -1,0 +1,174 @@
+# Optional: moves org GitHub Project (v2) cards when issues/PRs get mapped labels.
+# The repo does not require this workflow; see docs/project-label-bridge.md for why,
+# setup (secret + variables), and how to align labels with your board.
+
+name: Project label bridge
+
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled]
+
+concurrency:
+  group: project-label-bridge-${{ github.event_name }}-${{ github.event.issue.node_id || github.event.pull_request.node_id }}-${{ github.event.label.name }}
+  cancel-in-progress: true
+
+jobs:
+  sync-status-from-label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Secrets are not available in job-level `if`; gate on vars only (forks can skip via empty var).
+    if: vars.GITHUB_PROJECT_NUMBER != ''
+
+    steps:
+      - name: Resolve label → Status and update Project
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PROJECT_GITHUB_TOKEN }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          CONTENT_NODE_ID: ${{ github.event.issue.node_id || github.event.pull_request.node_id }}
+          PROJECT_ORG: ${{ vars.GITHUB_PROJECT_ORG || 'Artificer-Innovations' }}
+          PROJECT_NUMBER: ${{ vars.GITHUB_PROJECT_NUMBER }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::warning::ORG_PROJECT_GITHUB_TOKEN is not set; cannot update the org project."
+            exit 0
+          fi
+
+          # Labels: project/status-<kebab> (lowercase a-z, digits, hyphens).
+          # → Project "Status" option: each hyphen becomes a space. Default: Title Case
+          #   per word (e.g. backlog → Backlog, ready-for-qa → Ready For Qa).
+          # Exception: leading segment "in" with more segments → "In " + remaining
+          #   words lowercased (Kanban: "In progress", "In review").
+          if [[ "$LABEL_NAME" != project/status-* ]]; then
+            echo "Label '$LABEL_NAME' is not a project status label (expected prefix project/status-); skipping."
+            exit 0
+          fi
+          slug="${LABEL_NAME#project/status-}"
+          slug="${slug,,}"
+          if [[ -z "$slug" || "$slug" == *[^a-z0-9-]* ]]; then
+            echo "Label '$LABEL_NAME' has an invalid slug after project/status- (use a-z, 0-9, hyphens only); skipping."
+            exit 0
+          fi
+
+          IFS='-' read -ra parts <<< "$slug"
+          n=${#parts[@]}
+          if [[ "$n" -eq 0 ]]; then
+            echo "Label '$LABEL_NAME' is empty after project/status-; skipping."
+            exit 0
+          fi
+          if [[ "${parts[0],,}" == "in" && "$n" -eq 1 ]]; then
+            echo "Label '$LABEL_NAME' is incomplete (project/status-in); skipping."
+            exit 0
+          fi
+
+          if [[ "${parts[0],,}" == "in" && "$n" -ge 2 ]]; then
+            TARGET_STATUS="In"
+            for ((i = 1; i < n; i++)); do
+              w="${parts[i],,}"
+              [[ -z "$w" ]] && continue
+              TARGET_STATUS+=" $w"
+            done
+          else
+            TARGET_STATUS=""
+            for ((i = 0; i < n; i++)); do
+              w="${parts[i],,}"
+              [[ -z "$w" ]] && continue
+              [[ -n "$TARGET_STATUS" ]] && TARGET_STATUS+=" "
+              TARGET_STATUS+="${w^}"
+            done
+          fi
+
+          echo "Mapping label '$LABEL_NAME' → Status '$TARGET_STATUS'"
+
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org) {
+                projectV2(number: $number) {
+                  id
+                  fields(first: 40) {
+                    nodes {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options { id name }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f org="$PROJECT_ORG" -F number="$PROJECT_NUMBER" --jq . > project_meta.json
+
+          PROJECT_ID=$(jq -r '.data.organization.projectV2.id' project_meta.json)
+          STATUS_FIELD_ID=$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Status") | .id' project_meta.json)
+          OPTION_ID=$(jq -r --arg s "$TARGET_STATUS" '.data.organization.projectV2.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == $s) | .id' project_meta.json)
+
+          if [[ "$PROJECT_ID" == "null" || -z "$PROJECT_ID" ]]; then
+            echo "::error::Could not load project $PROJECT_ORG#$PROJECT_NUMBER (check GITHUB_PROJECT_ORG / GITHUB_PROJECT_NUMBER and token access)."
+            exit 1
+          fi
+          if [[ "$STATUS_FIELD_ID" == "null" || -z "$STATUS_FIELD_ID" ]]; then
+            echo "::error::Project has no single-select field named 'Status'. Rename the field or adjust this workflow."
+            exit 1
+          fi
+          if [[ "$OPTION_ID" == "null" || -z "$OPTION_ID" ]]; then
+            echo "::error::No Status option named '$TARGET_STATUS'. Add it to the project, or use a project/status-<kebab> label that derives to an existing option name (see workflow comments)."
+            exit 1
+          fi
+
+          gh api graphql -f query='
+            query($id: ID!) {
+              node(id: $id) {
+                ... on Issue {
+                  projectItems(first: 30) {
+                    nodes {
+                      id
+                      project { ... on ProjectV2 { id number } }
+                    }
+                  }
+                }
+                ... on PullRequest {
+                  projectItems(first: 30) {
+                    nodes {
+                      id
+                      project { ... on ProjectV2 { id number } }
+                    }
+                  }
+                }
+              }
+            }' -f id="$CONTENT_NODE_ID" --jq . > content_items.json
+
+          ITEM_ID=$(jq -r --argjson n "$PROJECT_NUMBER" '
+            .data.node.projectItems.nodes[]
+            | select(.project.number == $n)
+            | .id
+          ' content_items.json 2>/dev/null || true)
+
+          if [[ -z "$ITEM_ID" || "$ITEM_ID" == "null" ]]; then
+            echo "Item not on project yet — adding content then setting Status."
+            ITEM_ID=$(gh api graphql -f query='
+              mutation($project: ID!, $content: ID!) {
+                addProjectV2ItemById(input: { projectId: $project, contentId: $content }) {
+                  item { id }
+                }
+              }' -f project="$PROJECT_ID" -f content="$CONTENT_NODE_ID" --jq -r '.data.addProjectV2ItemById.item.id')
+          fi
+
+          gh api graphql -f query='
+            mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+              updateProjectV2ItemFieldValue(
+                input: {
+                  projectId: $project
+                  itemId: $item
+                  fieldId: $field
+                  value: { singleSelectOptionId: $option }
+                }
+              ) {
+                projectV2Item { id }
+              }
+            }' -f project="$PROJECT_ID" -f item="$ITEM_ID" -f field="$STATUS_FIELD_ID" -f option="$OPTION_ID" --silent
+
+          echo "Updated project item $ITEM_ID to Status='$TARGET_STATUS'."

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Start on the repo root **[README.md](../README.md)** and **[QUICKSTART.md](../QU
 | [supabase-preview-setup.md](supabase-preview-setup.md)                       | Shared PR preview database and redirects                                       |
 | [stripe-billing-setup.md](stripe-billing-setup.md)                           | Stripe + Supabase Edge billing (keys, webhooks, sync, local vs hosted)         |
 | [reference/github-actions-secrets.md](reference/github-actions-secrets.md)   | Actions secret/variable names (regenerate with `npm run docs:actions-secrets`) |
+| [project-label-bridge.md](project-label-bridge.md)                           | **Optional:** label-driven org GitHub Project updates (`npm run setup:project-label-bridge`) |
 | [branch-protection-setup.md](branch-protection-setup.md)                     | Branch rules                                                                   |
 
 ## OAuth (canonical order)

--- a/docs/project-label-bridge.md
+++ b/docs/project-label-bridge.md
@@ -1,0 +1,86 @@
+# Project label bridge (optional GitHub Actions)
+
+This repository **does not depend** on the [Project label bridge workflow](../.github/workflows/project-label-bridge.yml). CI, builds, and day-to-day development work the same if you never configure it. It exists only if you want **automation between issue labels and an organization GitHub Project (v2) board**.
+
+## Why it exists
+
+At **Artificer Innovations** we treat AI coding agents as part of the engineering team: they follow the same habits we expect from human engineers—issues, PRs, reviews, and incremental work you can trace in history. You can see that pattern in this repository, where multiple agent-led changes sit alongside human contributions.
+
+Humans still rely on **Kanban-style boards** to see flow at a glance. Agents can usually **label** issues and PRs, but we found that **fine-grained personal access tokens** often cannot grant **organization Projects** write access in a way agents can use reliably, so cards on the org board would not move even when work progressed.
+
+This workflow bridges that gap: **agents (or humans) only change labels**; GitHub Actions runs with a **classic PAT** (or another token that can write org projects) and updates the project **Status** field so the board stays in sync with the labels.
+
+If you do not use an org-level project board, or you move cards manually, you can ignore this workflow entirely.
+
+## When the workflow runs
+
+- Triggers on **`issues: labeled`** and **`pull_request: labeled`**.
+- If `GITHUB_PROJECT_NUMBER` is unset, the job is skipped (no failure).
+- If `ORG_PROJECT_GITHUB_TOKEN` is unset, the run exits with a warning and succeeds (so forks and clones without secrets do not break).
+
+## Setup
+
+### Quick setup (`gh` + npm)
+
+If you use the [GitHub CLI](https://cli.github.com/) (`gh`) with permission to manage Actions **variables** and **secrets** on this repository:
+
+```bash
+npm run setup:project-label-bridge -- --help
+# Preview:
+npm run setup:project-label-bridge -- --dry-run --number 5 --org Artificer-Innovations
+# Apply variables (org optional); you are then prompted once for the PAT (masked typing on a real TTY, same idea as npm run setup:full):
+npm run setup:project-label-bridge -- --number 5 --org Artificer-Innovations
+# Non-interactive: pipe or file (avoid echoing the PAT in argv)
+printf '%s' "$ORG_PROJECT_GITHUB_TOKEN" | npm run setup:project-label-bridge -- --number 5 --token-stdin
+npm run setup:project-label-bridge -- --number 5 --token-file ~/.config/beakerstack/github-pat-project.txt
+# Variables only (skip secret prompt entirely):
+npm run setup:project-label-bridge -- --number 5 --skip-secret
+```
+
+The helper is [`scripts/github/setup-project-label-bridge.mjs`](../scripts/github/setup-project-label-bridge.mjs). It uses [`scripts/lib/setup-secret-input.mjs`](../scripts/lib/setup-secret-input.mjs) (`readMaskedLineIfTty`, `resolveSecretInputLine`) so pastes, paths to bare secret files, and `ORG_PROJECT_GITHUB_TOKEN=...` dotenv lines behave like **setup-full**. Flags: `--plain-secret-prompts` (typed echo), `--skip-secret`, `--dry-run`. If the env var **`ORG_PROJECT_GITHUB_TOKEN`** is already set, it is used without prompting.
+
+### Manual setup (GitHub UI)
+
+1. **Repository variable (required)**  
+   In GitHub: **Settings → Secrets and variables → Actions → Variables**  
+   - **`GITHUB_PROJECT_NUMBER`** — the number in the project URL, e.g. `https://github.com/orgs/YourOrg/projects/5` → `5`.
+
+2. **Repository variable (optional)**  
+   - **`GITHUB_PROJECT_ORG`** — organization login owning the project. If omitted, the workflow default is `Artificer-Innovations` (change the default in the workflow file if your org differs and you prefer not to set a variable).
+
+3. **Repository secret (required for the bridge to do anything)**  
+   **Settings → Secrets and variables → Actions → Secrets**  
+   - **`ORG_PROJECT_GITHUB_TOKEN`** — a **classic** personal access token with at least **`repo`** and **`project`** (and whatever your org requires for SSO). Fine-grained PATs are often insufficient for org Projects; see GitHub’s [Automating Projects using Actions](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions) note about `GITHUB_TOKEN` vs PAT/App for org projects.
+
+4. **Labels and Status names**  
+   Use labels **`project/status-<kebab>`** where `<kebab>` is lowercase letters, digits, and hyphens (for example `project/status-ready-for-qa`). The workflow derives the GitHub Project **Status** option name automatically:
+
+   - Hyphens become spaces.
+   - **Default:** each word is **title-cased** (first letter uppercase, rest lowercase), e.g. `project/status-backlog` → `Backlog`, `project/status-ready` → `Ready`, `project/status-planning` → `Planning`, `project/status-done` → `Done`.
+   - **Exception:** if the slug starts with **`in-`** and has more segments (`in-*`), the result is **`In`** plus a space, then the **remaining words in all lowercase** — so `project/status-in-progress` → **`In progress`** and `project/status-in-review` → **`In review`** (matching this repo’s Kanban wording).
+
+   The derived string must match a **Status** single-select option on the project **exactly**. If you add a column, pick a kebab slug that produces that name, or rename the option in GitHub Projects to match what the label derives to.
+
+   Examples for this board:
+
+   | Label | Derived Status |
+   | ----- | ---------------- |
+   | `project/status-backlog` | Backlog |
+   | `project/status-ready` | Ready |
+   | `project/status-planning` | Planning |
+   | `project/status-in-progress` | In progress |
+   | `project/status-in-review` | In review |
+   | `project/status-done` | Done |
+
+5. **Items not yet on the board**  
+   If an issue or PR is not already on the project, the workflow adds it, then sets **Status**.
+
+## Security notes
+
+- Treat **`ORG_PROJECT_GITHUB_TOKEN`** like any other powerful PAT: minimal lifetime, rotate on schedule, and restrict org/repo access at the PAT level where GitHub allows it.
+- Workflows triggered from **fork pull requests** do not receive secrets; the bridge will no-op for those runs.
+
+## Related files
+
+- [`.github/workflows/project-label-bridge.yml`](../.github/workflows/project-label-bridge.yml) — derives **Status** from `project/status-<kebab>` labels and GraphQL updates.
+- [`scripts/github/setup-project-label-bridge.mjs`](../scripts/github/setup-project-label-bridge.mjs) — `gh` + masked secret prompts (`npm run setup:project-label-bridge`).

--- a/docs/project-label-bridge.md
+++ b/docs/project-label-bridge.md
@@ -15,7 +15,7 @@ If you do not use an org-level project board, or you move cards manually, you ca
 ## When the workflow runs
 
 - Triggers on **`issues: labeled`** and **`pull_request: labeled`**.
-- If `GITHUB_PROJECT_NUMBER` is unset, the job is skipped (no failure).
+- If the **`PROJECT_NUMBER`** repository variable is unset, the job is skipped (no failure).
 - If `ORG_PROJECT_GITHUB_TOKEN` is unset, the run exits with a warning and succeeds (so forks and clones without secrets do not break).
 
 ## Setup
@@ -43,10 +43,14 @@ The helper is [`scripts/github/setup-project-label-bridge.mjs`](../scripts/githu
 
 1. **Repository variable (required)**  
    In GitHub: **Settings → Secrets and variables → Actions → Variables**  
-   - **`GITHUB_PROJECT_NUMBER`** — the number in the project URL, e.g. `https://github.com/orgs/YourOrg/projects/5` → `5`.
+   - **`PROJECT_NUMBER`** — the number in the project URL, e.g. `https://github.com/orgs/YourOrg/projects/5` → `5`.
+
+   > **Naming:** GitHub reserves the `GITHUB_` prefix for built-in workflow context. Repository/configuration variables **must not** start with `GITHUB_` (they can be rejected or ineffective). Do not use `GITHUB_PROJECT_NUMBER`.
 
 2. **Repository variable (optional)**  
-   - **`GITHUB_PROJECT_ORG`** — organization login owning the project. If omitted, the workflow default is `Artificer-Innovations` (change the default in the workflow file if your org differs and you prefer not to set a variable).
+   - **`PROJECT_ORG`** — organization login owning the project. If omitted, the workflow default is `Artificer-Innovations` (change the default in the workflow file if your org differs and you prefer not to set a variable).
+
+   If you previously created **`GITHUB_PROJECT_NUMBER`** / **`GITHUB_PROJECT_ORG`**, delete them and recreate as **`PROJECT_NUMBER`** / **`PROJECT_ORG`**, or run `npm run setup:project-label-bridge` again so `gh variable set` uses the correct names.
 
 3. **Repository secret (required for the bridge to do anything)**  
    **Settings → Secrets and variables → Actions → Secrets**  

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "prepare": "husky install",
     "postinstall": "patch-package || true",
     "rename": "node ./scripts/rename-project.mjs",
+    "setup:project-label-bridge": "node scripts/github/setup-project-label-bridge.mjs",
     "docs:actions-secrets": "node ./scripts/generate-actions-secrets-doc.mjs",
     "docs:linkcheck": "npx --yes markdown-link-check@3.12.2 README.md QUICKSTART.md -c .markdown-link-check.json",
     "billing:sync-stripe": "node scripts/sync-billing-stripe.mjs --config apps/web/src/billing/billing-sync.json",

--- a/scripts/github/setup-project-label-bridge.mjs
+++ b/scripts/github/setup-project-label-bridge.mjs
@@ -33,8 +33,8 @@ Configure Actions variables for the optional project-label-bridge workflow (gh C
 
 Options:
   --repo OWNER/NAME        Target repository (default: gh repo view)
-  --number N               GITHUB_PROJECT_NUMBER (required). Env: GITHUB_PROJECT_NUMBER.
-  --org LOGIN              GITHUB_PROJECT_ORG (optional). Env: GITHUB_PROJECT_ORG.
+  --number N               PROJECT_NUMBER (required). Env: PROJECT_NUMBER (legacy: GITHUB_PROJECT_NUMBER).
+  --org LOGIN              PROJECT_ORG (optional). Env: PROJECT_ORG (legacy: GITHUB_PROJECT_ORG).
   --skip-secret            Do not set ORG_PROJECT_GITHUB_TOKEN (no prompt, no stdin read)
   --token-stdin            Read entire classic PAT from process stdin (use with piped input only)
   --token-file PATH        Read PAT from file
@@ -124,8 +124,8 @@ function parseArgv(argv) {
   /** @type {{ repo: string; number: string; org: string; dryRun: boolean; plainSecretPrompts: boolean; skipSecret: boolean; tokenStdin: boolean; tokenFile: string }} */
   const o = {
     repo: '',
-    number: process.env.GITHUB_PROJECT_NUMBER || '',
-    org: process.env.GITHUB_PROJECT_ORG || '',
+    number: process.env.PROJECT_NUMBER || process.env.GITHUB_PROJECT_NUMBER || '',
+    org: process.env.PROJECT_ORG || process.env.GITHUB_PROJECT_ORG || '',
     dryRun: false,
     plainSecretPrompts: false,
     skipSecret: false,
@@ -219,7 +219,7 @@ async function main() {
   const opts = parseArgv(process.argv.slice(2));
 
   if (!opts.number) {
-    console.error('GITHUB_PROJECT_NUMBER is required. Pass --number N or set env GITHUB_PROJECT_NUMBER.');
+    console.error('PROJECT_NUMBER is required. Pass --number N or set env PROJECT_NUMBER.');
     printHelp();
     process.exit(1);
   }
@@ -280,15 +280,15 @@ async function main() {
 
   const dry = opts.dryRun;
 
-  let r = runGh(['variable', 'set', 'GITHUB_PROJECT_NUMBER', '--repo', repo, '--body', opts.number], { dryRun: dry });
+  let r = runGh(['variable', 'set', 'PROJECT_NUMBER', '--repo', repo, '--body', opts.number], { dryRun: dry });
   if (r.status !== 0) process.exit(r.status || 1);
 
   if (opts.org) {
-    r = runGh(['variable', 'set', 'GITHUB_PROJECT_ORG', '--repo', repo, '--body', opts.org], { dryRun: dry });
+    r = runGh(['variable', 'set', 'PROJECT_ORG', '--repo', repo, '--body', opts.org], { dryRun: dry });
     if (r.status !== 0) process.exit(r.status || 1);
   } else {
     console.log(
-      'Skipping GITHUB_PROJECT_ORG (optional). Workflow default org applies unless you set the variable in the UI.',
+      'Skipping PROJECT_ORG (optional). Workflow default org applies unless you set the variable in the UI.',
     );
   }
 
@@ -300,7 +300,7 @@ async function main() {
   if (!dry) {
     const lr = runGh(['variable', 'list', '--repo', repo], { dryRun: false, captureStdout: true });
     if (lr.status === 0 && lr.stdout) {
-      const lines = lr.stdout.split('\n').filter((line) => /GITHUB_PROJECT_(NUMBER|ORG)/.test(line));
+      const lines = lr.stdout.split('\n').filter((line) => /PROJECT_(NUMBER|ORG)/.test(line));
       if (lines.length) console.log(lines.join('\n'));
     }
   } else {

--- a/scripts/github/setup-project-label-bridge.mjs
+++ b/scripts/github/setup-project-label-bridge.mjs
@@ -153,24 +153,40 @@ function parseArgv(argv) {
 
 /**
  * @param {string[]} args
- * @param {{ input?: string | Buffer; dryRun?: boolean }} [opts]
+ * @param {{ input?: string | Buffer; dryRun?: boolean; captureStdout?: boolean }} [opts]
  */
 function runGh(args, opts = {}) {
   if (opts.dryRun) {
     console.log(`[dry-run] gh ${args.map((x) => JSON.stringify(x)).join(' ')}`);
     return { status: 0, stdout: '', stderr: '' };
   }
+  const capture = !!opts.captureStdout;
   /** @type {import('node:child_process').StdioOptions} */
-  const stdio = opts.input !== undefined ? ['pipe', 'inherit', 'inherit'] : ['inherit', 'inherit', 'inherit'];
-  return spawnSync('gh', args, {
+  let stdio;
+  if (opts.input !== undefined) {
+    stdio = capture ? ['pipe', 'pipe', 'pipe'] : ['pipe', 'inherit', 'inherit'];
+  } else if (capture) {
+    stdio = ['ignore', 'pipe', 'pipe'];
+  } else {
+    stdio = ['inherit', 'inherit', 'inherit'];
+  }
+  const r = spawnSync('gh', args, {
     encoding: 'utf8',
     stdio,
     input: opts.input,
+    cwd: REPO_ROOT,
   });
+  if (r.status !== 0 && r.stderr) {
+    process.stderr.write(r.stderr);
+  }
+  return r;
 }
 
 function ghRepoDefault() {
-  const r = runGh(['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], { dryRun: false });
+  const r = runGh(['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], {
+    dryRun: false,
+    captureStdout: true,
+  });
   if (r.status !== 0) {
     console.error('Could not run gh repo view. Install gh, auth with gh auth login, or pass --repo OWNER/NAME.');
     process.exit(1);
@@ -282,7 +298,7 @@ async function main() {
 
   console.log(`Done. Target repo: ${repo}`);
   if (!dry) {
-    const lr = runGh(['variable', 'list', '--repo', repo], { dryRun: false });
+    const lr = runGh(['variable', 'list', '--repo', repo], { dryRun: false, captureStdout: true });
     if (lr.status === 0 && lr.stdout) {
       const lines = lr.stdout.split('\n').filter((line) => /GITHUB_PROJECT_(NUMBER|ORG)/.test(line));
       if (lines.length) console.log(lines.join('\n'));

--- a/scripts/github/setup-project-label-bridge.mjs
+++ b/scripts/github/setup-project-label-bridge.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+/**
+ * Configure GitHub Actions variables (and optionally ORG_PROJECT_GITHUB_TOKEN) for
+ * .github/workflows/project-label-bridge.yml via gh.
+ *
+ * Secret entry reuses the same helpers as setup-full: masked typing on a TTY (unless
+ * --plain-secret-prompts), or paste / path to a bare secret file (see setup-secret-input).
+ *
+ * See: docs/project-label-bridge.md
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createInterface } from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { promises as fs, openSync, ReadStream } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import url from 'node:url';
+
+import { readMaskedLineIfTty, resolveSecretInputLine } from '../lib/setup-secret-input.mjs';
+
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+const PAT_PRIMARY_KEY = 'ORG_PROJECT_GITHUB_TOKEN';
+const PAT_ALLOW_KEYS = new Set([PAT_PRIMARY_KEY]);
+
+function printHelp() {
+  console.log(`Usage: node scripts/github/setup-project-label-bridge.mjs [options]
+
+Configure Actions variables for the optional project-label-bridge workflow (gh CLI).
+
+Options:
+  --repo OWNER/NAME        Target repository (default: gh repo view)
+  --number N               GITHUB_PROJECT_NUMBER (required). Env: GITHUB_PROJECT_NUMBER.
+  --org LOGIN              GITHUB_PROJECT_ORG (optional). Env: GITHUB_PROJECT_ORG.
+  --skip-secret            Do not set ORG_PROJECT_GITHUB_TOKEN (no prompt, no stdin read)
+  --token-stdin            Read entire classic PAT from process stdin (use with piped input only)
+  --token-file PATH        Read PAT from file
+  --plain-secret-prompts   Echo typed secrets (default: mask on a real TTY; same as setup-full)
+  --dry-run                Print gh commands without running
+  -h, --help               Show this help
+
+If no token option is given and ORG_PROJECT_GITHUB_TOKEN is not in the environment, you are
+prompted once (masked typing / paste / file path) — same behavior as npm run setup:full secret prompts.
+
+Examples:
+  npm run setup:project-label-bridge -- --number 5 --org Artificer-Innovations
+  printf '%s' "$ORG_PROJECT_GITHUB_TOKEN" | npm run setup:project-label-bridge -- --number 5 --token-stdin
+`);
+}
+
+/**
+ * @returns {{ rl: import('node:readline/promises').ReadLine; promptInput: import('stream').Readable & { isTTY?: boolean; setRawMode?: (flag: boolean) => void } }}
+ */
+function createPromptInterface() {
+  let inStream = input;
+  if (!input.isTTY) {
+    try {
+      const fd = openSync('/dev/tty', 'r');
+      inStream = new ReadStream(undefined, { fd });
+    } catch {
+      /* interactive prompts may not work without a TTY */
+    }
+  }
+  return { rl: createInterface({ input: inStream, output }), promptInput: inStream };
+}
+
+/**
+ * @param {import('node:readline/promises').ReadLine} rl
+ * @param {string} prompt
+ */
+async function rlQuestion(rl, prompt) {
+  try {
+    return await rl.question(prompt);
+  } catch (e) {
+    if (typeof e === 'object' && e !== null && /** @type {{ name?: string }} */ (e).name === 'AbortError') {
+      return '';
+    }
+    throw e;
+  }
+}
+
+/**
+ * @param {import('node:readline/promises').ReadLine} rl
+ * @param {import('stream').Readable & { isTTY?: boolean; setRawMode?: (flag: boolean) => void }} promptInput
+ * @param {{ plainSecretPrompts: boolean }} flags
+ * @param {string} prompt
+ */
+async function readSecretLineMaskedOrVisible(rl, promptInput, flags, prompt) {
+  if (flags.plainSecretPrompts) {
+    return (await rlQuestion(rl, prompt)).trim();
+  }
+  const masked = await readMaskedLineIfTty(rl, promptInput, output, prompt);
+  if (masked === null) {
+    return (await rlQuestion(rl, prompt)).trim();
+  }
+  return masked.trim();
+}
+
+/**
+ * @param {string} line
+ * @returns {Promise<{ pat: string; ignoredKeys: string[] }>}
+ */
+async function resolvePatLine(line) {
+  const resolved = await resolveSecretInputLine({
+    line,
+    primaryKey: PAT_PRIMARY_KEY,
+    allowKeys: PAT_ALLOW_KEYS,
+    homedir,
+    repoRoot: REPO_ROOT,
+    readFileUtf8: (p) => fs.readFile(p, 'utf8'),
+  });
+  const pat = resolved.primary || resolved.merged[PAT_PRIMARY_KEY] || '';
+  return { pat, ignoredKeys: resolved.ignoredKeys };
+}
+
+function parseArgv(argv) {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    printHelp();
+    process.exit(0);
+  }
+  /** @type {{ repo: string; number: string; org: string; dryRun: boolean; plainSecretPrompts: boolean; skipSecret: boolean; tokenStdin: boolean; tokenFile: string }} */
+  const o = {
+    repo: '',
+    number: process.env.GITHUB_PROJECT_NUMBER || '',
+    org: process.env.GITHUB_PROJECT_ORG || '',
+    dryRun: false,
+    plainSecretPrompts: false,
+    skipSecret: false,
+    tokenStdin: false,
+    tokenFile: '',
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--dry-run') o.dryRun = true;
+    else if (a === '--plain-secret-prompts') o.plainSecretPrompts = true;
+    else if (a === '--skip-secret') o.skipSecret = true;
+    else if (a === '--token-stdin') o.tokenStdin = true;
+    else if (a === '--repo') o.repo = argv[++i] || '';
+    else if (a === '--number') o.number = argv[++i] || '';
+    else if (a === '--org') o.org = argv[++i] || '';
+    else if (a === '--token-file') o.tokenFile = argv[++i] || '';
+    else {
+      console.error(`Unknown option: ${a}`);
+      printHelp();
+      process.exit(1);
+    }
+  }
+  return o;
+}
+
+/**
+ * @param {string[]} args
+ * @param {{ input?: string | Buffer; dryRun?: boolean }} [opts]
+ */
+function runGh(args, opts = {}) {
+  if (opts.dryRun) {
+    console.log(`[dry-run] gh ${args.map((x) => JSON.stringify(x)).join(' ')}`);
+    return { status: 0, stdout: '', stderr: '' };
+  }
+  /** @type {import('node:child_process').StdioOptions} */
+  const stdio = opts.input !== undefined ? ['pipe', 'inherit', 'inherit'] : ['inherit', 'inherit', 'inherit'];
+  return spawnSync('gh', args, {
+    encoding: 'utf8',
+    stdio,
+    input: opts.input,
+  });
+}
+
+function ghRepoDefault() {
+  const r = runGh(['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], { dryRun: false });
+  if (r.status !== 0) {
+    console.error('Could not run gh repo view. Install gh, auth with gh auth login, or pass --repo OWNER/NAME.');
+    process.exit(1);
+  }
+  return (r.stdout || '').trim();
+}
+
+/**
+ * @param {string} token
+ * @param {string} repo
+ * @param {boolean} dryRun
+ */
+function ghSecretSetPat(token, repo, dryRun) {
+  const r = runGh(['secret', 'set', PAT_PRIMARY_KEY, '--repo', repo], {
+    dryRun,
+    input: `${token.replace(/\r?\n/g, '').trim()}\n`,
+  });
+  if (r.status !== 0) process.exit(r.status || 1);
+}
+
+async function readStdinUtf8() {
+  const chunks = [];
+  for await (const chunk of input) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8').trim();
+}
+
+async function main() {
+  const opts = parseArgv(process.argv.slice(2));
+
+  if (!opts.number) {
+    console.error('GITHUB_PROJECT_NUMBER is required. Pass --number N or set env GITHUB_PROJECT_NUMBER.');
+    printHelp();
+    process.exit(1);
+  }
+
+  const repo = opts.repo || ghRepoDefault();
+  if (!repo) {
+    console.error('Empty repository name.');
+    process.exit(1);
+  }
+
+  let pat = '';
+  if (opts.skipSecret) {
+    console.log('Skipping ORG_PROJECT_GITHUB_TOKEN (--skip-secret).');
+  } else if (opts.tokenStdin) {
+    pat = await readStdinUtf8();
+    if (!pat) {
+      console.error('No data read from stdin (--token-stdin).');
+      process.exit(1);
+    }
+  } else if (opts.tokenFile) {
+    try {
+      pat = (await fs.readFile(opts.tokenFile, 'utf8')).trim();
+    } catch (e) {
+      console.error(`Failed to read --token-file: ${e}`);
+      process.exit(1);
+    }
+    if (!pat) {
+      console.error('Token file is empty.');
+      process.exit(1);
+    }
+  } else if (process.env.ORG_PROJECT_GITHUB_TOKEN) {
+    pat = process.env.ORG_PROJECT_GITHUB_TOKEN.trim();
+    console.log('Using ORG_PROJECT_GITHUB_TOKEN from environment.');
+  } else if (opts.dryRun) {
+    console.log('[dry-run] Would prompt for ORG_PROJECT_GITHUB_TOKEN (interactive / paste / path).');
+  } else {
+    const { rl, promptInput } = createPromptInterface();
+    try {
+      const line = await readSecretLineMaskedOrVisible(
+        rl,
+        promptInput,
+        opts,
+        `${PAT_PRIMARY_KEY} — paste, path to file, or masked type (blank=skip): `,
+      );
+      const { pat: resolvedPat, ignoredKeys } = await resolvePatLine(line);
+      if (ignoredKeys.length) {
+        const uniq = [...new Set(ignoredKeys)].sort();
+        console.log(`[project-label-bridge] Secret input ignored unknown keys: ${uniq.join(', ')}`);
+      }
+      pat = resolvedPat;
+    } finally {
+      rl.close();
+    }
+    if (!pat) {
+      console.log('Skipping ORG_PROJECT_GITHUB_TOKEN (blank input).');
+    }
+  }
+
+  const dry = opts.dryRun;
+
+  let r = runGh(['variable', 'set', 'GITHUB_PROJECT_NUMBER', '--repo', repo, '--body', opts.number], { dryRun: dry });
+  if (r.status !== 0) process.exit(r.status || 1);
+
+  if (opts.org) {
+    r = runGh(['variable', 'set', 'GITHUB_PROJECT_ORG', '--repo', repo, '--body', opts.org], { dryRun: dry });
+    if (r.status !== 0) process.exit(r.status || 1);
+  } else {
+    console.log(
+      'Skipping GITHUB_PROJECT_ORG (optional). Workflow default org applies unless you set the variable in the UI.',
+    );
+  }
+
+  if (pat) {
+    ghSecretSetPat(pat, repo, dry);
+  }
+
+  console.log(`Done. Target repo: ${repo}`);
+  if (!dry) {
+    const lr = runGh(['variable', 'list', '--repo', repo], { dryRun: false });
+    if (lr.status === 0 && lr.stdout) {
+      const lines = lr.stdout.split('\n').filter((line) => /GITHUB_PROJECT_(NUMBER|ORG)/.test(line));
+      if (lines.length) console.log(lines.join('\n'));
+    }
+  } else {
+    console.log('  (dry-run — nothing was written)');
+  }
+  console.log('See docs/project-label-bridge.md for PAT scopes and label conventions.');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds an **optional** GitHub Actions workflow so **issue/PR labels** can drive **organization GitHub Project (v2) Kanban** `Status` updates, without giving coding agents org–project write PATs. Agents keep using labels (which work with typical tokens); CI applies board moves with a **classic PAT** stored as `ORG_PROJECT_GITHUB_TOKEN`.

Also adds **documentation** (`docs/project-label-bridge.md`, index entry) and a **`gh`-based setup helper** (`npm run setup:project-label-bridge`) that reuses the same **masked secret input** helpers as `setup-full`.

## Why

Fine-grained PATs often cannot expose **organization Projects** write in a way that works for agents, while labeling usually does. This bridges that gap and matches how we want agents to behave like the rest of the engineering team (see doc “Why it exists”).

## Behavior

- Triggers: `issues: labeled`, `pull_request: labeled`.
- Only labels matching **`project/status-<kebab>`** (lowercase `a-z`, digits, hyphens). Derives the **Status** option name:
  - Default: hyphen → space, **title case** per word (e.g. `project/status-planning` → `Planning`).
  - **`in-*`**: `In` + space + following words **lowercase** (e.g. `project/status-in-progress` → **In progress**, `project/status-in-review` → **In review**).
- Adds the item to the project if missing, then sets **Status** (field name `Status` on the project).
- Skips cleanly when `GITHUB_PROJECT_NUMBER` is unset or `ORG_PROJECT_GITHUB_TOKEN` is missing (no hard failure for forks/unconfigured clones).

## Setup (after merge)

1. Repo **variable**: `GITHUB_PROJECT_NUMBER` (required for the job to run).
2. Optional **variable**: `GITHUB_PROJECT_ORG` (workflow default org if unset).
3. Repo **secret**: `ORG_PROJECT_GITHUB_TOKEN` — classic PAT with **`repo`** + **`project`** (org access as required).

`npm run setup:project-label-bridge -- --help` — interactive masked PAT prompt or `--token-stdin` / `--token-file` / `--skip-secret`.

## Checklist

- [ ] Configure `GITHUB_PROJECT_NUMBER` (and secret) on the repo **or** accept that the workflow no-ops until configured.
- [ ] Ensure GitHub Project **Status** options match derived names (especially **In progress** / **In review**).
- [ ] Create repo labels such as `project/status-backlog`, … as needed.