### PR TITLE
feat: onboarding carousel, empty states, and onboarding_steps migration (#126)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Feature flags
+EXPO_PUBLIC_ONBOARDING_ENABLED=true

--- a/apps/mobile/src/components/EmptyState/EmptyState.tsx
+++ b/apps/mobile/src/components/EmptyState/EmptyState.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Image, ImageSourcePropType, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+interface Props {
+  title: string;
+  description: string;
+  illustration?: ImageSourcePropType;
+  action?: { label: string; onPress: () => void; accessibilityLabel?: string };
+}
+
+export function EmptyState({ title, description, illustration, action }: Props) {
+  return (
+    <View style={styles.container}>
+      {illustration && (
+        <Image
+          source={illustration}
+          style={styles.illustration}
+          accessibilityRole="none"
+          accessible={false}
+        />
+      )}
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.description}>{description}</Text>
+      {action && (
+        <TouchableOpacity
+          style={styles.button}
+          onPress={action.onPress}
+          accessibilityLabel={action.accessibilityLabel ?? action.label}
+          accessibilityRole="button"
+        >
+          <Text style={styles.buttonText}>{action.label}</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+  },
+  illustration: { width: 120, height: 120, marginBottom: 24 },
+  title: { fontSize: 20, fontWeight: '700', color: '#111827', marginBottom: 8, textAlign: 'center' },
+  description: { fontSize: 15, color: '#6b7280', textAlign: 'center', lineHeight: 22, marginBottom: 24 },
+  button: {
+    backgroundColor: '#111827',
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+    borderRadius: 8,
+    minWidth: 180,
+    alignItems: 'center',
+  },
+  buttonText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+});

--- a/apps/mobile/src/components/EmptyState/index.ts
+++ b/apps/mobile/src/components/EmptyState/index.ts
@@ -1,0 +1,1 @@
+export { EmptyState } from './EmptyState';

--- a/apps/mobile/src/hooks/useOnboardingGate.ts
+++ b/apps/mobile/src/hooks/useOnboardingGate.ts
@@ -29,7 +29,7 @@ export function useOnboardingGate(userId: string | null): OnboardingGateResult {
       .eq('user_id', userId)
       .eq('step_key', 'carousel_completed')
       .maybeSingle()
-      .then(({ data }) => {
+      .then(({ data, error }) => {
         setShowOnboarding(!error && !data);
         setLoading(false);
       });

--- a/apps/mobile/src/hooks/useOnboardingGate.ts
+++ b/apps/mobile/src/hooks/useOnboardingGate.ts
@@ -30,7 +30,7 @@ export function useOnboardingGate(userId: string | null): OnboardingGateResult {
       .eq('step_key', 'carousel_completed')
       .maybeSingle()
       .then(({ data }) => {
-        setShowOnboarding(!data);
+        setShowOnboarding(!error && !data);
         setLoading(false);
       });
   }, [userId]);

--- a/apps/mobile/src/hooks/useOnboardingGate.ts
+++ b/apps/mobile/src/hooks/useOnboardingGate.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+
+interface OnboardingGateResult {
+  showOnboarding: boolean;
+  loading: boolean;
+  markComplete: () => Promise<void>;
+}
+
+export function useOnboardingGate(userId: string | null): OnboardingGateResult {
+  const [showOnboarding, setShowOnboarding] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!userId) {
+      setLoading(false);
+      return;
+    }
+
+    const enabled = process.env.EXPO_PUBLIC_ONBOARDING_ENABLED !== 'false';
+    if (!enabled) {
+      setLoading(false);
+      return;
+    }
+
+    supabase
+      .from('onboarding_steps')
+      .select('step_key')
+      .eq('user_id', userId)
+      .eq('step_key', 'carousel_completed')
+      .maybeSingle()
+      .then(({ data }) => {
+        setShowOnboarding(!data);
+        setLoading(false);
+      });
+  }, [userId]);
+
+  const markComplete = async () => {
+    if (!userId) return;
+    await supabase.from('onboarding_steps').upsert(
+      { user_id: userId, step_key: 'carousel_completed', completed: true, completed_at: new Date().toISOString() },
+      { onConflict: 'user_id,step_key' }
+    );
+    setShowOnboarding(false);
+  };
+
+  return { showOnboarding, loading, markComplete };
+}

