### PR TITLE
feat(ci): per-component status table in PR preview comment (#85)

### DIFF
--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -465,7 +465,10 @@ jobs:
               return webUrl ? `[Preview →](${webUrl})` : '—';
             })();
 
-            const mobileStatus = mobileJobResult === 'skipped' ? 'skipped' : mobileJobResult || 'skipped';
+            const mobileStatus =
+              mobileJobResult === 'skipped' ? 'skipped' :
+              (mobileJobResult === 'success' && !mobileUpdateUrl) ? 'skipped' :
+              mobileJobResult || 'skipped';
             const mobileLinkCell = mobileJobResult === 'failure' ? logsLink : '—';
 
             const table = [

--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -58,8 +58,13 @@ jobs:
     needs: preview-scope
     runs-on: ubuntu-latest
     outputs:
-      bootstrap-url: ${{ steps.signed_cookies.outputs.BOOTSTRAP_URL }}
-      access-mode: ${{ steps.signed_cookies.outputs.ACCESS_MODE }}
+      bootstrap-url:             ${{ steps.signed_cookies.outputs.BOOTSTRAP_URL }}
+      access-mode:               ${{ steps.signed_cookies.outputs.ACCESS_MODE }}
+      supabase-outcome:          ${{ steps.supabase.outcome }}
+      stripe-sync-outcome:       ${{ steps.stripe-sync.outcome }}
+      stripe-webhook-outcome:    ${{ steps.stripe_webhook_preview.outcome }}
+      billing-functions-outcome: ${{ steps.billing-functions.outcome }}
+      web-outcome:               ${{ steps.web.outcome }}
     env:
       PREVIEW_DOMAIN: ${{ vars.PR_PREVIEW_DOMAIN }}
       PREVIEW_HOSTED_ZONE_ID: ${{ vars.PR_PREVIEW_HOSTED_ZONE_ID }}
@@ -132,6 +137,8 @@ jobs:
             --skip-if-unchanged
 
       - name: Sync Stripe prices to preview billing_plans
+        id: stripe-sync
+        continue-on-error: true
         env:
           STRIPE_SECRET_KEY: ${{ secrets.PREVIEW_STRIPE_SECRET_KEY }}
           SUPABASE_URL: ${{ secrets.PREVIEW_SUPABASE_URL }}
@@ -142,6 +149,7 @@ jobs:
 
       - name: Ensure Stripe webhook endpoint (preview)
         id: stripe_webhook_preview
+        continue-on-error: true
         env:
           STRIPE_SECRET_KEY: ${{ secrets.PREVIEW_STRIPE_SECRET_KEY }}
           STRIPE_WEBHOOK_URL: ${{ secrets.PREVIEW_SUPABASE_URL }}/functions/v1/stripe-webhook
@@ -150,6 +158,8 @@ jobs:
         run: node scripts/ensure-stripe-webhook-endpoint.mjs
 
       - name: Deploy preview billing edge functions
+        id: billing-functions
+        continue-on-error: true
         shell: bash
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
@@ -399,6 +409,12 @@ jobs:
           PREVIEW_PREFIX: ${{ vars.PR_PREVIEW_PREFIX }}
           BOOTSTRAP_URL: ${{ needs.deploy-preview.outputs.bootstrap-url }}
           ACCESS_MODE: ${{ needs.deploy-preview.outputs.access-mode }}
+          SUPABASE_OUTCOME: ${{ needs.deploy-preview.outputs.supabase-outcome }}
+          STRIPE_SYNC_OUTCOME: ${{ needs.deploy-preview.outputs.stripe-sync-outcome }}
+          STRIPE_WEBHOOK_OUTCOME: ${{ needs.deploy-preview.outputs.stripe-webhook-outcome }}
+          BILLING_FUNCTIONS_OUTCOME: ${{ needs.deploy-preview.outputs.billing-functions-outcome }}
+          WEB_OUTCOME: ${{ needs.deploy-preview.outputs.web-outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           MOBILE_JOB_RESULT: ${{ needs.deploy-preview-mobile.result }}
           MOBILE_CHANNEL: ${{ needs.deploy-preview-mobile.outputs.mobile-channel }}
           MOBILE_UPDATE_URL: ${{ needs.deploy-preview-mobile.outputs.mobile-update-url }}
@@ -412,57 +428,107 @@ jobs:
             const prefix = process.env.PREVIEW_PREFIX || 'pr-';
             const prNumber = context.payload.pull_request.number;
             const webUrl = domain ? `https://deploy.${domain}/${prefix}${prNumber}/` : '';
-            const mobileJobResult = process.env.MOBILE_JOB_RESULT;
-            const mobileChannel = process.env.MOBILE_CHANNEL;
-            const mobileUpdateUrl = process.env.MOBILE_UPDATE_URL;
-
+            const runUrl = process.env.RUN_URL;
             const bootstrapUrl = process.env.BOOTSTRAP_URL;
-            const lines = [];
-            lines.push('<!-- pr-preview-links -->');
-            if (webUrl || bootstrapUrl) {
-              const isSignedCookies = process.env.ACCESS_MODE === 'signed-cookies';
-              if (isSignedCookies && bootstrapUrl) {
-                lines.push(`🔐 **Web preview (access link):** ${bootstrapUrl}`);
-                lines.push('');
-                lines.push('> _Click the link above to set your access cookie, then browse the preview. The link expires in 7 days._');
-              } else {
-                lines.push(`🌐 **Web preview:** ${webUrl}`);
-              }
+            const isSignedCookies = process.env.ACCESS_MODE === 'signed-cookies';
+
+            const webOutcome          = process.env.WEB_OUTCOME;
+            const supabaseOutcome     = process.env.SUPABASE_OUTCOME;
+            const stripeSyncOutcome   = process.env.STRIPE_SYNC_OUTCOME;
+            const stripeWebhookOutcome = process.env.STRIPE_WEBHOOK_OUTCOME;
+            const billingFnsOutcome   = process.env.BILLING_FUNCTIONS_OUTCOME;
+            const mobileJobResult     = process.env.MOBILE_JOB_RESULT;
+            const mobileChannel       = process.env.MOBILE_CHANNEL;
+            const mobileUpdateUrl     = process.env.MOBILE_UPDATE_URL;
+
+            function statusCell(outcome, successLabel) {
+              if (outcome === 'success')   return `✅ ${successLabel}`;
+              if (outcome === 'failure')   return '❌ Failed';
+              if (outcome === 'skipped')   return '⏭️ Skipped';
+              if (outcome === 'cancelled') return '🚫 Cancelled';
+              return '—';
             }
-            if (mobileJobResult === 'skipped') {
-              // Mobile disabled via MOBILE_ENABLED=false — omit mobile section
-            } else if (mobileJobResult === 'failure') {
-              lines.push('');
-              lines.push('❌ **Mobile preview failed.** Check the **deploy-preview-mobile** job logs for details.');
-            } else if (mobileUpdateUrl) {
+
+            // Aggregate billing: any failure beats all; then cancelled; then success
+            const billingOutcomes = [stripeSyncOutcome, stripeWebhookOutcome, billingFnsOutcome];
+            let billingStatus;
+            if (billingOutcomes.some(o => o === 'failure'))        billingStatus = 'failure';
+            else if (billingOutcomes.some(o => o === 'cancelled')) billingStatus = 'cancelled';
+            else if (billingOutcomes.every(o => o === 'success'))  billingStatus = 'success';
+            else billingStatus = billingOutcomes.find(o => o && o !== 'success') || 'success';
+
+            const logsLink = `[View logs](${runUrl})`;
+            const webLink = (() => {
+              if (webOutcome !== 'success') return logsLink;
+              if (isSignedCookies && bootstrapUrl)
+                return `[Access preview →](${bootstrapUrl}) _(sets cookie, expires 7 days)_`;
+              return webUrl ? `[Preview →](${webUrl})` : '—';
+            })();
+
+            const mobileStatus = mobileJobResult === 'skipped' ? 'skipped' : mobileJobResult || 'skipped';
+            const mobileLinkCell = mobileJobResult === 'failure' ? logsLink : '—';
+
+            const table = [
+              '| Component | Status | Link |',
+              '|-----------|--------|------|',
+              `| 🌐 Web | ${statusCell(webOutcome, 'Deployed')} | ${webLink} |`,
+              `| 🗄️ Database | ${statusCell(supabaseOutcome, 'Migrated')} | ${supabaseOutcome === 'failure' ? logsLink : '—'} |`,
+              `| 💳 Billing | ${statusCell(billingStatus, 'Deployed')} | ${billingStatus === 'failure' ? logsLink : '—'} |`,
+              `| 📱 Mobile | ${statusCell(mobileStatus, 'Deployed')} | ${mobileLinkCell} |`,
+            ].join('\n');
+
+            // HH:MM PT timestamp
+            const now = new Date();
+            const timeStr = now.toLocaleString('en-US', {
+              timeZone: 'America/Los_Angeles',
+              hour: '2-digit',
+              minute: '2-digit',
+              hour12: false,
+            });
+            const tzStr = now.toLocaleString('en-US', {
+              timeZone: 'America/Los_Angeles',
+              timeZoneName: 'short',
+            }).split(', ').pop().split(' ').pop();
+
+            const lines = [];
+            lines.push(marker);
+            lines.push('');
+            lines.push(table);
+            lines.push('');
+            lines.push(`_Last deployed: ${timeStr} ${tzStr}_`);
+
+            // Mobile detail section — only when mobile succeeded with an update URL
+            if (mobileJobResult !== 'skipped' && mobileJobResult !== 'failure' && mobileUpdateUrl) {
               const iosDownloadUrl = process.env.MOBILE_IOS_DOWNLOAD_URL;
               const androidDownloadUrl = process.env.MOBILE_ANDROID_DOWNLOAD_URL;
               const needsNativeBuild = process.env.NEEDS_NATIVE_BUILD === 'true';
-              
+
+              lines.push('');
+              lines.push('---');
+              lines.push('');
               lines.push(`📱 **Mobile preview:** Channel \`${mobileChannel}\``);
               lines.push('');
-              
-              // Show native build downloads if available
+
               if (iosDownloadUrl || androidDownloadUrl) {
                 lines.push('### 📱 Mobile Preview Builds');
                 lines.push('');
                 lines.push('**Native builds are available for download:**');
                 lines.push('');
-                
+
                 if (iosDownloadUrl) {
                   lines.push('**iOS Simulator Build:**');
                   lines.push(`- [Download .app file](${iosDownloadUrl})`);
                   lines.push('- Install with: `xcrun simctl install booted ~/Downloads/BeakerStack.app`');
                   lines.push('');
                 }
-                
+
                 if (androidDownloadUrl) {
                   lines.push('**Android Build (Device & Emulator):**');
                   lines.push(`- [Download .apk file](${androidDownloadUrl})`);
                   lines.push('- Install with: `adb install ~/Downloads/BeakerStack.apk`');
                   lines.push('');
                 }
-                
+
                 lines.push('**Note:** These builds include the preview Supabase configuration and are ready to use.');
                 lines.push('');
               } else if (needsNativeBuild) {
@@ -496,23 +562,11 @@ jobs:
                 lines.push(`**Alternative:** For local development, use: \`cd apps/mobile && npx expo start --dev-client\`, then press 'i' for iOS simulator.`);
                 lines.push('');
               }
-              
+
               lines.push('📖 See [Mobile Build Testing Guide](../../docs/MOBILE_BUILD_TESTING.md) for detailed instructions.');
             }
-            let body = lines.join('\n');
 
-            // Add timestamp in Pacific time
-            const now = new Date();
-            const pacificTime = now.toLocaleString('en-US', {
-              timeZone: 'America/Los_Angeles',
-              dateStyle: 'long',
-              timeStyle: 'short'
-            });
-            const timezone = now.toLocaleString('en-US', {
-              timeZone: 'America/Los_Angeles',
-              timeZoneName: 'short'
-            }).split(' ').pop();
-            body = `${body}\n\n---\n\n_Updated at: ${pacificTime} ${timezone}_`;
+            const body = lines.join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

Closes #85.

Replaces the flat-text PR preview comment with a status table showing the outcome of each component individually.

### Changes

**`deploy-preview` job**
- Added `id: stripe-sync` + `continue-on-error: true` to the Stripe price sync step
- Added `continue-on-error: true` to the Stripe webhook step (already had an id)
- Added `id: billing-functions` + `continue-on-error: true` to the billing edge functions step
- Expanded `outputs:` block with `supabase-outcome`, `stripe-sync-outcome`, `stripe-webhook-outcome`, `billing-functions-outcome`, `web-outcome`

**`comment` job**
- New env vars thread the 5 step outcomes + `RUN_URL` into the script
- Comment now opens with a status table:
  ```
  | Component   | Status        | Link              |
  |-------------|---------------|-------------------|
  | 🌐 Web      | ✅ Deployed   | Preview →         |
  | 🗄️ Database | ✅ Migrated   | —                 |
  | 💳 Billing  | ❌ Failed     | View logs         |
  | 📱 Mobile   | ⏭️ Skipped   | —                 |
  ```
- Billing row aggregates all 3 billing steps (any failure → ❌)
- Mobile row: `skipped` job result → ⏭️ Skipped (MOBILE_ENABLED=false), `failure` → ❌ Failed + logs link
- Web link: plain URL for public previews, bootstrap cookie URL for signed-cookie access mode
- Timestamp simplified to `_Last deployed: HH:MM PDT_`
- Existing mobile detail section preserved below the table (separator + OTA/native content)

## Test plan
- [ ] Trigger a PR preview run and verify the comment renders the table correctly
- [ ] Verify billing failure shows ❌ with a logs link
- [ ] Verify mobile-disabled repo shows ⏭️ Skipped in Mobile row
- [ ] Verify signed-cookie access mode shows the bootstrap URL in the Web link cell

🤖 Generated with [Claude Code](https://claude.com/claude-code)