### PR TITLE
fix(ci): avoid secrets in workflow if expressions (#107)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -149,13 +149,16 @@ jobs:
 
       - name: Generate staging signed cookie bootstrap URL
         id: signed_cookies
-        if: secrets.CLOUDFRONT_SIGNING_KEY != ''
         shell: bash
         env:
           CLOUDFRONT_SIGNING_KEY: ${{ secrets.CLOUDFRONT_SIGNING_KEY }}
           CLOUDFRONT_SIGNING_KEY_ID: ${{ secrets.CLOUDFRONT_SIGNING_KEY_ID }}
         run: |
           set -euo pipefail
+          # secrets.* is not allowed in step `if:` — gate here when the secret is unset (direct URL access).
+          if [[ -z "${CLOUDFRONT_SIGNING_KEY:-}" ]]; then
+            exit 0
+          fi
           STAGING_DOMAIN="staging.${DOMAIN}"
           RESOURCE="https://${STAGING_DOMAIN}/*"
           EXPIRY=$(date -u -d "+30 days" +%s)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -155,9 +155,13 @@ jobs:
           CLOUDFRONT_SIGNING_KEY_ID: ${{ secrets.CLOUDFRONT_SIGNING_KEY_ID }}
         run: |
           set -euo pipefail
-          # secrets.* is not allowed in step `if:` — gate here when the secret is unset (direct URL access).
-          if [[ -z "${CLOUDFRONT_SIGNING_KEY:-}" ]]; then
+          # secrets.* is not allowed in step `if:` — gate here (direct URL access when neither secret is set).
+          if [[ -z "${CLOUDFRONT_SIGNING_KEY:-}" && -z "${CLOUDFRONT_SIGNING_KEY_ID:-}" ]]; then
             exit 0
+          fi
+          if [[ -z "${CLOUDFRONT_SIGNING_KEY:-}" || -z "${CLOUDFRONT_SIGNING_KEY_ID:-}" ]]; then
+            echo "::error::CLOUDFRONT_SIGNING_KEY and CLOUDFRONT_SIGNING_KEY_ID must both be set. Configure both secrets or neither."
+            exit 1
           fi
           STAGING_DOMAIN="staging.${DOMAIN}"
           RESOURCE="https://${STAGING_DOMAIN}/*"

--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -206,7 +206,7 @@ jobs:
       # Skipped when CLOUDFRONT_SIGNING_KEY is not set (public access mode).
       - name: Generate signed cookie bootstrap URL
         id: signed_cookies
-        if: steps.web.outcome == 'success' && secrets.CLOUDFRONT_SIGNING_KEY != ''
+        if: steps.web.outcome == 'success'
         shell: bash
         env:
           CLOUDFRONT_SIGNING_KEY: ${{ secrets.CLOUDFRONT_SIGNING_KEY }}
@@ -214,6 +214,10 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
+          # secrets.* is not allowed in step `if:` — gate here when the secret is unset (public preview).
+          if [[ -z "${CLOUDFRONT_SIGNING_KEY:-}" ]]; then
+            exit 0
+          fi
           PREVIEW_PREFIX_VALUE="${PREVIEW_PREFIX:-pr-}"
           DEPLOY_DOMAIN="deploy.${PREVIEW_DOMAIN}"
           DEST="/${PREVIEW_PREFIX_VALUE}${PR_NUMBER}/"

--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -203,7 +203,7 @@ jobs:
             --region "${AWS_REGION_VALUE}"
 
       # Generate CloudFront signed cookies and post GitHub Deployment with access URL.
-      # Skipped when CLOUDFRONT_SIGNING_KEY is not set (public access mode).
+      # Skipped when neither signing secret is set (public access mode). Partial config fails the step.
       - name: Generate signed cookie bootstrap URL
         id: signed_cookies
         if: steps.web.outcome == 'success'
@@ -214,9 +214,13 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          # secrets.* is not allowed in step `if:` — gate here when the secret is unset (public preview).
-          if [[ -z "${CLOUDFRONT_SIGNING_KEY:-}" ]]; then
+          # secrets.* is not allowed in step `if:` — gate here (public preview when neither secret is set).
+          if [[ -z "${CLOUDFRONT_SIGNING_KEY:-}" && -z "${CLOUDFRONT_SIGNING_KEY_ID:-}" ]]; then
             exit 0
+          fi
+          if [[ -z "${CLOUDFRONT_SIGNING_KEY:-}" || -z "${CLOUDFRONT_SIGNING_KEY_ID:-}" ]]; then
+            echo "::error::CLOUDFRONT_SIGNING_KEY and CLOUDFRONT_SIGNING_KEY_ID must both be set. Configure both secrets or neither."
+            exit 1
           fi
           PREVIEW_PREFIX_VALUE="${PREVIEW_PREFIX:-pr-}"
           DEPLOY_DOMAIN="deploy.${PREVIEW_DOMAIN}"

--- a/infra/aws/pr-preview-stack.yml
+++ b/infra/aws/pr-preview-stack.yml
@@ -442,6 +442,28 @@ Resources:
           };
         }
 
