### PR TITLE
feat(mobile): billing screens — Overview, Plans, Invoices tabs (issue #113)

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -53,6 +53,7 @@
     "@react-navigation/native": "^6.1.18",
     "@react-navigation/native-stack": "^6.9.26",
     "@supabase/supabase-js": "^2.38.0",
+    "@react-navigation/material-top-tabs": "^6.6.14",
     "expo": "~50.0.0",
     "expo-constants": "~15.4.6",
     "expo-dev-client": "~3.3.12",
@@ -60,12 +61,15 @@
     "expo-image-picker": "~14.7.1",
     "expo-status-bar": "~1.11.1",
     "expo-updates": "~0.24.13",
+    "expo-web-browser": "~12.8.2",
     "react": "18.2.0",
     "react-native": "0.73.6",
     "react-native-get-random-values": "~1.8.0",
+    "react-native-pager-view": "6.2.3",
     "react-native-safe-area-context": "4.8.2",
     "react-native-screens": "~3.29.0",
     "react-native-svg": "14.1.0",
+    "react-native-tab-view": "^3.5.2",
     "react-native-url-polyfill": "^2.0.0"
   },
   "devDependencies": {

--- a/apps/mobile/src/billing/billingUrls.ts
+++ b/apps/mobile/src/billing/billingUrls.ts
@@ -1,0 +1,5 @@
+const appScheme =
+  (typeof process !== 'undefined' && process.env?.EXPO_PUBLIC_APP_SCHEME) ||
+  'exp';
+
+export const BILLING_DEEP_LINK_URL = `${appScheme}://billing`;

--- a/apps/mobile/src/navigation/BillingNavigator.tsx
+++ b/apps/mobile/src/navigation/BillingNavigator.tsx
@@ -1,0 +1,29 @@
+import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
+import type { ReactElement } from 'react';
+import { BillingOverviewScreen } from '../screens/billing/BillingOverviewScreen';
+import { BillingPlansScreen } from '../screens/billing/BillingPlansScreen';
+import { BillingInvoicesScreen } from '../screens/billing/BillingInvoicesScreen';
+
+const Tab = createMaterialTopTabNavigator();
+
+export function BillingNavigator(): ReactElement {
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        tabBarActiveTintColor: '#4f46e5',
+        tabBarInactiveTintColor: '#6b7280',
+        tabBarIndicatorStyle: { backgroundColor: '#4f46e5' },
+        tabBarStyle: { backgroundColor: '#fff' },
+        tabBarLabelStyle: {
+          fontSize: 13,
+          fontWeight: '600',
+          textTransform: 'none',
+        },
+      }}
+    >
+      <Tab.Screen name='Overview' component={BillingOverviewScreen} />
+      <Tab.Screen name='Plans' component={BillingPlansScreen} />
+      <Tab.Screen name='Invoices' component={BillingInvoicesScreen} />
+    </Tab.Navigator>
+  );
+}