--- a/apps/mobile/src/hooks/useOnboardingGate.ts
+++ b/apps/mobile/src/hooks/useOnboardingGate.ts
@@ -32,6 +32,11 @@ export function useOnboardingGate(userId: string | null): OnboardingGateResult {
       .then(({ data, error }) => {
         setShowOnboarding(!error && !data);
         setLoading(false);
+      })
+      .catch(() => {
+        // Fail-open: network error → don't show carousel, clear loading
+        setShowOnboarding(false);
+        setLoading(false);
       });
   }, [userId]);
 

--- a/apps/mobile/src/hooks/useReduceMotion.ts
+++ b/apps/mobile/src/hooks/useReduceMotion.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+export function useReduceMotion(): boolean {
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotion);
+    const sub = AccessibilityInfo.addEventListener('reduceMotionChanged', setReduceMotion);
+    return () => sub.remove();
+  }, []);
+
+  return reduceMotion;
+}

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -11,6 +11,9 @@ import DashboardScreen from '../screens/DashboardScreen';
 import ProfileScreen from '../screens/ProfileScreen';
 import BillingScreen from '../screens/BillingScreen';
 import { useFeatureFlags } from '../config/featureFlags';
+import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
+import { useOnboardingGate } from '../hooks/useOnboardingGate';
+import { OnboardingScreen } from '../screens/onboarding/OnboardingScreen';
 
 type RootStackParamList = {
   Home: undefined;
@@ -23,10 +26,45 @@ type RootStackParamList = {
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
+function AuthenticatedRoot({ userId }: { userId: string }) {
+  const { showOnboarding, loading, markComplete } = useOnboardingGate(userId);
+  const { showNativeHeader } = useFeatureFlags();
+
+  if (loading) return null;
+  if (showOnboarding) return <OnboardingScreen onComplete={markComplete} />;
+
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        gestureEnabled: false, // Disable swipe-back gestures
+        animation: 'none', // Disable screen transition animations
+        headerShown: showNativeHeader, // Control native header visibility via feature flag
+        headerBackVisible: showNativeHeader, // Control back button visibility
+      }}
+    >
+      <Stack.Screen
+        name='Home'
+        component={HomeScreen}
+        options={{ headerShown: false }} // Home always uses custom header
+      />
+      <Stack.Screen name='Login' component={LoginScreen} />
+      <Stack.Screen name='Signup' component={SignupScreen} />
+      <Stack.Screen name='Dashboard' component={DashboardScreen} />
+      <Stack.Screen name='Profile' component={ProfileScreen} />
+      <Stack.Screen
+        name='Billing'
+        component={BillingScreen}
+        options={{ title: 'Billing' }}
+      />
+    </Stack.Navigator>
+  );
+}
+
 export const AppNavigator = () => {
   const navigationRef =
     React.useRef<NavigationContainerRef<RootStackParamList>>(null);
   const { showNativeHeader } = useFeatureFlags();
+  const auth = useAuthContext();
 
   // Expose navigation to global scope for debugging (dev only)
   if (__DEV__ && typeof global !== 'undefined') {
@@ -36,31 +74,37 @@ export const AppNavigator = () => {
     }, []);
   }
 
+  const userId = auth.user?.id ?? null;
+
   return (
     <NavigationContainer ref={navigationRef}>
-      <Stack.Navigator
-        screenOptions={{
-          gestureEnabled: false, // Disable swipe-back gestures
-          animation: 'none', // Disable screen transition animations
-          headerShown: showNativeHeader, // Control native header visibility via feature flag
-          headerBackVisible: showNativeHeader, // Control back button visibility
-        }}
-      >
-        <Stack.Screen
-          name='Home'
-          component={HomeScreen}
-          options={{ headerShown: false }} // Home always uses custom header
-        />
-        <Stack.Screen name='Login' component={LoginScreen} />
-        <Stack.Screen name='Signup' component={SignupScreen} />
-        <Stack.Screen name='Dashboard' component={DashboardScreen} />
-        <Stack.Screen name='Profile' component={ProfileScreen} />
-        <Stack.Screen
-          name='Billing'
-          component={BillingScreen}
-          options={{ title: 'Billing' }}
-        />
-      </Stack.Navigator>
+      {userId ? (
+        <AuthenticatedRoot userId={userId} />
+      ) : (
+        <Stack.Navigator
+          screenOptions={{
+            gestureEnabled: false,
+            animation: 'none',
+            headerShown: showNativeHeader,
+            headerBackVisible: showNativeHeader,
+          }}
+        >
+          <Stack.Screen
+            name='Home'
+            component={HomeScreen}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen name='Login' component={LoginScreen} />
+          <Stack.Screen name='Signup' component={SignupScreen} />
+          <Stack.Screen name='Dashboard' component={DashboardScreen} />
+          <Stack.Screen name='Profile' component={ProfileScreen} />
+          <Stack.Screen
+            name='Billing'
+            component={BillingScreen}
+            options={{ title: 'Billing' }}
+          />
+        </Stack.Navigator>
+      )}
     </NavigationContainer>
   );
 };

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -4,6 +4,7 @@ import {
   type NavigationContainerRef,
 } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { StyleSheet, View } from 'react-native';
 import HomeScreen from '../screens/HomeScreen';
 import LoginScreen from '../screens/LoginScreen';
 import SignupScreen from '../screens/SignupScreen';