+  # Explicit no-cache policy for the /_preview-auth cookie-setter path.
+  # Uses a custom resource rather than the CachingDisabled managed policy UUID to avoid
+  # any account-level availability issues with AWS-managed policy IDs.
+  PreviewAuthCachePolicy:
+    Type: AWS::CloudFront::CachePolicy
+    Properties:
+      CachePolicyConfig:
+        Name: !Sub '${AWS::StackName}-preview-auth-no-cache'
+        Comment: Disables caching on the /_preview-auth cookie-setter path
+        DefaultTTL: 0
+        MinTTL: 0
+        MaxTTL: 1
+        ParametersInCacheKeyAndForwardedToOrigin:
+          EnableAcceptEncodingGzip: false
+          EnableAcceptEncodingBrotli: false
+          CookiesConfig:
+            CookieBehavior: none
+          HeadersConfig:
+            HeaderBehavior: none
+          QueryStringsConfig:
+            QueryStringBehavior: none
+
   # Key group associating the provisioned CloudFront public key with distributions.
   # Created only when at least one distribution is in signed-cookies mode.
   # The public key itself is provisioned outside CloudFormation by
@@ -529,9 +551,9 @@ Resources:
             TargetOriginId: StagingOrigin
             ViewerProtocolPolicy: redirect-to-https
             Compress: false
-            # CachingDisabled — synthetic responses from CF Functions are not cached, but
-            # this policy is explicit and prevents any accidental cache sharing.
-            CachePolicyId: 4135872e-7369-4a65-bac3-7ea18cd55781
+            # No-cache policy — synthetic responses from CF Functions are not cached, but
+            # an explicit policy prevents any accidental cache sharing.
+            CachePolicyId: !Ref PreviewAuthCachePolicy
             FunctionAssociations:
               - EventType: viewer-request
                 FunctionARN: !GetAtt PreviewAuthFunction.FunctionMetadata.FunctionARN
@@ -594,9 +616,9 @@ Resources:
             TargetOriginId: DeployOrigin
             ViewerProtocolPolicy: redirect-to-https
             Compress: false
-            # CachingDisabled — synthetic responses from CF Functions are not cached, but
-            # this policy is explicit and prevents any accidental cache sharing.
-            CachePolicyId: 4135872e-7369-4a65-bac3-7ea18cd55781
+            # No-cache policy — synthetic responses from CF Functions are not cached, but
+            # an explicit policy prevents any accidental cache sharing.
+            CachePolicyId: !Ref PreviewAuthCachePolicy
             FunctionAssociations:
               - EventType: viewer-request
                 FunctionARN: !GetAtt PreviewAuthFunction.FunctionMetadata.FunctionARN


### PR DESCRIPTION
## Summary

GitHub Actions rejects the `secrets` context in step `if:` expressions, which made `pr-preview-environment.yml` invalid at parse time and would do the same for `deploy-staging.yml`.

## Changes

- **`.github/workflows/pr-preview-environment.yml`:** Use `if: steps.web.outcome == 'success'` only; detect an unset `CLOUDFRONT_SIGNING_KEY` inside the step and exit early (public preview mode).
- **`.github/workflows/deploy-staging.yml`:** Remove invalid `if: secrets...`; same shell guard for optional signed-cookie bootstrap URL generation.

## Context

- Closes #107
- Related cookie / CloudFront signing work: #80 / #90