--- a/apps/mobile/src/screens/BillingScreen.tsx
+++ b/apps/mobile/src/screens/BillingScreen.tsx
@@ -5,7 +5,7 @@ import type { ReactElement } from 'react';
 import { useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { beakerstackBillingConfig } from '../billing/beakerstackBillingConfig';
-import { BILLING_DEEP_LINK_URL } from '../billing/BILLING_DEEP_LINK_URLs';
+import { BILLING_DEEP_LINK_URL} from '../billing/billingUrls';
 import { supabase } from '../lib/supabase';
 import { BillingNavigator } from '../navigation/BillingNavigator';
 

--- a/apps/mobile/src/screens/BillingScreen.tsx
+++ b/apps/mobile/src/screens/BillingScreen.tsx
@@ -1,203 +1,48 @@
-import {
-  BillingProvider,
-  useRecordUsage,
-  useUsage,
-} from '@beakerstack/billing';
-import {
-  CustomerPortalLink,
-  FeatureGate,
-  PricingTable,
-  SubscriptionStatus,
-  UpgradePrompt,
-  UsageIndicator,
-} from '@beakerstack/billing/native';
+import { BillingProvider } from '@beakerstack/billing';
 import { useNavigation } from '@react-navigation/native';
-import React, { useState, type ReactElement } from 'react';
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import {
-  beakerstackBillingConfig,
-  BEAKERSTACK_METER_AI_SUMMARIZE,
-} from '../billing/beakerstackBillingConfig';
+import { useFocusEffect } from '@react-navigation/native';
+import type { ReactElement } from 'react';
+import { useCallback } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { beakerstackBillingConfig } from '../billing/beakerstackBillingConfig';
 import { supabase } from '../lib/supabase';
+import { BillingNavigator } from '../navigation/BillingNavigator';
 
-function readBillingScreenDemoMode(): boolean {
-  return process.env?.EXPO_PUBLIC_BILLING_DEMO_MODE === 'true';
-}
-
-/** Set EXPO_PUBLIC_BILLING_DEMO_BASE_URL to your dev machine URL for Stripe return URLs on device. */
-const billingBaseUrl =
-  (typeof process !== 'undefined' &&
-    process.env?.EXPO_PUBLIC_BILLING_DEMO_BASE_URL) ||
-  'http://127.0.0.1:8081';
-
-function MeteredBlock(): ReactElement {
-  const { exceeded, refresh } = useUsage<
-    typeof beakerstackBillingConfig,
-    typeof BEAKERSTACK_METER_AI_SUMMARIZE
-  >(BEAKERSTACK_METER_AI_SUMMARIZE);
-  const { record, pending } = useRecordUsage<
-    typeof beakerstackBillingConfig,
-    typeof BEAKERSTACK_METER_AI_SUMMARIZE
-  >(BEAKERSTACK_METER_AI_SUMMARIZE);
-  return (
-    <View style={styles.section}>
-      <Text style={styles.h2}>AI summarize (metered)</Text>
-      <UsageIndicator<typeof beakerstackBillingConfig>
-        meter={BEAKERSTACK_METER_AI_SUMMARIZE}
-        variant='text'
-      />
-      {exceeded ? (
-        <UpgradePrompt<typeof beakerstackBillingConfig>
-          targetTier='beakerstack_pro'
-          reason='Monthly limit reached.'
-        />
-      ) : (
-        <Pressable
-          style={styles.btn}
-          disabled={pending}
-          onPress={() => void record(1)}
-        >
-          <Text style={styles.btnText}>
-            {pending ? '…' : 'Use one summarize'}
-          </Text>
-        </Pressable>
-      )}
-      <Pressable onPress={() => void refresh()}>
-        <Text style={styles.link}>Refresh usage</Text>
-      </Pressable>
-    </View>
-  );
-}
-
-function DemoRpcButtons(): ReactElement {
-  const [msg, setMsg] = useState<string | null>(null);
-  if (!readBillingScreenDemoMode()) {
-    return (
-      <Text style={styles.muted}>
-        Set EXPO_PUBLIC_BILLING_DEMO_MODE=true and DB demo_billing_mode for
-        simulate controls.
-      </Text>
-    );
-  }
-  const sim = async (planId: string) => {
-    const { error } = await supabase.rpc('billing_demo_simulate_upgrade', {
-      p_product_id: 'beakerstack',
-      p_plan_id: planId,
-    });
-    setMsg(error ? error.message : `Simulated ${planId}`);
-  };
-  return (
-    <View style={styles.demoBox}>
-      <Text style={styles.warn}>Demo mode — not real billing</Text>
-      <Pressable
-        style={styles.smallBtn}
-        onPress={() => void sim('beakerstack_pro')}
-      >
-        <Text>Simulate Pro</Text>
-      </Pressable>
-      {msg ? <Text style={styles.muted}>{msg}</Text> : null}
-    </View>
-  );
-}
+const appScheme =
+  (typeof process !== 'undefined' && process.env?.EXPO_PUBLIC_APP_SCHEME) ||
+  'exp';
+const billingUrl = `${appScheme}://billing`;
 
 export default function BillingScreen(): ReactElement {
   const navigation = useNavigation();
+
+  // Hide the bottom tab bar while the billing screen is in focus.
+  // getParent() is null on the current flat stack (pre-#116) — the call is a safe no-op.
+  useFocusEffect(
+    useCallback(() => {
+      const parent = navigation.getParent();
+      parent?.setOptions({ tabBarStyle: { display: 'none' } });
+      return () => {
+        parent?.setOptions({ tabBarStyle: undefined });
+      };
+    }, [navigation])
+  );
+
   return (
-    <SafeAreaView style={styles.safe}>
-      <ScrollView contentContainerStyle={styles.scroll}>
-        <Pressable
-          onPress={() => navigation.goBack()}
-          style={{ marginBottom: 8 }}
-        >
-          <Text style={styles.link}>← Back</Text>
-        </Pressable>
-        <Text style={styles.h1}>Billing</Text>
-        <Text style={styles.subtitle}>
-          For the full /billing experience (tabs, plans, invoices), use the web
-          app. This screen reuses the billing package for dev testing.
-        </Text>
-        <BillingProvider<typeof beakerstackBillingConfig>
-          supabase={supabase}
-          config={beakerstackBillingConfig}
-          checkoutSuccessUrl={`${billingBaseUrl}/billing`}
-          checkoutCancelUrl={`${billingBaseUrl}/billing`}
-          portalReturnUrl={`${billingBaseUrl}/billing`}
-        >
-          <DemoRpcButtons />
-          <View style={styles.section}>
-            <Text style={styles.h2}>Subscription</Text>
-            <SubscriptionStatus<typeof beakerstackBillingConfig> />
-            <CustomerPortalLink<typeof beakerstackBillingConfig>
-              style={{ marginTop: 8 }}
-            >
-              <Text style={styles.link}>Customer portal</Text>
-            </CustomerPortalLink>
-            <PricingTable<typeof beakerstackBillingConfig> highlightCurrent />
-          </View>
-          <MeteredBlock />
-          <View style={styles.section}>
-            <Text style={styles.h2}>Feature B (Max)</Text>
-            <FeatureGate<typeof beakerstackBillingConfig>
-              feature='feature_b'
-              fallback={
-                <UpgradePrompt<typeof beakerstackBillingConfig>
-                  targetTier='beakerstack_max'
-                  reason='Feature B requires Max.'
-                />
-              }
-            >
-              <Text style={styles.ok}>Feature B enabled</Text>
-            </FeatureGate>
-          </View>
-        </BillingProvider>
-      </ScrollView>
-    </SafeAreaView>
+    <View style={s.container}>
+      <BillingProvider<typeof beakerstackBillingConfig>
+        supabase={supabase}
+        config={beakerstackBillingConfig}
+        checkoutSuccessUrl={billingUrl}
+        checkoutCancelUrl={billingUrl}
+        portalReturnUrl={billingUrl}
+      >
+        <BillingNavigator />
+      </BillingProvider>
+    </View>
   );
 }
 
-const styles = StyleSheet.create({
-  safe: { flex: 1, backgroundColor: '#f9fafb' },
-  scroll: { padding: 16, paddingBottom: 32 },
-  h1: { fontSize: 22, fontWeight: '700', marginBottom: 8 },
-  subtitle: {
-    fontSize: 13,
-    color: '#6b7280',
-    marginBottom: 12,
-    lineHeight: 18,
-  },
-  h2: { fontSize: 18, fontWeight: '600', marginBottom: 8 },
-  section: {
-    marginBottom: 16,
-    padding: 12,
-    backgroundColor: '#fff',
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: '#e5e7eb',
-  },
-  btn: {
-    backgroundColor: '#4f46e5',
-    padding: 10,
-    borderRadius: 6,
-    marginTop: 8,
-    alignSelf: 'flex-start',
-  },
-  btnText: { color: '#fff' },
-  link: { color: '#4f46e5', marginTop: 8 },
-  muted: { color: '#6b7280', fontSize: 12, marginTop: 6 },
-  ok: { color: '#15803d' },
-  demoBox: {
-    backgroundColor: '#fef3c7',
-    padding: 8,
-    borderRadius: 6,
-    marginBottom: 12,
-  },
-  warn: { fontWeight: '600', marginBottom: 6 },
-  smallBtn: {
-    alignSelf: 'flex-start',
-    padding: 6,
-    borderWidth: 1,
-    borderColor: '#d97706',
-    borderRadius: 4,
-  },
+const s = StyleSheet.create({
+  container: { flex: 1 },
 });

--- a/apps/mobile/src/screens/BillingScreen.tsx
+++ b/apps/mobile/src/screens/BillingScreen.tsx
@@ -5,13 +5,9 @@ import type { ReactElement } from 'react';
 import { useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { beakerstackBillingConfig } from '../billing/beakerstackBillingConfig';
+import { BILLING_DEEP_LINK_URL } from '../billing/BILLING_DEEP_LINK_URLs';
 import { supabase } from '../lib/supabase';
 import { BillingNavigator } from '../navigation/BillingNavigator';
-
-const appScheme =
-  (typeof process !== 'undefined' && process.env?.EXPO_PUBLIC_APP_SCHEME) ||
-  'exp';
-const billingUrl = `${appScheme}://billing`;
 
 export default function BillingScreen(): ReactElement {
   const navigation = useNavigation();
@@ -33,9 +29,9 @@ export default function BillingScreen(): ReactElement {
       <BillingProvider<typeof beakerstackBillingConfig>
         supabase={supabase}
         config={beakerstackBillingConfig}
-        checkoutSuccessUrl={billingUrl}
-        checkoutCancelUrl={billingUrl}
-        portalReturnUrl={billingUrl}
+        checkoutSuccessUrl={BILLING_DEEP_LINK_URL}
+        checkoutCancelUrl={BILLING_DEEP_LINK_URL}
+        portalReturnUrl={BILLING_DEEP_LINK_URL}
       >
         <BillingNavigator />
       </BillingProvider>

--- a/apps/mobile/src/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen.tsx
@@ -30,6 +30,7 @@ type RootStackParamList = {
   Signup: undefined;
   Dashboard: undefined;
   Profile: undefined;
+  Billing: undefined;
 };
 
 type ProfileScreenNavigationProp = NativeStackNavigationProp<
@@ -79,7 +80,7 @@ export default function ProfileScreen({ navigation }: Props) {
   return <ProfileScreenContent navigation={navigation} />;
 }
 
-function ProfileScreenContent({ navigation: _navigation }: Props) {
+function ProfileScreenContent({ navigation }: Props) {
   const [isEditing, setIsEditing] = useState(false);
   const [componentsLoaded, setComponentsLoaded] = useState(false);
   const auth = useAuthContext();
@@ -144,6 +145,18 @@ function ProfileScreenContent({ navigation: _navigation }: Props) {
                 <ProfileStats profile={profile.profile} />
               </View>
             )}
+
+            {/* Billing */}
+            <View style={styles.card}>
+              <TouchableOpacity
+                onPress={() => navigation.navigate('Billing')}
+                style={styles.editButton}
+              >
+                <Text style={styles.editButtonText}>
+                  Billing &amp; subscription
+                </Text>
+              </TouchableOpacity>
+            </View>
 
             {/* Profile Editor Section */}
             {!isEditing && (

--- a/apps/mobile/src/screens/billing/BillingInvoicesScreen.tsx
+++ b/apps/mobile/src/screens/billing/BillingInvoicesScreen.tsx
@@ -1,0 +1,28 @@
+import { useInvoices } from '@beakerstack/billing';
+import { InvoiceList } from '@beakerstack/billing/native';
+import type { ReactElement } from 'react';
+import { StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { beakerstackBillingConfig } from '../../billing/beakerstackBillingConfig';
+
+export function BillingInvoicesScreen(): ReactElement {
+  const { items, loading, error, hasMore, loadMore, refresh } =
+    useInvoices<typeof beakerstackBillingConfig>();
+
+  return (
+    <SafeAreaView style={s.safe} edges={['bottom']}>
+      <InvoiceList
+        items={items}
+        loading={loading}
+        error={error}
+        hasMore={hasMore}
+        loadMore={loadMore}
+        refresh={refresh}
+      />
+    </SafeAreaView>
+  );
+}
+
+const s = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: '#fff' },
+});

--- a/apps/mobile/src/screens/billing/BillingInvoicesScreen.tsx
+++ b/apps/mobile/src/screens/billing/BillingInvoicesScreen.tsx
@@ -24,5 +24,5 @@ export function BillingInvoicesScreen(): ReactElement {
 }
 
 const s = StyleSheet.create({
-  safe: { flex: 1, backgroundColor: '#fff' },
+  safe: { flex: 1, backgroundColor: '#f9fafb' },
 });

--- a/apps/mobile/src/screens/billing/BillingOverviewScreen.tsx
+++ b/apps/mobile/src/screens/billing/BillingOverviewScreen.tsx
@@ -1,0 +1,153 @@
+import {
+  CustomerPortalLink,
+  SubscriptionStatus,
+  SubscriptionStatusBadge,
+  UsageIndicator,
+} from '@beakerstack/billing/native';
+import { useSubscription, usePlan } from '@beakerstack/billing';
+import type { ReactElement } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  beakerstackBillingConfig,
+  BEAKERSTACK_METER_AI_SUMMARIZE,
+} from '../../billing/beakerstackBillingConfig';
+
+export function BillingOverviewScreen(): ReactElement {
+  const {
+    data: sub,
+    loading,
+    error,
+    refresh,
+  } = useSubscription<typeof beakerstackBillingConfig>();
+  usePlan<typeof beakerstackBillingConfig>(); // keep plan cache warm
+
+  if (loading) {
+    return (
+      <View style={s.centered}>
+        <ActivityIndicator color='#4f46e5' />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={s.centered}>
+        <Text style={s.errorText}>{error.message}</Text>
+        <Pressable onPress={() => void refresh()} style={s.retryBtn}>
+          <Text style={s.retryText}>Retry</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const periodEnd = sub?.current_period_end
+    ? new Date(sub.current_period_end).toLocaleDateString('en-US', {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+      })
+    : null;
+
+  const downgradeScheduled =
+    sub?.cancel_at_period_end || sub?.pending_target_plan_id;
+
+  return (
+    <SafeAreaView style={s.safe} edges={['bottom']}>
+      <ScrollView contentContainerStyle={s.scroll}>
+        <View style={s.card}>
+          <Text style={s.sectionLabel}>Current plan</Text>
+          <SubscriptionStatus<typeof beakerstackBillingConfig> />
+          <View style={s.badgeRow}>
+            <SubscriptionStatusBadge subscription={sub} />
+          </View>
+        </View>
+
+        {downgradeScheduled && periodEnd ? (
+          <View style={[s.card, s.warningCard]}>
+            <Text style={s.warningText}>
+              {sub?.cancel_at_period_end
+                ? `Your plan will be cancelled on ${periodEnd}.`
+                : `Downgrade scheduled for ${periodEnd}.`}
+            </Text>
+          </View>
+        ) : periodEnd ? (
+          <View style={s.card}>
+            <Text style={s.meta}>Next renewal: {periodEnd}</Text>
+          </View>
+        ) : null}
+
+        <View style={s.card}>
+          <Text style={s.sectionLabel}>Usage this period</Text>
+          <UsageIndicator<typeof beakerstackBillingConfig>
+            meter={BEAKERSTACK_METER_AI_SUMMARIZE}
+            variant='expanded'
+          />
+        </View>
+
+        <View style={s.card}>
+          <CustomerPortalLink<typeof beakerstackBillingConfig>
+            style={s.portalLink}
+          >
+            <Text style={s.portalLinkText}>Manage billing →</Text>
+          </CustomerPortalLink>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const s = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: '#f9fafb' },
+  scroll: { padding: 16, gap: 12, paddingBottom: 32 },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 10,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  warningCard: {
+    backgroundColor: '#fffbeb',
+    borderColor: '#fcd34d',
+    borderWidth: 1,
+  },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#6b7280',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 10,
+  },
+  badgeRow: { marginTop: 8 },
+  meta: { fontSize: 14, color: '#6b7280' },
+  warningText: { fontSize: 14, color: '#92400e', lineHeight: 20 },
+  portalLink: { alignSelf: 'flex-start' },
+  portalLinkText: { fontSize: 15, color: '#4f46e5', fontWeight: '600' },
+  errorText: { color: '#b91c1c', marginBottom: 12, textAlign: 'center' },
+  retryBtn: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#4f46e5',
+  },
+  retryText: { color: '#4f46e5', fontWeight: '600' },
+});

--- a/apps/mobile/src/screens/billing/BillingPlansScreen.tsx
+++ b/apps/mobile/src/screens/billing/BillingPlansScreen.tsx
@@ -1,0 +1,241 @@
+import * as WebBrowser from 'expo-web-browser';
+import {
+  usePlanCatalog,
+  useSubscription,
+  useCheckout,
+  useBillingStripeActions,
+  usePlan,
+} from '@beakerstack/billing';
+import { PricingTable } from '@beakerstack/billing/native';
+import { ConfirmDowngradeModal } from '@beakerstack/billing/native';
+import type { ReactElement } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  AppState,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { beakerstackBillingConfig } from '../../billing/beakerstackBillingConfig';
+import type { Plan } from '@beakerstack/billing';
+
+const appScheme =
+  (typeof process !== 'undefined' && process.env?.EXPO_PUBLIC_APP_SCHEME) ||
+  'exp';
+const checkoutRedirectUrl = `${appScheme}://billing`;
+
+export function BillingPlansScreen(): ReactElement {
+  const {
+    plans,
+    loading: catalogLoading,
+    error: catalogError,
+    refresh: refreshCatalog,
+  } = usePlanCatalog<typeof beakerstackBillingConfig>();
+  const {
+    data: sub,
+    loading: subLoading,
+    refresh: refreshSub,
+  } = useSubscription<typeof beakerstackBillingConfig>();
+  const { data: currentPlan } = usePlan<typeof beakerstackBillingConfig>();
+  const { startCheckout, pending: checkoutPending } =
+    useCheckout<typeof beakerstackBillingConfig>();
+  const {
+    scheduleCancelToFree,
+    updateSubscription,
+    pending: actionPending,
+  } = useBillingStripeActions<typeof beakerstackBillingConfig>();
+
+  const [cadence, setCadence] = useState<'monthly' | 'annual'>('monthly');
+  const [confirmTarget, setConfirmTarget] = useState<Plan | null>(null);
+  const [downgradeAction, setDowngradeAction] = useState<
+    'cancel' | 'update' | null
+  >(null);
+
+  // Refresh subscription when user returns from Stripe checkout
+  const appState = useRef(AppState.currentState);
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', nextState => {
+      if (
+        appState.current.match(/inactive|background/) &&
+        nextState === 'active'
+      ) {
+        void refreshSub();
+      }
+      appState.current = nextState;
+    });
+    return () => sub.remove();
+  }, [refreshSub]);
+
+  const handleSelectPlan = useCallback(
+    async (planId: string) => {
+      const target = plans.find(p => p.id === planId);
+      if (!target) return;
+
+      const currentOrder = currentPlan?.display_order ?? 0;
+      const targetOrder = target.display_order ?? 0;
+      const isDowngrade = targetOrder < currentOrder;
+      const isFreeDowngrade = target.price_cents === 0;
+
+      if (isDowngrade) {
+        setConfirmTarget(target);
+        setDowngradeAction(isFreeDowngrade ? 'cancel' : 'update');
+        return;
+      }
+
+      // Upgrade — open Stripe checkout
+      const result = await startCheckout(planId, cadence);
+      if (result?.checkoutUrl) {
+        await WebBrowser.openAuthSessionAsync(
+          result.checkoutUrl,
+          checkoutRedirectUrl
+        );
+      }
+    },
+    [plans, currentPlan, startCheckout, cadence]
+  );
+
+  const handleConfirmDowngrade = useCallback(async () => {
+    if (!confirmTarget) return;
+    if (downgradeAction === 'cancel') {
+      await scheduleCancelToFree();
+    } else {
+      await updateSubscription(confirmTarget.id, cadence);
+    }
+    setConfirmTarget(null);
+    setDowngradeAction(null);
+  }, [
+    confirmTarget,
+    downgradeAction,
+    scheduleCancelToFree,
+    updateSubscription,
+    cadence,
+  ]);
+
+  const loading = catalogLoading || subLoading;
+
+  if (loading && plans.length === 0) {
+    return (
+      <View style={s.centered}>
+        <ActivityIndicator color='#4f46e5' />
+      </View>
+    );
+  }
+
+  if (catalogError && plans.length === 0) {
+    return (
+      <View style={s.centered}>
+        <Text style={s.errorText}>{catalogError.message}</Text>
+        <Pressable onPress={() => void refreshCatalog()} style={s.retryBtn}>
+          <Text style={s.retryText}>Retry</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <SafeAreaView style={s.safe} edges={['bottom']}>
+      <ScrollView contentContainerStyle={s.scroll}>
+        <View style={s.cadenceToggle}>
+          {(['monthly', 'annual'] as const).map(c => (
+            <Pressable
+              key={c}
+              style={[s.cadenceBtn, cadence === c && s.cadenceBtnActive]}
+              onPress={() => setCadence(c)}
+            >
+              <Text
+                style={[
+                  s.cadenceBtnText,
+                  cadence === c && s.cadenceBtnTextActive,
+                ]}
+              >
+                {c.charAt(0).toUpperCase() + c.slice(1)}
+                {c === 'annual' ? ' · Save 20%' : ''}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <PricingTable<typeof beakerstackBillingConfig>
+          highlightPlanId={sub?.plan_id ?? null}
+          onCheckout={planId => void handleSelectPlan(planId)}
+        />
+
+        {checkoutPending || actionPending ? (
+          <View style={s.pendingBar}>
+            <ActivityIndicator color='#4f46e5' size='small' />
+            <Text style={s.pendingText}>Processing…</Text>
+          </View>
+        ) : null}
+      </ScrollView>
+
+      {confirmTarget ? (
+        <ConfirmDowngradeModal
+          visible
+          targetPlan={confirmTarget}
+          currentPlan={currentPlan}
+          onConfirm={() => void handleConfirmDowngrade()}
+          onCancel={() => {
+            setConfirmTarget(null);
+            setDowngradeAction(null);
+          }}
+          pending={actionPending}
+        />
+      ) : null}
+    </SafeAreaView>
+  );
+}
+
+const s = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: '#f9fafb' },
+  scroll: { padding: 16, gap: 16, paddingBottom: 32 },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  cadenceToggle: {
+    flexDirection: 'row',
+    backgroundColor: '#f3f4f6',
+    borderRadius: 8,
+    padding: 4,
+    gap: 4,
+  },
+  cadenceBtn: {
+    flex: 1,
+    paddingVertical: 8,
+    borderRadius: 6,
+    alignItems: 'center',
+  },
+  cadenceBtnActive: {
+    backgroundColor: '#fff',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 1,
+    elevation: 1,
+  },
+  cadenceBtnText: { fontSize: 13, color: '#6b7280', fontWeight: '500' },
+  cadenceBtnTextActive: { color: '#111827', fontWeight: '600' },
+  pendingBar: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 12,
+  },
+  pendingText: { color: '#6b7280', fontSize: 14 },
+  errorText: { color: '#b91c1c', marginBottom: 12, textAlign: 'center' },
+  retryBtn: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#4f46e5',
+  },
+  retryText: { color: '#4f46e5', fontWeight: '600' },
+});

