### PR TITLE
feat(shared): ErrorBoundary, FallbackUI, crash reporter (#127)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Error reporting adapter (optional). Set to 'sentry' to enable Sentry (requires #117).
+EXPO_PUBLIC_ERROR_REPORTER=
+VITE_ERROR_REPORTER=

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -7,8 +7,11 @@ import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
 // Import from native-specific file for correct types
 import { configureGoogleSignIn } from '@beakerstack/shared/hooks/useAuth.native';
 import { Logger } from '@beakerstack/shared/utils/logger';
+import { ErrorBoundary, reporter, ConsoleAdapter } from '@beakerstack/shared';
 import { supabase } from './src/lib/supabase';
 import { AppNavigator } from './src/navigation/AppNavigator';
+
+reporter.init(new ConsoleAdapter());
 
 export default function App() {
   useEffect(() => {
@@ -103,11 +106,13 @@ export default function App() {
   }, []);
 
   return (
-    <AuthProvider supabaseClient={supabase}>
-      <ProfileProvider supabaseClient={supabase}>
-        <AppNavigator />
-        <StatusBar style='auto' />
-      </ProfileProvider>
-    </AuthProvider>
+    <ErrorBoundary level='root'>
+      <AuthProvider supabaseClient={supabase}>
+        <ProfileProvider supabaseClient={supabase}>
+          <AppNavigator />
+          <StatusBar style='auto' />
+        </ProfileProvider>
+      </AuthProvider>
+    </ErrorBoundary>
   );
 }

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -4,6 +4,7 @@ import {
   type NavigationContainerRef,
 } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { ErrorBoundary } from '@beakerstack/shared';
 import HomeScreen from '../screens/HomeScreen';
 import LoginScreen from '../screens/LoginScreen';
 import SignupScreen from '../screens/SignupScreen';
@@ -22,6 +23,16 @@ type RootStackParamList = {
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
+
+function withScreenBoundary(Component: React.ComponentType<any>) {
+  return function BoundedScreen(props: any) {
+    return (
+      <ErrorBoundary level="screen">
+        <Component {...props} />
+      </ErrorBoundary>
+    );
+  };
+}
 
 export const AppNavigator = () => {
   const navigationRef =
@@ -48,16 +59,16 @@ export const AppNavigator = () => {
       >
         <Stack.Screen
           name='Home'
-          component={HomeScreen}
+          component={withScreenBoundary(HomeScreen)}
           options={{ headerShown: false }} // Home always uses custom header
         />
-        <Stack.Screen name='Login' component={LoginScreen} />
-        <Stack.Screen name='Signup' component={SignupScreen} />
-        <Stack.Screen name='Dashboard' component={DashboardScreen} />
-        <Stack.Screen name='Profile' component={ProfileScreen} />
+        <Stack.Screen name='Login' component={withScreenBoundary(LoginScreen)} />
+        <Stack.Screen name='Signup' component={withScreenBoundary(SignupScreen)} />
+        <Stack.Screen name='Dashboard' component={withScreenBoundary(DashboardScreen)} />
+        <Stack.Screen name='Profile' component={withScreenBoundary(ProfileScreen)} />
         <Stack.Screen
           name='Billing'
-          component={BillingScreen}
+          component={withScreenBoundary(BillingScreen)}
           options={{ title: 'Billing' }}
         />
       </Stack.Navigator>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Outlet } from 'react-router-dom';
 import { ProtectedRoute } from '@beakerstack/shared/components/auth/ProtectedRoute.web';
 import { BillingProviderLayout } from './billing/BillingProviderLayout';
 import { AppFooter } from './components/AppFooter';
+import { ErrorBoundary } from '@beakerstack/shared';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
 import DashboardPage from './pages/DashboardPage';
@@ -35,21 +36,25 @@ function App() {
           <Route
             path='/'
             element={
-              <Suspense fallback={null}>
-                <HomePage />
-              </Suspense>
+              <ErrorBoundary level='screen'>
+                <Suspense fallback={null}>
+                  <HomePage />
+                </Suspense>
+              </ErrorBoundary>
             }
           />
-          <Route path='/login' element={<LoginPage />} />
-          <Route path='/signup' element={<SignupPage />} />
-          <Route path='/terms' element={<PolicyPage policy='terms' />} />
-          <Route path='/privacy' element={<PolicyPage policy='privacy' />} />
-          <Route path='/refunds' element={<PolicyPage policy='refunds' />} />
+          <Route path='/login' element={<ErrorBoundary level='screen'><LoginPage /></ErrorBoundary>} />
+          <Route path='/signup' element={<ErrorBoundary level='screen'><SignupPage /></ErrorBoundary>} />
+          <Route path='/terms' element={<ErrorBoundary level='screen'><PolicyPage policy='terms' /></ErrorBoundary>} />
+          <Route path='/privacy' element={<ErrorBoundary level='screen'><PolicyPage policy='privacy' /></ErrorBoundary>} />
+          <Route path='/refunds' element={<ErrorBoundary level='screen'><PolicyPage policy='refunds' /></ErrorBoundary>} />
           <Route
             path='/profile'
             element={
               <ProtectedRoute>
-                <ProfilePage />
+                <ErrorBoundary level='screen'>
+                  <ProfilePage />
+                </ErrorBoundary>
               </ProtectedRoute>
             }
           />
@@ -61,17 +66,17 @@ function App() {
             }
           >
             <Route element={<BillingProviderLayout />}>
-              <Route path='/dashboard' element={<DashboardPage />} />
-              <Route path='/billing' element={<BillingOverviewPage />} />
-              <Route path='/billing/usage' element={<BillingUsagePage />} />
-              <Route path='/billing/plans' element={<BillingPlansPage />} />
+              <Route path='/dashboard' element={<ErrorBoundary level='screen'><DashboardPage /></ErrorBoundary>} />
+              <Route path='/billing' element={<ErrorBoundary level='screen'><BillingOverviewPage /></ErrorBoundary>} />
+              <Route path='/billing/usage' element={<ErrorBoundary level='screen'><BillingUsagePage /></ErrorBoundary>} />
+              <Route path='/billing/plans' element={<ErrorBoundary level='screen'><BillingPlansPage /></ErrorBoundary>} />
               <Route
                 path='/billing/invoices'
-                element={<BillingInvoicesPage />}
+                element={<ErrorBoundary level='screen'><BillingInvoicesPage /></ErrorBoundary>}
               />
             </Route>
           </Route>
-          <Route path='/auth/callback' element={<AuthCallbackPage />} />
+          <Route path='/auth/callback' element={<ErrorBoundary level='screen'><AuthCallbackPage /></ErrorBoundary>} />
         </Route>
       </Routes>
     </div>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { ErrorBoundary } from '@beakerstack/shared';
 import { supabase } from './lib/supabase';
 import App from './App';
 import './index.css';
@@ -19,14 +20,16 @@ const basePath = import.meta.env.VITE_BASE_PATH || '/';
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <ThemeProvider>
-      <AuthProvider supabaseClient={supabase}>
-        <ProfileProvider supabaseClient={supabase}>
-          <BrowserRouter basename={basePath}>
-            <App />
-          </BrowserRouter>
-        </ProfileProvider>
-      </AuthProvider>
-    </ThemeProvider>
+    <ErrorBoundary level='root'>
+      <ThemeProvider>
+        <AuthProvider supabaseClient={supabase}>
+          <ProfileProvider supabaseClient={supabase}>
+            <BrowserRouter basename={basePath}>
+              <App />
+            </BrowserRouter>
+          </ProfileProvider>
+        </AuthProvider>
+      </ThemeProvider>
+    </ErrorBoundary>
   </React.StrictMode>
 );

--- a/packages/shared/src/error/ErrorBoundary.tsx
+++ b/packages/shared/src/error/ErrorBoundary.tsx
@@ -25,7 +25,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+  override componentDidCatch(error: Error, info: React.ErrorInfo): void {
     reporter.captureException(error, { componentStack: info.componentStack });
     this.props.onError?.(error, info);
   }
@@ -34,7 +34,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
     this.setState({ hasError: false, error: null });
   }
 
-  render(): React.ReactNode {
+  override render(): React.ReactNode {
     if (this.state.hasError) {
       const { fallback, level } = this.props;
       if (fallback !== undefined) {

--- a/packages/shared/src/error/ErrorBoundary.tsx
+++ b/packages/shared/src/error/ErrorBoundary.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { reporter } from './reporter';
+import { FallbackUI } from './FallbackUI';
+
+interface Props {
+  fallback?: React.ReactNode | ((error: Error, reset: () => void) => React.ReactNode);
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+  level?: 'screen' | 'root';
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+    this.reset = this.reset.bind(this);
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    reporter.captureException(error, { componentStack: info.componentStack });
+    this.props.onError?.(error, info);
+  }
+
+  reset(): void {
+    this.setState({ hasError: false, error: null });
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      const { fallback, level } = this.props;
+      if (fallback !== undefined) {
+        if (typeof fallback === 'function') {
+          return fallback(this.state.error!, this.reset);
+        }
+        return fallback;
+      }
+      return (
+        <FallbackUI
+          level={level ?? 'screen'}
+          error={this.state.error!}
+          reset={this.reset}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/packages/shared/src/error/FallbackUI.native.tsx
+++ b/packages/shared/src/error/FallbackUI.native.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 

--- a/packages/shared/src/error/FallbackUI.native.tsx
+++ b/packages/shared/src/error/FallbackUI.native.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+
+interface Props {
+  error: Error;
+  reset: () => void;
+  level?: 'screen' | 'root';
+}
+
+function ScreenFallback({ error, reset }: { error: Error; reset: () => void }) {
+  const navigation = useNavigation();
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Something went wrong</Text>
+      <Text style={styles.message}>{error.message}</Text>
+      <TouchableOpacity style={styles.button} onPress={reset}>
+        <Text style={styles.buttonText}>Try again</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={[styles.button, styles.secondaryButton]} onPress={() => navigation.goBack()}>
+        <Text style={[styles.buttonText, styles.secondaryButtonText]}>Go back</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+export function FallbackUI({ error, reset, level = 'screen' }: Props) {
+  if (level === 'root') {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Something went wrong</Text>
+        <Text style={styles.message}>{error.message}</Text>
+        <TouchableOpacity style={styles.button} onPress={reset}>
+          <Text style={styles.buttonText}>Try again</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+  return <ScreenFallback error={error} reset={reset} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#f9fafb',
+    padding: 24,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 8,
+  },
+  message: {
+    fontSize: 14,
+    color: '#dc2626',
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  button: {
+    backgroundColor: '#111827',
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+    borderRadius: 8,
+    marginBottom: 12,
+    minWidth: 160,
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  secondaryButton: {
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#111827',
+  },
+  secondaryButtonText: {
+    color: '#111827',
+  },
+});

--- a/packages/shared/src/error/FallbackUI.tsx
+++ b/packages/shared/src/error/FallbackUI.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+
+interface Props {
+  error: Error;
+  reset: () => void;
+  level?: 'screen' | 'root';
+}
+
+function ScreenFallback({ error, reset }: { error: Error; reset: () => void }) {
+  const navigation = useNavigation();
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Something went wrong</Text>
+      <Text style={styles.message}>{error.message}</Text>
+      <TouchableOpacity style={styles.button} onPress={reset}>
+        <Text style={styles.buttonText}>Try again</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={[styles.button, styles.secondaryButton]} onPress={() => navigation.goBack()}>
+        <Text style={[styles.buttonText, styles.secondaryButtonText]}>Go back</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+export function FallbackUI({ error, reset, level = 'screen' }: Props) {
+  if (level === 'root') {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Something went wrong</Text>
+        <Text style={styles.message}>{error.message}</Text>
+        <TouchableOpacity style={styles.button} onPress={reset}>
+          <Text style={styles.buttonText}>Try again</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+  return <ScreenFallback error={error} reset={reset} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#f9fafb',
+    padding: 24,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 8,
+  },
+  message: {
+    fontSize: 14,
+    color: '#dc2626',
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  button: {
+    backgroundColor: '#111827',
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+    borderRadius: 8,
+    marginBottom: 12,
+    minWidth: 160,
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  secondaryButton: {
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#111827',
+  },
+  secondaryButtonText: {
+    color: '#111827',
+  },
+});

--- a/packages/shared/src/error/FallbackUI.tsx
+++ b/packages/shared/src/error/FallbackUI.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
 
 interface Props {
   error: Error;
@@ -8,77 +6,26 @@ interface Props {
   level?: 'screen' | 'root';
 }
 
-function ScreenFallback({ error, reset }: { error: Error; reset: () => void }) {
-  const navigation = useNavigation();
+export function FallbackUI({ error, reset, level = 'screen' }: Props) {
+  const isRoot = level === 'root';
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Something went wrong</Text>
-      <Text style={styles.message}>{error.message}</Text>
-      <TouchableOpacity style={styles.button} onPress={reset}>
-        <Text style={styles.buttonText}>Try again</Text>
-      </TouchableOpacity>
-      <TouchableOpacity style={[styles.button, styles.secondaryButton]} onPress={() => navigation.goBack()}>
-        <Text style={[styles.buttonText, styles.secondaryButtonText]}>Go back</Text>
-      </TouchableOpacity>
-    </View>
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', ...(isRoot ? { minHeight: '100vh' } : { padding: 24 }), padding: 24, backgroundColor: '#f9fafb' }}>
+      <h2 style={{ fontSize: 20, fontWeight: 700, color: '#111827', marginBottom: 8, margin: '0 0 8px' }}>Something went wrong</h2>
+      <p style={{ fontSize: 14, color: '#dc2626', textAlign: 'center', marginBottom: 24, margin: '0 0 24px' }}>{error.message}</p>
+      <button
+        onClick={reset}
+        style={{ backgroundColor: '#111827', color: '#fff', border: 'none', padding: '12px 32px', borderRadius: 8, fontSize: 16, fontWeight: 600, cursor: 'pointer', minWidth: 160, marginBottom: 12 }}
+      >
+        Try again
+      </button>
+      {!isRoot && (
+        <button
+          onClick={() => window.history.back()}
+          style={{ backgroundColor: '#fff', color: '#111827', border: '1px solid #111827', padding: '12px 32px', borderRadius: 8, fontSize: 16, fontWeight: 600, cursor: 'pointer', minWidth: 160 }}
+        >
+          Go back
+        </button>
+      )}
+    </div>
   );
 }
-
-export function FallbackUI({ error, reset, level = 'screen' }: Props) {
-  if (level === 'root') {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.title}>Something went wrong</Text>
-        <Text style={styles.message}>{error.message}</Text>
-        <TouchableOpacity style={styles.button} onPress={reset}>
-          <Text style={styles.buttonText}>Try again</Text>
-        </TouchableOpacity>
-      </View>
-    );
-  }
-  return <ScreenFallback error={error} reset={reset} />;
-}
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#f9fafb',
-    padding: 24,
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: '700',
-    color: '#111827',
-    marginBottom: 8,
-  },
-  message: {
-    fontSize: 14,
-    color: '#dc2626',
-    textAlign: 'center',
-    marginBottom: 24,
-  },
-  button: {
-    backgroundColor: '#111827',
-    paddingVertical: 12,
-    paddingHorizontal: 32,
-    borderRadius: 8,
-    marginBottom: 12,
-    minWidth: 160,
-    alignItems: 'center',
-  },
-  buttonText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  secondaryButton: {
-    backgroundColor: '#fff',
-    borderWidth: 1,
-    borderColor: '#111827',
-  },
-  secondaryButtonText: {
-    color: '#111827',
-  },
-});

--- a/packages/shared/src/error/FallbackUI.tsx
+++ b/packages/shared/src/error/FallbackUI.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 interface Props {
   error: Error;
   reset: () => void;

--- a/packages/shared/src/error/FallbackUI.web.tsx
+++ b/packages/shared/src/error/FallbackUI.web.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface Props {
+  error: Error;
+  reset: () => void;
+  level?: 'screen' | 'root';
+}
+
+const containerBase: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 24,
+  backgroundColor: '#f9fafb',
+};
+
+const titleStyle: React.CSSProperties = {
+  fontSize: 20,
+  fontWeight: 700,
+  color: '#111827',
+  margin: '0 0 8px',
+};
+
+const messageStyle: React.CSSProperties = {
+  fontSize: 14,
+  color: '#dc2626',
+  textAlign: 'center',
+  margin: '0 0 24px',
+};
+
+const primaryBtn: React.CSSProperties = {
+  backgroundColor: '#111827',
+  color: '#fff',
+  border: 'none',
+  padding: '12px 32px',
+  borderRadius: 8,
+  fontSize: 16,
+  fontWeight: 600,
+  cursor: 'pointer',
+  minWidth: 160,
+  marginBottom: 12,
+};
+
+const secondaryBtn: React.CSSProperties = {
+  backgroundColor: '#fff',
+  color: '#111827',
+  border: '1px solid #111827',
+  padding: '12px 32px',
+  borderRadius: 8,
+  fontSize: 16,
+  fontWeight: 600,
+  cursor: 'pointer',
+  minWidth: 160,
+};
+
+function ScreenFallbackWeb({ error, reset }: { error: Error; reset: () => void }) {
+  const navigate = useNavigate();
+  return (
+    <div style={containerBase}>
+      <h2 style={titleStyle}>Something went wrong</h2>
+      <p style={messageStyle}>{error.message}</p>
+      <button onClick={reset} style={primaryBtn}>Try again</button>
+      <button onClick={() => navigate(-1)} style={secondaryBtn}>Go back</button>
+    </div>
+  );
+}
+
+export function FallbackUI({ error, reset, level = 'screen' }: Props) {
+  if (level === 'root') {
+    return (
+      <div style={{ ...containerBase, minHeight: '100vh' }}>
+        <h2 style={titleStyle}>Something went wrong</h2>
+        <p style={messageStyle}>{error.message}</p>
+        <button onClick={reset} style={primaryBtn}>Try again</button>
+      </div>
+    );
+  }
+  return <ScreenFallbackWeb error={error} reset={reset} />;
+}

--- a/packages/shared/src/error/adapters/ConsoleAdapter.ts
+++ b/packages/shared/src/error/adapters/ConsoleAdapter.ts
@@ -1,0 +1,8 @@
+import type { ErrorReporter } from '../reporter';
+
+export class ConsoleAdapter implements ErrorReporter {
+  captureException(error: Error, context?: Record<string, unknown>): void {
+    // console.warn avoids triggering React Native's red screen overlay
+    console.warn('[ErrorReporter]', new Date().toISOString(), error, context);
+  }
+}

--- a/packages/shared/src/error/adapters/index.ts
+++ b/packages/shared/src/error/adapters/index.ts
@@ -1,0 +1,2 @@
+export type { ErrorReporter } from '../reporter';
+export { ConsoleAdapter } from './ConsoleAdapter';

--- a/packages/shared/src/error/index.ts
+++ b/packages/shared/src/error/index.ts
@@ -1,0 +1,5 @@
+export { ErrorBoundary } from './ErrorBoundary';
+export { FallbackUI } from './FallbackUI';
+export { reporter } from './reporter';
+export type { ErrorReporter } from './reporter';
+export * from './adapters';

--- a/packages/shared/src/error/reporter.ts
+++ b/packages/shared/src/error/reporter.ts
@@ -1,0 +1,14 @@
+export interface ErrorReporter {
+  captureException(error: Error, context?: Record<string, unknown>): void;
+}
+
+let _adapter: ErrorReporter | null = null;
+
+export const reporter = {
+  init(adapter: ErrorReporter): void {
+    _adapter = adapter;
+  },
+  captureException(error: Error, context?: Record<string, unknown>): void {
+    _adapter?.captureException(error, context);
+  },
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -43,3 +43,6 @@ export * from './validation/profileSchema';
 // Exporting both would cause conflicts, so let the bundlers handle platform resolution
 
 export * from './utils/logger';
+
+// Error boundary and crash reporting
+export * from './error';


### PR DESCRIPTION
## Summary

- Implements issue #127: error boundary and crash reporting infrastructure for the shared package
- Adds `ErrorBoundary` class component (required — function components cannot be error boundaries) with configurable `fallback`, `onError`, and `level` props
- Adds `FallbackUI` with `screen`/`root` level variants — root level never calls `useNavigation()` (no NavigationContainer context), screen level uses an inner `ScreenFallback` component to safely call the hook
- Adds `reporter` singleton: `init(adapter)` + `captureException()` — safe no-op if `init` was never called
- Adds `ConsoleAdapter` using `console.warn` (not `console.error`) to avoid triggering React Native's red screen overlay
- Wires `ErrorBoundary level="root"` at the app root in both mobile (`App.tsx`) and web (`main.tsx`)
- Wraps all navigation screens with `ErrorBoundary level="screen"` via `withScreenBoundary` HOC in `AppNavigator.tsx`
- Wraps all route elements with `ErrorBoundary level="screen"` in web `App.tsx`
- Exports everything from `@beakerstack/shared` index
- Adds `EXPO_PUBLIC_ERROR_REPORTER` / `VITE_ERROR_REPORTER` env vars to `.env.example` (Sentry integration deferred to #117)

## Test plan

- [ ] Trigger a crash in a screen component; verify `FallbackUI` renders with "Try again" and "Go back" buttons
- [ ] "Try again" resets the error boundary and re-renders the screen
- [ ] "Go back" calls `navigation.goBack()` correctly
- [ ] Trigger a crash at root level (e.g. in `AuthProvider`); verify root `FallbackUI` renders with only "Try again" (no "Go back", no `useNavigation` call)
- [ ] Verify `reporter.captureException` is a no-op before `init()` is called (no crash)
- [ ] `ConsoleAdapter` logs to `console.warn` with timestamp, error, and context
- [ ] TypeScript compiles without errors in both `apps/mobile` and `apps/web`
- [ ] Web app: crash in a route element shows `FallbackUI` without crashing the whole app

🤖 Generated with [Claude Code](https://claude.com/claude-code)