### PR TITLE
fix(dark-mode): add dark variants to ProtectedRoute loading state (fixes #106)

### DIFF
--- a/packages/shared/src/components/auth/ProtectedRoute.web.tsx
+++ b/packages/shared/src/components/auth/ProtectedRoute.web.tsx
@@ -20,10 +20,10 @@ export function ProtectedRoute({
   // Show loading state while checking authentication
   if (auth.loading) {
     return (
-      <div className='min-h-screen flex items-center justify-center bg-gray-50'>
+      <div className='min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900'>
         <div className='text-center'>
           <div className='inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600'></div>
-          <p className='mt-4 text-gray-600'>Loading...</p>
+          <p className='mt-4 text-gray-600 dark:text-gray-400'>Loading...</p>
         </div>
       </div>
     );


### PR DESCRIPTION
Fixes #106

## Root cause

`ProtectedRoute.web.tsx`'s loading state had `bg-gray-50` with no `dark:` counterpart. When `signOut()` is called, `auth.loading` flips to `true` while Supabase's async signOut completes. During that window the loading div covers the full viewport in light gray — white flash in dark mode.

The inline anti-FOUC script in `index.html` keeps the `dark` class on `<html>` throughout, but Tailwind can only apply `dark:bg-gray-900` if the class is declared in the source. It wasn't.

## Change

`packages/shared/src/components/auth/ProtectedRoute.web.tsx`

```diff
- <div className='min-h-screen flex items-center justify-center bg-gray-50'>
+ <div className='min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900'>
    <div className='text-center'>
      <div className='inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600'></div>
-     <p className='mt-4 text-gray-600'>Loading...</p>
+     <p className='mt-4 text-gray-600 dark:text-gray-400'>Loading...</p>
    </div>
  </div>
```

## Test plan

1. Enable dark mode
2. Sign out
3. Confirm no white flash — transition stays dark throughout
4. Repeat with system theme (OS dark) to confirm `prefers-color-scheme` fallback path is also clean
5. Confirm loading spinner is readable in dark mode