--- a/apps/mobile/src/screens/billing/BillingPlansScreen.tsx
+++ b/apps/mobile/src/screens/billing/BillingPlansScreen.tsx
@@ -159,6 +159,7 @@ export function BillingPlansScreen(): ReactElement {
 
         <PricingTable<typeof beakerstackBillingConfig>
           highlightPlanId={sub?.plan_id ?? null}
+          cadence={cadence}
           onCheckout={planId => void handleSelectPlan(planId)}
         />
 

--- a/apps/mobile/src/screens/billing/BillingPlansScreen.tsx
+++ b/apps/mobile/src/screens/billing/BillingPlansScreen.tsx
@@ -58,7 +58,7 @@ export function BillingPlansScreen(): ReactElement {
   // Refresh subscription when user returns from Stripe checkout
   const appState = useRef(AppState.currentState);
   useEffect(() => {
-    const sub = AppState.addEventListener('change', nextState => {
+    const listener = AppState.addEventListener('change', nextState => {
       if (
         appState.current.match(/inactive|background/) &&
         nextState === 'active'
@@ -67,7 +67,7 @@ export function BillingPlansScreen(): ReactElement {
       }
       appState.current = nextState;
     });
-    return () => sub.remove();
+    return () => listener.remove();
   }, [refreshSub]);
 
   const handleSelectPlan = useCallback(

--- a/apps/mobile/src/screens/billing/BillingPlansScreen.tsx
+++ b/apps/mobile/src/screens/billing/BillingPlansScreen.tsx
@@ -21,12 +21,10 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { beakerstackBillingConfig } from '../../billing/beakerstackBillingConfig';
+import { BILLING_DEEP_LINK_URL } from '../../billing/billingUrls';
 import type { Plan } from '@beakerstack/billing';
 
-const appScheme =
-  (typeof process !== 'undefined' && process.env?.EXPO_PUBLIC_APP_SCHEME) ||
-  'exp';
-const checkoutRedirectUrl = `${appScheme}://billing`;
+const checkoutRedirectUrl = BILLING_DEEP_LINK_URL;
 
 export function BillingPlansScreen(): ReactElement {
   const {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@beakerstack/billing": "^1.0.0",
         "@react-native-async-storage/async-storage": "1.21.0",
         "@react-native-google-signin/google-signin": "13.3.1",
+        "@react-navigation/material-top-tabs": "^6.6.14",
         "@react-navigation/native": "^6.1.18",
         "@react-navigation/native-stack": "^6.9.26",
         "@supabase/supabase-js": "^2.38.0",
@@ -63,12 +64,15 @@
         "expo-image-picker": "~14.7.1",
         "expo-status-bar": "~1.11.1",
         "expo-updates": "~0.24.13",
+        "expo-web-browser": "~12.8.2",
         "react": "18.2.0",
         "react-native": "0.73.6",
         "react-native-get-random-values": "~1.8.0",
+        "react-native-pager-view": "6.2.3",
         "react-native-safe-area-context": "4.8.2",
         "react-native-screens": "~3.29.0",
         "react-native-svg": "14.1.0",
+        "react-native-tab-view": "^3.5.2",
         "react-native-url-polyfill": "^2.0.0"
       },
       "devDependencies": {
@@ -9463,6 +9467,23 @@
         "react-native-safe-area-context": ">= 3.0.0"
       }
     },
+    "node_modules/@react-navigation/material-top-tabs": {
+      "version": "6.6.14",
+      "resolved": "https://registry.npmjs.org/@react-navigation/material-top-tabs/-/material-top-tabs-6.6.14.tgz",
+      "integrity": "sha512-kfNQt3BInQusEc8A+PDWaKmRQNaCrSqngcOQwUe1uNizJdZJEFdfaInivtBFW2LcQqtzgIHK/am2TgK0Pos6og==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^4.2.3",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-pager-view": ">= 4.0.0",
+        "react-native-tab-view": ">= 3.0.0"
+      }
+    },
     "node_modules/@react-navigation/native": {
       "version": "6.1.18",
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-6.1.18.tgz",
@@ -12743,6 +12764,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -12760,6 +12794,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/colorette": {
       "version": "1.4.0",
@@ -12799,6 +12843,18 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "license": "MIT"
+    },
+    "node_modules/compare-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-urls/-/compare-urls-2.0.0.tgz",
+      "integrity": "sha512-eCJcWn2OYFEIqbm70ta7LQowJOOZZqq1a2YbbFCFI1uwSvj+TWMwXVn7vPR1ceFNcAIt5RSTDbwdlX82gYLTkA==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-url": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/component-type": {
       "version": "1.2.2",
@@ -15536,6 +15592,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/expo-web-browser": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-12.8.2.tgz",
+      "integrity": "sha512-Mw8WoFMSADecNjtC4PZVsVj1/lYdxIAH1jOVV+F8v8SEWYxORWofoShfXg7oUxRLu0iUG8JETfO5y4m8+fOgdg==",
+      "license": "MIT",
+      "dependencies": {
+        "compare-urls": "^2.0.0",
+        "url": "^0.11.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo/node_modules/@babel/code-frame": {
@@ -21063,6 +21132,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-url": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+      "license": "MIT",
+      "dependencies": {
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/normalize-url/node_modules/query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url/node_modules/strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/npm-package-arg": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
@@ -22468,6 +22574,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
@@ -22674,7 +22789,6 @@
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
       "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -22940,6 +23054,16 @@
         "react-native": ">=0.56"
       }
     },
+    "node_modules/react-native-pager-view": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-6.2.3.tgz",
+      "integrity": "sha512-dqVpXWFtPNfD3D2QQQr8BP+ullS5MhjRJuF8Z/qml4QTILcrWaW8F5iAxKkQR3Jl0ikcEryG/+SQlNcwlo0Ggg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-safe-area-context": {
       "version": "4.8.2",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.8.2.tgz",
@@ -22976,6 +23100,29 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-tab-view": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-3.5.2.tgz",
+      "integrity": "sha512-nE5WqjbeEPsWQx4mtz81QGVvgHRhujTNIIZiMCx3Bj6CBFDafbk7XZp9ocmtzXUQaZ4bhtVS43R4FIiR4LboJw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-latest-callback": "^0.1.5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-pager-view": "*"
+      }
+    },
+    "node_modules/react-native-tab-view/node_modules/use-latest-callback": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.1.11.tgz",
+      "integrity": "sha512-8nhb73STSD/z3GTHklvNjL8F9wMOo0bj0AFnulpIYuFTm6aQlT3ZcNbXF2YurKImIY8+kpSFSDHZZyQmurGrhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/react-native-url-polyfill": {
@@ -24298,6 +24445,21 @@
         "node": ">= 5.10.0"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -24361,6 +24523,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sort-keys/node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map": {
@@ -26264,10 +26447,29 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/url-join": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
       "integrity": "sha512-EGXjXJZhIHiQMK2pQukuFcL303nskqIRzWvPvV5O8miOfwoUb9G+a/Cld60kUyeaybEI94wvVClT10DtfeAExA==",
+      "license": "MIT"
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "license": "MIT"
     },
     "node_modules/use-latest-callback": {

--- a/packages/billing/src/components/ConfirmDowngradeModal.native.tsx
+++ b/packages/billing/src/components/ConfirmDowngradeModal.native.tsx
@@ -1,0 +1,161 @@
+import type { ReactElement } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import type { Plan } from '../types.js';
+
+type Props = {
+  visible: boolean;
+  targetPlan: Plan;
+  currentPlan: Plan | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+  pending?: boolean;
+};
+
+function featuresLost(current: Plan | null, target: Plan): string[] {
+  if (!current) return [];
+  const lost: string[] = [];
+  for (const [key, value] of Object.entries(current.features)) {
+    const targetValue = target.features[key];
+    if (value === true && targetValue !== true) {
+      lost.push(key.replace(/_/g, ' '));
+    }
+    if (
+      typeof value === 'number' &&
+      typeof targetValue === 'number' &&
+      targetValue < value
+    ) {
+      lost.push(`${key.replace(/_/g, ' ')} (${targetValue} → ${value} limit)`);
+    }
+    if (typeof value === 'number' && targetValue === undefined) {
+      lost.push(key.replace(/_/g, ' '));
+    }
+  }
+  return lost;
+}
+
+export function ConfirmDowngradeModal({
+  visible,
+  targetPlan,
+  currentPlan,
+  onConfirm,
+  onCancel,
+  pending = false,
+}: Props): ReactElement {
+  const lost = featuresLost(currentPlan, targetPlan);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType='fade'
+      onRequestClose={onCancel}
+    >
+      <View style={s.overlay}>
+        <View style={s.sheet}>
+          <Text style={s.title}>Downgrade to {targetPlan.display_name}?</Text>
+
+          {lost.length > 0 ? (
+            <>
+              <Text style={s.warningLabel}>You will lose access to:</Text>
+              <ScrollView style={s.list} showsVerticalScrollIndicator={false}>
+                {lost.map(item => (
+                  <View key={item} style={s.listRow}>
+                    <Text style={s.bullet}>•</Text>
+                    <Text style={s.listItem}>{item}</Text>
+                  </View>
+                ))}
+              </ScrollView>
+            </>
+          ) : (
+            <Text style={s.body}>
+              This will change your plan to{' '}
+              <Text style={s.bold}>{targetPlan.display_name}</Text> at the end
+              of the current billing period.
+            </Text>
+          )}
+
+          <View style={s.actions}>
+            <Pressable
+              onPress={onCancel}
+              style={[s.btn, s.cancelBtn]}
+              disabled={pending}
+            >
+              <Text style={s.cancelText}>Keep current plan</Text>
+            </Pressable>
+            <Pressable
+              onPress={onConfirm}
+              style={[s.btn, s.confirmBtn]}
+              disabled={pending}
+            >
+              {pending ? (
+                <ActivityIndicator color='#fff' size='small' />
+              ) : (
+                <Text style={s.confirmText}>Confirm downgrade</Text>
+              )}
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const s = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    backgroundColor: '#fff',
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    padding: 24,
+    maxHeight: '75%',
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 16,
+  },
+  warningLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#92400e',
+    marginBottom: 8,
+  },
+  list: { maxHeight: 200, marginBottom: 16 },
+  listRow: {
+    flexDirection: 'row',
+    gap: 6,
+    marginBottom: 6,
+  },
+  bullet: { color: '#d97706', fontWeight: '700' },
+  listItem: { fontSize: 14, color: '#374151', flex: 1 },
+  body: { fontSize: 14, color: '#374151', lineHeight: 20, marginBottom: 16 },
+  bold: { fontWeight: '600' },
+  actions: { gap: 10, marginTop: 8 },
+  btn: {
+    paddingVertical: 14,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  cancelBtn: {
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+  },
+  confirmBtn: {
+    backgroundColor: '#dc2626',
+  },
+  cancelText: { fontSize: 15, color: '#374151', fontWeight: '600' },
+  confirmText: { fontSize: 15, color: '#fff', fontWeight: '600' },
+});

--- a/packages/billing/src/components/ConfirmDowngradeModal.native.tsx
+++ b/packages/billing/src/components/ConfirmDowngradeModal.native.tsx
@@ -32,7 +32,7 @@ function featuresLost(current: Plan | null, target: Plan): string[] {
       typeof targetValue === 'number' &&
       targetValue < value
     ) {
-      lost.push(`${key.replace(/_/g, ' ')} (${targetValue} → ${value} limit)`);
+      lost.push(`${key.replace(/_/g, ' ')} (${value} → ${targetValue} limit)`);
     }
     if (typeof value === 'number' && targetValue === undefined) {
       lost.push(key.replace(/_/g, ' '));

--- a/packages/billing/src/components/InvoiceList.native.tsx
+++ b/packages/billing/src/components/InvoiceList.native.tsx
@@ -1,0 +1,175 @@
+import * as WebBrowser from 'expo-web-browser';
+import type { ReactElement } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import type { BillingError } from '../errors.js';
+import type { BillingInvoiceRow } from '../types.js';
+
+type Props = {
+  items: BillingInvoiceRow[];
+  loading: boolean;
+  error: BillingError | null;
+  hasMore: boolean;
+  loadMore: () => void;
+  refresh: () => void;
+};
+
+function fmt(cents: number, currency: string): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: currency.toUpperCase(),
+  }).format(cents / 100);
+}
+
+function fmtDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function statusColor(status: string): string {
+  if (status === 'paid') return '#15803d';
+  if (status === 'open') return '#d97706';
+  return '#6b7280';
+}
+
+function InvoiceRow({ item }: { item: BillingInvoiceRow }): ReactElement {
+  const url = item.hosted_invoice_url ?? item.invoice_pdf_url;
+  const date = item.finalized_at ?? item.created_at;
+  const label = fmtDate(date);
+
+  return (
+    <View style={s.row}>
+      <View style={s.rowLeft}>
+        <Text style={s.date}>{label}</Text>
+        <Text style={[s.status, { color: statusColor(item.status) }]}>
+          {item.status.charAt(0).toUpperCase() + item.status.slice(1)}
+        </Text>
+      </View>
+      <View style={s.rowRight}>
+        <Text style={s.amount}>{fmt(item.amount_due, item.currency)}</Text>
+        {url ? (
+          <Pressable
+            onPress={() => void WebBrowser.openBrowserAsync(url)}
+            accessibilityLabel={`View invoice from ${label} — opens in browser`}
+            accessibilityRole='button'
+          >
+            <Text style={s.viewLink}>View</Text>
+          </Pressable>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+export function InvoiceList({
+  items,
+  loading,
+  error,
+  hasMore,
+  loadMore,
+  refresh,
+}: Props): ReactElement {
+  if (loading && items.length === 0) {
+    return (
+      <View style={s.centered}>
+        <ActivityIndicator color='#4f46e5' />
+      </View>
+    );
+  }
+
+  if (error && items.length === 0) {
+    return (
+      <View style={s.centered}>
+        <Text style={s.errorText}>{error.message}</Text>
+        <Pressable onPress={refresh} style={s.retryBtn}>
+          <Text style={s.retryText}>Retry</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <View style={s.centered}>
+        <Text style={s.emptyTitle}>No invoices yet</Text>
+        <Text style={s.emptyBody}>
+          Invoices appear here once you subscribe to a paid plan.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      data={items}
+      keyExtractor={item => item.id}
+      renderItem={({ item }) => <InvoiceRow item={item} />}
+      ItemSeparatorComponent={() => <View style={s.separator} />}
+      onEndReached={hasMore ? loadMore : undefined}
+      onEndReachedThreshold={0.3}
+      onRefresh={refresh}
+      refreshing={loading}
+    />
+  );
+}
+
+const s = StyleSheet.create({
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+  },
+  rowLeft: { gap: 2 },
+  rowRight: { alignItems: 'flex-end', gap: 4 },
+  date: { fontSize: 14, fontWeight: '500', color: '#111827' },
+  status: { fontSize: 12 },
+  amount: { fontSize: 15, fontWeight: '600', color: '#111827' },
+  viewLink: { fontSize: 13, color: '#4f46e5' },
+  separator: {
+    height: 1,
+    backgroundColor: '#f3f4f6',
+    marginHorizontal: 16,
+  },
+  errorText: {
+    color: '#b91c1c',
+    marginBottom: 12,
+    textAlign: 'center',
+  },
+  retryBtn: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#4f46e5',
+  },
+  retryText: { color: '#4f46e5', fontWeight: '600' },
+  emptyTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#374151',
+    marginBottom: 8,
+  },
+  emptyBody: {
+    fontSize: 14,
+    color: '#6b7280',
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+});

--- a/packages/billing/src/components/PricingTable.native.tsx
+++ b/packages/billing/src/components/PricingTable.native.tsx
@@ -12,12 +12,18 @@ export function PricingTable<P extends ProductBillingConfig>({
   highlightPlanId,
   productId: _productId,
   currentUserId: _currentUserId,
+  cadence,
   style,
 }: PricingTableProps): ReactElement {
   void _productId;
   void _currentUserId;
   const onPlanChosen = onCheckout ?? onSelectPlan;
-  const { plans, loading } = usePlanCatalog<P>();
+  const { plans: allPlans, loading } = usePlanCatalog<P>();
+  const plans = cadence
+    ? allPlans.filter(
+        p => p.price_cents === 0 || p.billing_period === cadence
+      )
+    : allPlans;
   const { data: currentPlan } = usePlan<P>();
 
   if (loading) {

--- a/packages/billing/src/components/PricingTable.types.ts
+++ b/packages/billing/src/components/PricingTable.types.ts
@@ -19,6 +19,11 @@ export type PricingTableProps = {
   productId?: string;
   /** Core spec surface; reserved for future use (e.g. admin viewing another user). */
   currentUserId?: string | null;
+  /**
+   * When set, only plans with a matching `billing_period` (or free plans with
+   * `price_cents === 0`) are shown. Omit to show all plans.
+   */
+  cadence?: 'monthly' | 'annual';
   className?: string;
   style?: object;
 };

--- a/packages/billing/src/components/PricingTable.web.tsx
+++ b/packages/billing/src/components/PricingTable.web.tsx
@@ -12,13 +12,19 @@ export function PricingTable<P extends ProductBillingConfig>({
   isAuthenticated = true,
   productId: _productId,
   currentUserId: _currentUserId,
+  cadence,
   className,
   style,
 }: PricingTableProps): ReactElement {
   void _productId;
   void _currentUserId;
   const onPlanChosen = onCheckout ?? onSelectPlan;
-  const { plans, loading } = usePlanCatalog<P>();
+  const { plans: allPlans, loading } = usePlanCatalog<P>();
+  const plans = cadence
+    ? allPlans.filter(
+        p => p.price_cents === 0 || p.billing_period === cadence
+      )
+    : allPlans;
   const { data: currentPlan } = usePlan<P>();
 
   return (

--- a/packages/billing/src/native.ts
+++ b/packages/billing/src/native.ts
@@ -1,9 +1,11 @@
 /** React Native entry — import from `@beakerstack/billing/native` in Expo apps. */
+export { ConfirmDowngradeModal } from './components/ConfirmDowngradeModal.native.js';
+export { CustomerPortalLink } from './components/CustomerPortalLink.native.js';
 export { FeatureGate } from './components/FeatureGate.native.js';
-export { UsageIndicator } from './components/UsageIndicator.native.js';
-export { UpgradePrompt } from './components/UpgradePrompt.native.js';
+export { InvoiceList } from './components/InvoiceList.native.js';
 export { PricingTable } from './components/PricingTable.native.js';
 export { SubscriptionStatus } from './components/SubscriptionStatus.native.js';
-export { CustomerPortalLink } from './components/CustomerPortalLink.native.js';
 export { SubscriptionStatusBadge } from './components/SubscriptionStatusBadge.native.js';
 export type { SubscriptionStatusBadgeProps } from './components/SubscriptionStatusBadge.native.js';
+export { UpgradePrompt } from './components/UpgradePrompt.native.js';
+export { UsageIndicator } from './components/UsageIndicator.native.js';


### PR DESCRIPTION
## Summary

Implements the three-screen mobile billing flow from issue #113, nested as a `createMaterialTopTabNavigator` pushed from the Profile tab.

- **BillingNavigator** — top-tab navigator (Overview · Plans · Invoices) wrapped in `BillingProvider`
- **BillingOverviewScreen** — current plan badge (`SubscriptionStatusBadge`), downgrade warning, usage indicator, customer portal link
- **BillingPlansScreen** — cadence toggle (monthly/annual), `PricingTable`, `ConfirmDowngradeModal`, `AppState` listener to refresh sub after Stripe checkout
- **BillingInvoicesScreen** — thin wrapper over `useInvoices` + `InvoiceList`
- **`ConfirmDowngradeModal`** (new native component) — bottom-sheet modal; computes lost features via `featuresLost()` helper comparing `plan.features` dicts
- **`InvoiceList`** (new native component) — `FlatList` with skeleton/error/empty states and `WebBrowser.openBrowserAsync` for invoice links
- **ProfileScreen** — added "Billing & subscription" button navigating to the Billing stack screen
- **`packages/billing/src/native.ts`** — added `ConfirmDowngradeModal` and `InvoiceList` exports

## Nav tree

```
NativeStackNavigator (AppNavigator)
  └── Billing (BillingScreen)
        └── BillingNavigator (createMaterialTopTabNavigator)
              ├── Overview (BillingOverviewScreen)
              ├── Plans   (BillingPlansScreen)
              └── Invoices (BillingInvoicesScreen)
```

Entry point: `navigation.navigate(Billing)` from ProfileScreen.

The `useFocusEffect` tab-bar hide in `BillingScreen` is a safe no-op until #116 adds the bottom tab navigator — `getParent()` returns null on the current flat stack.

## Dependencies

- Depends on **#116** (tab navigator) for the tab-bar hide to take effect
- Packages added to `apps/mobile/package.json`: `@react-navigation/material-top-tabs@^6.6.14`, `expo-web-browser@~12.8.2`, `react-native-pager-view@6.2.3`, `react-native-tab-view@^3.5.2` — run `npx expo install` to resolve to exact SDK 50 versions
- TS errors for `expo-web-browser` and `@react-navigation/material-top-tabs` are non-blocking (modules not in node_modules until install runs in CI)
- `ThemeColors.surface` (Diegos #133): billing screens use inline `StyleSheet.create` with hardcoded colors; ThemeColors adoption is a follow-up

## Test plan

- [ ] Navigate from Profile → "Billing & subscription" → lands on Overview tab
- [ ] Plans tab: cadence toggle switches monthly/annual prices; selecting an upgrade opens Stripe checkout in-browser; returning to app refreshes subscription
- [ ] Plans tab: selecting a downgrade shows `ConfirmDowngradeModal` with features-lost list; confirming calls `scheduleCancelToFree` (free) or `updateSubscription` (paid downgrade)
- [ ] Invoices tab: lists invoices with date, status, amount; "View" opens hosted URL in browser; pull-to-refresh works; pagination loads more
- [ ] Empty/error states render correctly in all three tabs
- [ ] Tab bar hidden while Billing screen is focused (after #116 merges)
- [ ] `npx expo install` resolves all 4 new packages without version conflicts

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)