### PR TITLE
feat(landing): add marketing/SEO feature rows and reorder grid for B2C audience

### DIFF
--- a/apps/web/src/config/landing.ts
+++ b/apps/web/src/config/landing.ts
@@ -9,6 +9,9 @@ import {
   GitBranch,
   TestTube,
   Database,
+  Megaphone,
+  Search,
+  Bot,
 } from 'lucide-react';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -142,22 +145,37 @@ export const landingConfig: LandingConfig = {
   featureGrid: {
     heading: 'Everything wired. Nothing hidden.',
     subhead:
-      'Stop stitching libraries together. BeakerStack ships the hard parts pre-integrated.',
+      'Stop stitching libraries together. BeakerStack ships cross-platform apps, B2C-ready auth and billing, and a marketable web presence — all pre-integrated.',
     items: [
+      {
+        icon: Smartphone,
+        title: 'Mobile from day one',
+        body: 'Reach users on iOS and Android with the same business logic as your web app — shared hooks, auth, and billing across React and React Native.',
+      },
       {
         icon: Zap,
         title: 'Auth out of the box',
-        body: 'Email, OAuth, and magic links via Supabase — no custom session handling required.',
+        body: 'Email, OAuth, and magic links via Supabase — session handling and protected routes are already wired for web and mobile.',
+      },
+      {
+        icon: Megaphone,
+        title: 'Marketing landing in config',
+        body: 'Hero, features, pricing, FAQ, and footer are driven from a typed config file — rebrand or white-label the landing page without rewriting JSX.',
+      },
+      {
+        icon: Search,
+        title: 'SEO-friendly home page',
+        body: 'The marketing home is pre-rendered to static HTML at build time with canonical and Open Graph URLs — better for crawlers and social previews than a blank SPA shell.',
       },
       {
         icon: CreditCard,
         title: 'Billing that works',
-        body: 'Stripe subscriptions, usage metering, plan gates, and a customer portal — ready to go.',
+        body: 'Stripe subscriptions, plan gates, a customer portal, and upgrade flows — the same patterns you need for self-serve B2C plans.',
       },
       {
-        icon: Smartphone,
-        title: 'Mobile from day one',
-        body: 'Shared business logic between your React web app and React Native mobile app.',
+        icon: BarChart3,
+        title: 'Usage metering',
+        body: 'Track feature usage per user, enforce limits, and surface quota data in the UI — ideal for free tiers and usage-based add-ons.',
       },
       {
         icon: Database,
@@ -170,9 +188,9 @@ export const landingConfig: LandingConfig = {
         body: 'End-to-end types from the database schema to your UI components.',
       },
       {
-        icon: BarChart3,
-        title: 'Usage metering',
-        body: 'Track feature usage per user, enforce limits, and surface quota data in the UI.',
+        icon: Bot,
+        title: 'Agent-friendly codebase',
+        body: 'Typed configs, schema-generated types, colocated tests with a decision matrix, and a clear monorepo layout give AI coding agents the structure they need to make safe, targeted changes. Ships with reusable skills directories for Claude, Cursor, and Augment.',
       },
       {
         icon: GitBranch,
@@ -195,21 +213,41 @@ export const landingConfig: LandingConfig = {
   },
   featureRows: [
     {
-      title: 'Billing that actually ships.',
-      body: 'Most templates stop at "add Stripe." BeakerStack includes plan gating, usage metering, upgrade prompts, a billing portal, and downgrade blockers — all wired to real Stripe products and ready for your plans.',
-      ctaLabel: 'See billing docs',
-      ctaHref: '#pricing',
-      mediaSrc: 'https://placehold.co/560x315?text=Billing+UI',
-      mediaAlt: 'Billing plans UI screenshot',
-      mediaSide: 'right',
-    },
-    {
       title: 'Web and mobile from a single codebase.',
       body: 'Shared auth logic. Shared billing hooks. Shared business rules. Your React web app and React Native mobile app stay in sync without duplicating work. About 40–60% of the codebase is shared across platforms.',
       ctaLabel: 'Learn about mobile',
       ctaHref: '#features',
       mediaSrc: 'https://placehold.co/560x315?text=Mobile+App',
       mediaAlt: 'Mobile app screenshot',
+      mediaSide: 'right',
+    },
+    {
+      title: 'Marketing copy you can rebrand in one file.',
+      body: 'Every piece of landing-page content — hero, features, social proof, pricing, FAQ, footer — lives in a single typed config. Swap the config and the same section components render a completely different product, with zero JSX changes. An alternate example config ships in the repo to prove it.',
+      ctaLabel: 'Read the landing README',
+      ctaHref:
+        'https://github.com/Artificer-Innovations/BeakerStack/blob/main/apps/web/src/components/landing/README.md',
+      mediaSrc: 'https://placehold.co/560x315?text=Marketing+config',
+      mediaAlt: 'Landing page config file screenshot',
+      mediaSide: 'left',
+    },
+    {
+      title: 'Pre-rendered home page for SEO and link previews.',
+      body: 'The marketing home is rendered to static HTML at build time and injected into `index.html`, with canonical and Open Graph URLs wired in per environment. Crawlers and social previews see real content immediately — no blank shell, no client-side flash — while the rest of the SPA hydrates as usual.',
+      ctaLabel: 'See the prerender script',
+      ctaHref:
+        'https://github.com/Artificer-Innovations/BeakerStack/blob/main/apps/web/scripts/prerender-home.ts',
+      mediaSrc: 'https://placehold.co/560x315?text=SEO+prerender',
+      mediaAlt: 'Pre-rendered HTML and meta tags screenshot',
+      mediaSide: 'right',
+    },
+    {
+      title: 'Billing that actually ships.',
+      body: 'Most templates stop at "add Stripe." BeakerStack includes plan gating, usage metering, upgrade prompts, a billing portal, and downgrade blockers — all wired to real Stripe products and ready for your plans.',
+      ctaLabel: 'See billing docs',
+      ctaHref: '#pricing',
+      mediaSrc: 'https://placehold.co/560x315?text=Billing+UI',
+      mediaAlt: 'Billing plans UI screenshot',
       mediaSide: 'left',
     },
     {

--- a/apps/web/src/config/landing.ts
+++ b/apps/web/src/config/landing.ts
@@ -190,7 +190,7 @@ export const landingConfig: LandingConfig = {
       {
         icon: Bot,
         title: 'Agent-friendly codebase',
-        body: 'Typed configs, schema-generated types, colocated tests with a decision matrix, and a clear monorepo layout give AI coding agents the structure they need to make safe, targeted changes. Ships with reusable skills directories for Claude, Cursor, and Augment.',
+        body: 'Typed configs, schema-generated types, colocated tests with a decision matrix, and a clear monorepo layout give AI coding agents the structure they need to make safe, targeted changes.',
       },
       {
         icon: GitBranch,
@@ -233,7 +233,7 @@ export const landingConfig: LandingConfig = {
     },
     {
       title: 'Pre-rendered home page for SEO and link previews.',
-      body: 'The marketing home is rendered to static HTML at build time and injected into `index.html`, with canonical and Open Graph URLs wired in per environment. Crawlers and social previews see real content immediately — no blank shell, no client-side flash — while the rest of the SPA hydrates as usual.',
+      body: 'The marketing home is rendered to static HTML at build time with canonical and Open Graph URLs wired in per environment. Crawlers and social previews see real content immediately — no blank shell, no client-side flash — while the rest of the SPA hydrates as usual.',
       ctaLabel: 'See the prerender script',
       ctaHref:
         'https://github.com/Artificer-Innovations/BeakerStack/blob/main/apps/web/scripts/prerender-home.ts',


### PR DESCRIPTION
## Description

Strengthen the landing page story for the target audience — OSS developers building B2C SaaS products — by adding marketing/SEO content and reordering existing items for a clearer narrative.

All changes are limited to `apps/web/src/config/landing.ts`. No type, component, or test changes were required.

### Feature rows

- Added **Marketing copy you can rebrand in one file.** — links to the landing README; anchored on the config-driven structure already documented there.
- Added **Pre-rendered home page for SEO and link previews.** — links to `apps/web/scripts/prerender-home.ts`; describes the actual behavior (static HTML inject + canonical/`og:url`), not full-site SSR.
- Reordered rows around a B2C-first narrative: reach (mobile) → make it yours (marketing config) → get found (SEO) → monetize (billing) → ship safely (environments) → start fast (setup).
- Updated `mediaSide` values to preserve the right/left alternation under the new order.

### Feature grid

- Added **Marketing landing in config**, **SEO-friendly home page**, and **Agent-friendly codebase** cards (new `Megaphone`, `Search`, `Bot` icons from lucide-react).
- The agent-friendly card is grounded in repo facts: `ARCHITECTURE.md` line 26 ("Better AI coding agent support"), the colocated-tests decision matrix, schema-generated TypeScript types, typed configs, the monorepo layout, and the existing `.claude/skills/`, `.agents/skills/`, `.augment/skills/` directories.
- Reordered cards to lead with reach/trust (Mobile, Auth) → acquisition (Marketing, SEO) → monetize (Billing, Usage metering) → platform/quality (Supabase, TypeScript, Agent-friendly, CI/CD, Tests) → OSS closer.
- Tightened the grid subhead to mention cross-platform apps, B2C-ready auth/billing, and a marketable web presence.
- Minor body-copy tweaks on Mobile, Auth, Billing, and Usage metering to lean into the B2C use case.

The grid is `md:grid-cols-3`, so 12 cards fills exactly 4 rows of 3.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactoring
- [ ] Other (please describe)

## Merge Strategy Reminder

This PR targets ``develop`` — use **"Squash and merge"**.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code (N/A — config-only)
- [ ] Documentation updated (if needed) — landing README already covers the config pattern; new copy links to it
- [x] No new warnings generated (lint clean on the edited file)
- [ ] Tests added/updated (if needed) — N/A; existing tests use isolated fixtures (`featureRows: []` mock in `HomePage.test.tsx`, local fixtures in `FeatureRows.test.tsx` and `FeatureGrid.test.tsx`)
- [ ] All tests pass locally

## Testing

Visual verification on the rendered landing page (dev server) is the primary check; copy/icons render through existing section components with no logic changes.

## Related Issues

None.