@@ -26,45 +27,13 @@ type RootStackParamList = {
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
-function AuthenticatedRoot({ userId }: { userId: string }) {
-  const { showOnboarding, loading, markComplete } = useOnboardingGate(userId);
-  const { showNativeHeader } = useFeatureFlags();
-
-  if (loading) return null;
-  if (showOnboarding) return <OnboardingScreen onComplete={markComplete} />;
-
-  return (
-    <Stack.Navigator
-      screenOptions={{
-        gestureEnabled: false, // Disable swipe-back gestures
-        animation: 'none', // Disable screen transition animations
-        headerShown: showNativeHeader, // Control native header visibility via feature flag
-        headerBackVisible: showNativeHeader, // Control back button visibility
-      }}
-    >
-      <Stack.Screen
-        name='Home'
-        component={HomeScreen}
-        options={{ headerShown: false }} // Home always uses custom header
-      />
-      <Stack.Screen name='Login' component={LoginScreen} />
-      <Stack.Screen name='Signup' component={SignupScreen} />
-      <Stack.Screen name='Dashboard' component={DashboardScreen} />
-      <Stack.Screen name='Profile' component={ProfileScreen} />
-      <Stack.Screen
-        name='Billing'
-        component={BillingScreen}
-        options={{ title: 'Billing' }}
-      />
-    </Stack.Navigator>
-  );
-}
-
 export const AppNavigator = () => {
   const navigationRef =
     React.useRef<NavigationContainerRef<RootStackParamList>>(null);
   const { showNativeHeader } = useFeatureFlags();
   const auth = useAuthContext();
+  const userId = auth.user?.id ?? null;
+  const { showOnboarding, loading, markComplete } = useOnboardingGate(userId);
 
   // Expose navigation to global scope for debugging (dev only)
   if (__DEV__ && typeof global !== 'undefined') {
@@ -74,36 +43,35 @@ export const AppNavigator = () => {
     }, []);
   }
 
-  const userId = auth.user?.id ?? null;
-
   return (
     <NavigationContainer ref={navigationRef}>
-      {userId ? (
-        <AuthenticatedRoot userId={userId} />
-      ) : (
-        <Stack.Navigator
-          screenOptions={{
-            gestureEnabled: false,
-            animation: 'none',
-            headerShown: showNativeHeader,
-            headerBackVisible: showNativeHeader,
-          }}
-        >
-          <Stack.Screen
-            name='Home'
-            component={HomeScreen}
-            options={{ headerShown: false }}
-          />
-          <Stack.Screen name='Login' component={LoginScreen} />
-          <Stack.Screen name='Signup' component={SignupScreen} />
-          <Stack.Screen name='Dashboard' component={DashboardScreen} />
-          <Stack.Screen name='Profile' component={ProfileScreen} />
-          <Stack.Screen
-            name='Billing'
-            component={BillingScreen}
-            options={{ title: 'Billing' }}
-          />
-        </Stack.Navigator>
+      <Stack.Navigator
+        screenOptions={{
+          gestureEnabled: false,
+          animation: 'none',
+          headerShown: showNativeHeader,
+          headerBackVisible: showNativeHeader,
+        }}
+      >
+        <Stack.Screen
+          name='Home'
+          component={HomeScreen}
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen name='Login' component={LoginScreen} />
+        <Stack.Screen name='Signup' component={SignupScreen} />
+        <Stack.Screen name='Dashboard' component={DashboardScreen} />
+        <Stack.Screen name='Profile' component={ProfileScreen} />
+        <Stack.Screen
+          name='Billing'
+          component={BillingScreen}
+          options={{ title: 'Billing' }}
+        />
+      </Stack.Navigator>
+      {!loading && showOnboarding && (
+        <View style={StyleSheet.absoluteFill}>
+          <OnboardingScreen onComplete={markComplete} />
+        </View>
       )}
     </NavigationContainer>
   );

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -33,6 +33,7 @@ import {
 } from '../billing/beakerstackBillingConfig';
 import { useDemoCollections } from '../billing/useDemoCollections';
 import { nextFakeAiSummary } from '../lib/fakeAi';
+import { EmptyState } from '../components/EmptyState';
 
 // Read at call time (not module init) so tests and dev toggles can change process.env without reload.
 function readBillingDashboardDemoMode(): boolean {
@@ -224,9 +225,15 @@ function MeteredBlock(): ReactElement {
       ) : null}
       <View style={styles.resultBox}>
         {results.length === 0 ? (
-          <Text style={styles.muted}>
-            Tap &apos;Simulate AI summarize&apos; to generate a result.
-          </Text>
+          <EmptyState
+            title="No results yet"
+            description="Tap 'Simulate AI summarize' to generate a result."
+            action={{
+              label: 'Simulate AI summarize',
+              accessibilityLabel: 'Simulate an AI summarize usage event',
+              onPress: () => void onSimulate(),
+            }}
+          />
         ) : (
           results.map(e => (
             <View key={e.id} style={styles.resultItem}>
@@ -313,9 +320,15 @@ function NumericCapsBlock(): ReactElement {
       </View>
       {actionErr ? <Text style={styles.errText}>{actionErr}</Text> : null}
       {!loading && collections.length === 0 ? (
-        <Text style={styles.muted}>
-          No collections yet. Tap Add collection to start.
-        </Text>
+        <EmptyState
+          title="No collections yet"
+          description="Your collections will appear here once you add them."
+          action={{
+            label: 'Add collection',
+            accessibilityLabel: 'Add a new collection',
+            onPress: () => void wrap('add', addCollection),
+          }}
+        />
       ) : (
         collections.map(row => {
           const itemCap =
@@ -740,6 +753,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#f9fafb',
     borderRadius: 8,
     padding: 10,
+    minHeight: 80,
   },
   resultItem: {
     marginBottom: 10,

--- a/apps/mobile/src/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen.tsx
@@ -7,6 +7,7 @@ import {
   SafeAreaView,
   ScrollView,
   ActivityIndicator,
+  Alert,
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
@@ -14,6 +15,7 @@ import { useProfileContext } from '@beakerstack/shared/contexts/ProfileContext';
 import { Logger } from '@beakerstack/shared/utils/logger';
 import { supabase } from '../lib/supabase';
 import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.native';
+import Constants from 'expo-constants';
 // Import Profile Display Components - Metro will automatically resolve .native.tsx files
 import { ProfileHeader } from '@beakerstack/shared/components/profile/ProfileHeader.native';
 import { ProfileStats } from '@beakerstack/shared/components/profile/ProfileStats.native';
@@ -102,6 +104,17 @@ function ProfileScreenContent({ navigation: _navigation }: Props) {
     }
   }, [isEditing, componentsLoaded]);
 
+  const handleDevResetOnboarding = async () => {
+    const userId = auth.user?.id;
+    if (!userId) return;
+    await supabase
+      .from('onboarding_steps')
+      .delete()
+      .eq('user_id', userId)
+      .eq('step_key', 'carousel_completed');
+    Alert.alert('Dev', 'Onboarding reset — sign out and back in to see carousel.');
+  };
+
   return (
     <SafeAreaView style={styles.container}>
       <AppHeader supabaseClient={supabase} />
@@ -177,6 +190,18 @@ function ProfileScreenContent({ navigation: _navigation }: Props) {
                   </View>
                 )}
               </View>
+            )}
+
+            {/* Version label — long-press in __DEV__ resets onboarding carousel */}
+            {__DEV__ && (
+              <TouchableOpacity
+                delayLongPress={500}
+                onLongPress={() => void handleDevResetOnboarding()}
+                style={styles.versionLabel}
+                accessibilityLabel="App version — long-press to reset onboarding in dev mode"
+              >
+                <Text style={styles.versionText}>v{Constants.expoConfig?.version ?? '—'}</Text>
+              </TouchableOpacity>
             )}
           </View>
         )}
@@ -255,5 +280,14 @@ const styles = StyleSheet.create({
     color: '#ffffff',
     fontSize: 16,
     fontWeight: '600',
+  },
+  versionLabel: {
+    alignItems: 'center',
+    paddingVertical: 8,
+    marginTop: 4,
+  },
+  versionText: {
+    fontSize: 12,
+    color: '#9ca3af',
   },
 });

--- a/apps/mobile/src/screens/onboarding/OnboardingScreen.tsx
+++ b/apps/mobile/src/screens/onboarding/OnboardingScreen.tsx
@@ -1,0 +1,159 @@
+import React, { useRef, useState } from 'react';
+import {
+  Animated,
+  Dimensions,
+  Image,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { slides } from './slides';
+import { useReduceMotion } from '../../hooks/useReduceMotion';
+
+const { width } = Dimensions.get('window');
+
+interface Props {
+  onComplete: () => void;
+}
+
+export function OnboardingScreen({ onComplete }: Props) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const scrollRef = useRef<ScrollView>(null);
+  const reduceMotion = useReduceMotion();
+
+  const handleScroll = (e: { nativeEvent: { contentOffset: { x: number } } }) => {
+    const index = Math.round(e.nativeEvent.contentOffset.x / width);
+    setActiveIndex(index);
+  };
+
+  const goToNext = () => {
+    if (activeIndex < slides.length - 1) {
+      const nextIndex = activeIndex + 1;
+      scrollRef.current?.scrollTo({ x: nextIndex * width, animated: !reduceMotion });
+      setActiveIndex(nextIndex);
+    } else {
+      onComplete();
+    }
+  };
+
+  const isLast = activeIndex === slides.length - 1;
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        style={styles.skipButton}
+        onPress={onComplete}
+        accessibilityLabel="Skip onboarding"
+        accessibilityRole="button"
+      >
+        {!isLast && <Text style={styles.skipText}>Skip</Text>}
+      </TouchableOpacity>
+
+      <ScrollView
+        ref={scrollRef}
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+        scrollEnabled={true}
+      >
+        {slides.map((slide, i) => (
+          <View
+            key={slide.key}
+            style={[styles.slide, { backgroundColor: slide.backgroundColor }]}
+            accessibilityLabel={`${slide.title}. Slide ${i + 1} of ${slides.length}`}
+          >
+            {slide.imageSource && (
+              <Image
+                source={slide.imageSource}
+                style={styles.illustration}
+                accessibilityRole="none"
+                accessible={false}
+              />
+            )}
+            {!slide.imageSource && <View style={[styles.illustration, styles.illustrationPlaceholder]} />}
+            <Text style={styles.title}>{slide.title}</Text>
+            <Text style={styles.description}>{slide.description}</Text>
+          </View>
+        ))}
+      </ScrollView>
+
+      <View style={styles.footer}>
+        <View style={styles.dots}>
+          {slides.map((_, i) => (
+            <View
+              key={i}
+              style={[styles.dot, i === activeIndex && styles.dotActive]}
+            />
+          ))}
+        </View>
+
+        <TouchableOpacity
+          style={styles.ctaButton}
+          onPress={goToNext}
+          accessibilityLabel={isLast ? 'Get started with BeakerStack' : 'Next slide'}
+          accessibilityRole="button"
+        >
+          <Text style={styles.ctaText}>{isLast ? 'Get started' : 'Next'}</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  skipButton: {
+    position: 'absolute',
+    top: 56,
+    right: 24,
+    zIndex: 10,
+    padding: 8,
+  },
+  skipText: { fontSize: 16, color: '#6b7280' },
+  slide: {
+    width,
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+  illustration: { width: 200, height: 200, marginBottom: 40 },
+  illustrationPlaceholder: { backgroundColor: 'rgba(0,0,0,0.08)', borderRadius: 16 },
+  title: {
+    fontSize: 26,
+    fontWeight: '700',
+    color: '#111827',
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+  description: {
+    fontSize: 16,
+    color: '#4b5563',
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 48,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    gap: 24,
+  },
+  dots: { flexDirection: 'row', gap: 8 },
+  dot: { width: 8, height: 8, borderRadius: 4, backgroundColor: '#d1d5db' },
+  dotActive: { backgroundColor: '#111827', width: 20 },
+  ctaButton: {
+    backgroundColor: '#111827',
+    paddingVertical: 14,
+    paddingHorizontal: 48,
+    borderRadius: 12,
+    minWidth: 200,
+    alignItems: 'center',
+  },
+  ctaText: { color: '#fff', fontSize: 17, fontWeight: '600' },
+});

--- a/apps/mobile/src/screens/onboarding/slides.ts
+++ b/apps/mobile/src/screens/onboarding/slides.ts
@@ -1,0 +1,30 @@
+import { ImageSourcePropType } from 'react-native';
+
+export interface OnboardingSlide {
+  key: string;
+  title: string;
+  description: string;
+  imageSource?: ImageSourcePropType;
+  backgroundColor: string;
+}
+
+export const slides: OnboardingSlide[] = [
+  {
+    key: 'welcome',
+    title: 'Welcome to BeakerStack',
+    description: 'Your all-in-one platform for managing your account, billing, and more.',
+    backgroundColor: '#f0f9ff',
+  },
+  {
+    key: 'dashboard',
+    title: 'Your Dashboard',
+    description: 'Get a clear overview of your activity and manage everything from one place.',
+    backgroundColor: '#f0fdf4',
+  },
+  {
+    key: 'billing',
+    title: 'Simple Billing',
+    description: 'Upgrade, downgrade, and track your invoices — all without leaving the app.',
+    backgroundColor: '#fdf4ff',
+  },
+];

--- a/supabase/migrations/20260513000001_onboarding_steps.sql
+++ b/supabase/migrations/20260513000001_onboarding_steps.sql
@@ -1,0 +1,17 @@
+create table if not exists public.onboarding_steps (
+  user_id      uuid not null references auth.users(id) on delete cascade,
+  step_key     text not null,
+  completed    boolean not null default false,
+  completed_at timestamptz,
+  primary key (user_id, step_key)
+);
+
+create index if not exists onboarding_steps_user_id_idx on public.onboarding_steps(user_id);
+
+alter table public.onboarding_steps enable row level security;
+
+create policy "Users can manage their own onboarding steps"
+  on public.onboarding_steps
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- `onboarding_steps` Supabase migration with RLS (includes schema for #119 since it's unassigned — first to implement owns it)
- 3-slide onboarding carousel (`OnboardingScreen` + `slides.ts`) — `ScrollView` with `pagingEnabled`, dot indicators synced via `onScroll`
- `useOnboardingGate` hook — queries `onboarding_steps` for `carousel_completed`, marks complete on skip/finish
- `useReduceMotion` hook — async `AccessibilityInfo.isReduceMotionEnabled()` in `useEffect`; instant transitions when enabled
- `EmptyState` component — illustration (optional), title, description, action button with full `accessibilityLabel`
- `OnboardingGate` mounted above authenticated navigator — navigator-agnostic, compatible with #116
- `__DEV__`-only long-press debug reset on version label in ProfileScreen
- Feature-flagged via `EXPO_PUBLIC_ONBOARDING_ENABLED` (default true)

## Test plan
- [ ] New user (no `carousel_completed` row) sees carousel on first login
- [ ] Returning user (row exists) goes straight to main app
- [ ] "Skip" on any non-final slide inserts `carousel_completed` and navigates to main app
- [ ] "Get started" on final slide inserts `carousel_completed` and navigates to main app
- [ ] Dot indicator reflects current slide index
- [ ] `reduceMotion=true`: slide transitions are instant (no animation)
- [ ] Each slide's `accessibilityLabel` includes slide number (e.g. "Welcome to BeakerStack. Slide 1 of 3")
- [ ] Dashboard shows `EmptyState` when data array is empty
- [ ] `__DEV__` long-press (500ms) on version label deletes `carousel_completed` row
- [ ] Sign out → sign back in → carousel does NOT re-appear (row persists)
- [ ] `EXPO_PUBLIC_ONBOARDING_ENABLED=false` → carousel never shown

Note on #119: `onboarding_steps` table is created by this PR's migration. Anyone implementing #119 should build against this table.