### PR TITLE
fix(ci): fix GitHub Deployment visibility for PR previews (#140)

### DIFF
--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -268,10 +268,11 @@ jobs:
           script: |
             // Fork PRs: pull_request events from forks run with a read-only token;
             // deployments: write is unavailable — skip cleanly rather than error.
-            const prRepo = context.payload.pull_request.head.repo.full_name;
+            // head.repo can be null when the fork is deleted before the workflow runs.
+            const headRepo = context.payload.pull_request.head.repo?.full_name;
             const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
-            if (prRepo !== baseRepo) {
-              core.info(`Skipping: fork PR (${prRepo}) — Deployments API write not available for fork PRs.`);
+            if (!headRepo || headRepo !== baseRepo) {
+              core.info(`Skipping: fork PR (${headRepo ?? 'deleted repo'}) — Deployments API write not available for fork PRs.`);
               return;
             }
 
@@ -281,27 +282,14 @@ jobs:
             const environmentUrl = process.env.BOOTSTRAP_URL || webUrl;
             const logUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
-            // Deactivate previous deployments for this environment so the PR
-            // Deployments panel shows only one active row per PR on re-runs.
-            const { data: existing } = await github.rest.repos.listDeployments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              environment,
-              per_page: 20,
-            });
-            for (const dep of existing) {
-              await github.rest.repos.createDeploymentStatus({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                deployment_id: dep.id,
-                state: 'inactive',
-              });
-            }
-
+            // Create the new deployment first. Only deactivate previous deployments
+            // after success so a partial failure doesn't leave the PR Deployments
+            // panel empty. Use head.sha (not context.sha which is the synthetic merge
+            // commit) so GitHub associates the deployment with the PR's own head ref.
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.sha,
+              ref: context.payload.pull_request.head.sha,
               environment,
               auto_merge: false,
               required_contexts: [],
@@ -320,6 +308,24 @@ jobs:
               log_url: logUrl,
               description: 'Preview deployed',
             });
+
+            // Deactivate previous deployments for this environment now that the new
+            // one is registered, keeping only one active row on the PR Deployments tab.
+            const { data: existing } = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment,
+              per_page: 100,
+            });
+            for (const dep of existing) {
+              if (dep.id === deployment.data.id) continue;
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: dep.id,
+                state: 'inactive',
+              });
+            }
 
       # Publish edge routing only after a successful web build so a failed deploy cannot
       # replace live CloudFront function code while leaving stale or missing S3 assets.

--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -58,8 +58,13 @@ jobs:
     needs: preview-scope
     runs-on: ubuntu-latest
     outputs:
-      bootstrap-url: ${{ steps.signed_cookies.outputs.BOOTSTRAP_URL }}
-      access-mode: ${{ steps.signed_cookies.outputs.ACCESS_MODE }}
+      bootstrap-url:             ${{ steps.signed_cookies.outputs.BOOTSTRAP_URL }}
+      access-mode:               ${{ steps.signed_cookies.outputs.ACCESS_MODE }}
+      supabase-outcome:          ${{ steps.supabase.outcome }}
+      stripe-sync-outcome:       ${{ steps.stripe-sync.outcome }}
+      stripe-webhook-outcome:    ${{ steps.stripe_webhook_preview.outcome }}
+      billing-functions-outcome: ${{ steps.billing-functions.outcome }}
+      web-outcome:               ${{ steps.web.outcome }}
     env:
       PREVIEW_DOMAIN: ${{ vars.PR_PREVIEW_DOMAIN }}
       PREVIEW_HOSTED_ZONE_ID: ${{ vars.PR_PREVIEW_HOSTED_ZONE_ID }}
@@ -132,6 +137,8 @@ jobs:
             --skip-if-unchanged
 
       - name: Sync Stripe prices to preview billing_plans
+        id: stripe-sync
+        continue-on-error: true
         env:
           STRIPE_SECRET_KEY: ${{ secrets.PREVIEW_STRIPE_SECRET_KEY }}
           SUPABASE_URL: ${{ secrets.PREVIEW_SUPABASE_URL }}
@@ -142,6 +149,7 @@ jobs:
 
       - name: Ensure Stripe webhook endpoint (preview)
         id: stripe_webhook_preview
+        continue-on-error: true
         env:
           STRIPE_SECRET_KEY: ${{ secrets.PREVIEW_STRIPE_SECRET_KEY }}
           STRIPE_WEBHOOK_URL: ${{ secrets.PREVIEW_SUPABASE_URL }}/functions/v1/stripe-webhook
@@ -150,6 +158,8 @@ jobs:
         run: node scripts/ensure-stripe-webhook-endpoint.mjs
 
       - name: Deploy preview billing edge functions
+        id: billing-functions
+        continue-on-error: true
         shell: bash
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
@@ -430,6 +440,12 @@ jobs:
           PREVIEW_PREFIX: ${{ vars.PR_PREVIEW_PREFIX }}
           BOOTSTRAP_URL: ${{ needs.deploy-preview.outputs.bootstrap-url }}
           ACCESS_MODE: ${{ needs.deploy-preview.outputs.access-mode }}
+          SUPABASE_OUTCOME: ${{ needs.deploy-preview.outputs.supabase-outcome }}
+          STRIPE_SYNC_OUTCOME: ${{ needs.deploy-preview.outputs.stripe-sync-outcome }}
+          STRIPE_WEBHOOK_OUTCOME: ${{ needs.deploy-preview.outputs.stripe-webhook-outcome }}
+          BILLING_FUNCTIONS_OUTCOME: ${{ needs.deploy-preview.outputs.billing-functions-outcome }}
+          WEB_OUTCOME: ${{ needs.deploy-preview.outputs.web-outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           MOBILE_JOB_RESULT: ${{ needs.deploy-preview-mobile.result }}
           MOBILE_CHANNEL: ${{ needs.deploy-preview-mobile.outputs.mobile-channel }}
           MOBILE_UPDATE_URL: ${{ needs.deploy-preview-mobile.outputs.mobile-update-url }}
@@ -443,57 +459,110 @@ jobs:
             const prefix = process.env.PREVIEW_PREFIX || 'pr-';
             const prNumber = context.payload.pull_request.number;
             const webUrl = domain ? `https://deploy.${domain}/${prefix}${prNumber}/` : '';
-            const mobileJobResult = process.env.MOBILE_JOB_RESULT;
-            const mobileChannel = process.env.MOBILE_CHANNEL;
-            const mobileUpdateUrl = process.env.MOBILE_UPDATE_URL;
-
+            const runUrl = process.env.RUN_URL;
             const bootstrapUrl = process.env.BOOTSTRAP_URL;
-            const lines = [];
-            lines.push('<!-- pr-preview-links -->');
-            if (webUrl || bootstrapUrl) {
-              const isSignedCookies = process.env.ACCESS_MODE === 'signed-cookies';
-              if (isSignedCookies && bootstrapUrl) {
-                lines.push(`🔐 **Web preview (access link):** ${bootstrapUrl}`);
-                lines.push('');
-                lines.push('> _Click the link above to set your access cookie, then browse the preview. The link expires in 7 days._');
-              } else {
-                lines.push(`🌐 **Web preview:** ${webUrl}`);
-              }
+            const isSignedCookies = process.env.ACCESS_MODE === 'signed-cookies';
+
+            const webOutcome          = process.env.WEB_OUTCOME;
+            const supabaseOutcome     = process.env.SUPABASE_OUTCOME;
+            const stripeSyncOutcome   = process.env.STRIPE_SYNC_OUTCOME;
+            const stripeWebhookOutcome = process.env.STRIPE_WEBHOOK_OUTCOME;
+            const billingFnsOutcome   = process.env.BILLING_FUNCTIONS_OUTCOME;
+            const mobileJobResult     = process.env.MOBILE_JOB_RESULT;
+            const mobileChannel       = process.env.MOBILE_CHANNEL;
+            const mobileUpdateUrl     = process.env.MOBILE_UPDATE_URL;
+
+            function statusCell(outcome, successLabel) {
+              if (outcome === 'success')   return `✅ ${successLabel}`;
+              if (outcome === 'failure')   return '❌ Failed';
+              if (outcome === 'skipped')   return '⏭️ Skipped';
+              if (outcome === 'cancelled') return '🚫 Cancelled';
+              return '—';
             }
-            if (mobileJobResult === 'skipped') {
-              // Mobile disabled via MOBILE_ENABLED=false — omit mobile section
-            } else if (mobileJobResult === 'failure') {
-              lines.push('');
-              lines.push('❌ **Mobile preview failed.** Check the **deploy-preview-mobile** job logs for details.');
-            } else if (mobileUpdateUrl) {
+
+            // Aggregate billing: any failure beats all; then cancelled; then success
+            const billingOutcomes = [stripeSyncOutcome, stripeWebhookOutcome, billingFnsOutcome];
+            let billingStatus;
+            if (billingOutcomes.some(o => o === 'failure'))        billingStatus = 'failure';
+            else if (billingOutcomes.some(o => o === 'cancelled')) billingStatus = 'cancelled';
+            else if (billingOutcomes.every(o => o === 'success'))  billingStatus = 'success';
+            else billingStatus = billingOutcomes.find(o => o && o !== 'success') || 'success';
+
+            const logsLink = `[View logs](${runUrl})`;
+            const webLink = (() => {
+              if (webOutcome !== 'success') return logsLink;
+              if (isSignedCookies && bootstrapUrl)
+                return `[Access preview →](${bootstrapUrl}) _(sets cookie, expires 7 days)_`;
+              return webUrl ? `[Preview →](${webUrl})` : '—';
+            })();
+
+            const mobileStatus =
+              mobileJobResult === 'skipped' ? 'skipped' :
+              (mobileJobResult === 'success' && !mobileUpdateUrl) ? 'skipped' :
+              mobileJobResult || 'skipped';
+            const mobileLinkCell = mobileJobResult === 'failure' ? logsLink : '—';
+
+            const table = [
+              '| Component | Status | Link |',
+              '|-----------|--------|------|',
+              `| 🌐 Web | ${statusCell(webOutcome, 'Deployed')} | ${webLink} |`,
+              `| 🗄️ Database | ${statusCell(supabaseOutcome, 'Migrated')} | ${supabaseOutcome === 'failure' ? logsLink : '—'} |`,
+              `| 💳 Billing | ${statusCell(billingStatus, 'Deployed')} | ${billingStatus === 'failure' ? logsLink : '—'} |`,
+              `| 📱 Mobile | ${statusCell(mobileStatus, 'Deployed')} | ${mobileLinkCell} |`,
+            ].join('\n');
+
+            // HH:MM PT timestamp
+            const now = new Date();
+            const timeStr = now.toLocaleString('en-US', {
+              timeZone: 'America/Los_Angeles',
+              hour: '2-digit',
+              minute: '2-digit',
+              hour12: false,
+            });
+            const tzStr = now.toLocaleString('en-US', {
+              timeZone: 'America/Los_Angeles',
+              timeZoneName: 'short',
+            }).split(', ').pop().split(' ').pop();
+
+            const lines = [];
+            lines.push(marker);
+            lines.push('');
+            lines.push(table);
+            lines.push('');
+            lines.push(`_Last deployed: ${timeStr} ${tzStr}_`);
+
+            // Mobile detail section — only when mobile succeeded with an update URL
+            if (mobileJobResult !== 'skipped' && mobileJobResult !== 'failure' && mobileUpdateUrl) {
               const iosDownloadUrl = process.env.MOBILE_IOS_DOWNLOAD_URL;
               const androidDownloadUrl = process.env.MOBILE_ANDROID_DOWNLOAD_URL;
               const needsNativeBuild = process.env.NEEDS_NATIVE_BUILD === 'true';
-              
+
+              lines.push('');
+              lines.push('---');
+              lines.push('');
               lines.push(`📱 **Mobile preview:** Channel \`${mobileChannel}\``);
               lines.push('');
-              
-              // Show native build downloads if available
+
               if (iosDownloadUrl || androidDownloadUrl) {
                 lines.push('### 📱 Mobile Preview Builds');
                 lines.push('');
                 lines.push('**Native builds are available for download:**');
                 lines.push('');
-                
+
                 if (iosDownloadUrl) {
                   lines.push('**iOS Simulator Build:**');
                   lines.push(`- [Download .app file](${iosDownloadUrl})`);
                   lines.push('- Install with: `xcrun simctl install booted ~/Downloads/BeakerStack.app`');
                   lines.push('');
                 }
-                
+
                 if (androidDownloadUrl) {
                   lines.push('**Android Build (Device & Emulator):**');
                   lines.push(`- [Download .apk file](${androidDownloadUrl})`);
                   lines.push('- Install with: `adb install ~/Downloads/BeakerStack.apk`');
                   lines.push('');
                 }
-                
+
                 lines.push('**Note:** These builds include the preview Supabase configuration and are ready to use.');
                 lines.push('');
               } else if (needsNativeBuild) {
@@ -527,23 +596,11 @@ jobs:
                 lines.push(`**Alternative:** For local development, use: \`cd apps/mobile && npx expo start --dev-client\`, then press 'i' for iOS simulator.`);
                 lines.push('');
               }
-              
+
               lines.push('📖 See [Mobile Build Testing Guide](../../docs/MOBILE_BUILD_TESTING.md) for detailed instructions.');
             }
-            let body = lines.join('\n');
 
-            // Add timestamp in Pacific time
-            const now = new Date();
-            const pacificTime = now.toLocaleString('en-US', {
-              timeZone: 'America/Los_Angeles',
-              dateStyle: 'long',
-              timeStyle: 'short'
-            });
-            const timezone = now.toLocaleString('en-US', {
-              timeZone: 'America/Los_Angeles',
-              timeZoneName: 'short'
-            }).split(' ').pop();
-            body = `${body}\n\n---\n\n_Updated at: ${pacificTime} ${timezone}_`;
+            const body = lines.join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -569,6 +626,52 @@ jobs:
                 body,
               });
             }
+
+  lighthouse:
+    if: >-
+      github.event.action != 'closed' &&
+      needs.deploy-preview.result == 'success' &&
+      needs.deploy-preview.outputs.access-mode != 'signed-cookies'
+    needs: [deploy-preview]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install @lhci/cli
+        run: npm install -g @lhci/cli@0.14
+
+      - name: Warm up preview URL
+        env:
+          PREVIEW_DOMAIN: ${{ vars.PR_PREVIEW_DOMAIN }}
+          PREVIEW_PREFIX: ${{ vars.PR_PREVIEW_PREFIX }}
+        run: |
+          set -euo pipefail
+          PREVIEW_PREFIX_VALUE="${PREVIEW_PREFIX:-pr-}"
+          URL="https://deploy.${PREVIEW_DOMAIN}/${PREVIEW_PREFIX_VALUE}${{ github.event.pull_request.number }}/"
+          echo "Warming up ${URL}"
+          curl -sf --max-time 30 --retry 5 --retry-delay 5 --retry-all-errors "${URL}" -o /dev/null
+          sleep 5
+
+      - name: Run Lighthouse CI
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          PREVIEW_DOMAIN: ${{ vars.PR_PREVIEW_DOMAIN }}
+          PREVIEW_PREFIX: ${{ vars.PR_PREVIEW_PREFIX }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${LHCI_GITHUB_APP_TOKEN:-}" ]]; then
+            echo "LHCI_GITHUB_APP_TOKEN not set — skipping Lighthouse CI."
+            exit 0
+          fi
+          PREVIEW_PREFIX_VALUE="${PREVIEW_PREFIX:-pr-}"
+          URL="https://deploy.${PREVIEW_DOMAIN}/${PREVIEW_PREFIX_VALUE}${{ github.event.pull_request.number }}/"
+          lhci autorun --collect.url="${URL}"
 
   teardown-preview:
     if: github.event.action == 'closed' && (github.base_ref != 'develop' || github.head_ref != 'main')

--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -58,13 +58,8 @@ jobs:
     needs: preview-scope
     runs-on: ubuntu-latest
     outputs:
-      bootstrap-url:             ${{ steps.signed_cookies.outputs.BOOTSTRAP_URL }}
-      access-mode:               ${{ steps.signed_cookies.outputs.ACCESS_MODE }}
-      supabase-outcome:          ${{ steps.supabase.outcome }}
-      stripe-sync-outcome:       ${{ steps.stripe-sync.outcome }}
-      stripe-webhook-outcome:    ${{ steps.stripe_webhook_preview.outcome }}
-      billing-functions-outcome: ${{ steps.billing-functions.outcome }}
-      web-outcome:               ${{ steps.web.outcome }}
+      bootstrap-url: ${{ steps.signed_cookies.outputs.BOOTSTRAP_URL }}
+      access-mode: ${{ steps.signed_cookies.outputs.ACCESS_MODE }}
     env:
       PREVIEW_DOMAIN: ${{ vars.PR_PREVIEW_DOMAIN }}
       PREVIEW_HOSTED_ZONE_ID: ${{ vars.PR_PREVIEW_HOSTED_ZONE_ID }}
@@ -137,8 +132,6 @@ jobs:
             --skip-if-unchanged
 
       - name: Sync Stripe prices to preview billing_plans
-        id: stripe-sync
-        continue-on-error: true
         env:
           STRIPE_SECRET_KEY: ${{ secrets.PREVIEW_STRIPE_SECRET_KEY }}
           SUPABASE_URL: ${{ secrets.PREVIEW_SUPABASE_URL }}
@@ -149,7 +142,6 @@ jobs:
 
       - name: Ensure Stripe webhook endpoint (preview)
         id: stripe_webhook_preview
-        continue-on-error: true
         env:
           STRIPE_SECRET_KEY: ${{ secrets.PREVIEW_STRIPE_SECRET_KEY }}
           STRIPE_WEBHOOK_URL: ${{ secrets.PREVIEW_SUPABASE_URL }}/functions/v1/stripe-webhook
@@ -158,8 +150,6 @@ jobs:
         run: node scripts/ensure-stripe-webhook-endpoint.mjs
 
       - name: Deploy preview billing edge functions
-        id: billing-functions
-        continue-on-error: true
         shell: bash
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
@@ -266,10 +256,38 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
           script: |
+            // Fork PRs: pull_request events from forks run with a read-only token;
+            // deployments: write is unavailable — skip cleanly rather than error.
+            const prRepo = context.payload.pull_request.head.repo.full_name;
+            const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
+            if (prRepo !== baseRepo) {
+              core.info(`Skipping: fork PR (${prRepo}) — Deployments API write not available for fork PRs.`);
+              return;
+            }
+
             const environment = `pr-${process.env.PR_NUMBER}-preview`;
             const prefix = process.env.PREVIEW_PREFIX || 'pr-';
             const webUrl = `https://deploy.${process.env.PREVIEW_DOMAIN}/${prefix}${process.env.PR_NUMBER}/`;
             const environmentUrl = process.env.BOOTSTRAP_URL || webUrl;
+            const logUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // Deactivate previous deployments for this environment so the PR
+            // Deployments panel shows only one active row per PR on re-runs.
+            const { data: existing } = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment,
+              per_page: 20,
+            });
+            for (const dep of existing) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: dep.id,
+                state: 'inactive',
+              });
+            }
+
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -279,16 +297,19 @@ jobs:
               required_contexts: [],
               description: `PR #${process.env.PR_NUMBER} preview`,
             });
-            if (deployment.data.id) {
-              await github.rest.repos.createDeploymentStatus({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                deployment_id: deployment.data.id,
-                state: 'success',
-                environment_url: environmentUrl,
-                description: 'Preview deployed',
-              });
+            if (!deployment.data.id) {
+              core.warning(`createDeployment returned no id (HTTP ${deployment.status}): ${deployment.data.message ?? JSON.stringify(deployment.data)}`);
+              return;
             }
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: 'success',
+              environment_url: environmentUrl,
+              log_url: logUrl,
+              description: 'Preview deployed',
+            });
 
       # Publish edge routing only after a successful web build so a failed deploy cannot
       # replace live CloudFront function code while leaving stale or missing S3 assets.
@@ -409,12 +430,6 @@ jobs:
           PREVIEW_PREFIX: ${{ vars.PR_PREVIEW_PREFIX }}
           BOOTSTRAP_URL: ${{ needs.deploy-preview.outputs.bootstrap-url }}
           ACCESS_MODE: ${{ needs.deploy-preview.outputs.access-mode }}
-          SUPABASE_OUTCOME: ${{ needs.deploy-preview.outputs.supabase-outcome }}
-          STRIPE_SYNC_OUTCOME: ${{ needs.deploy-preview.outputs.stripe-sync-outcome }}
-          STRIPE_WEBHOOK_OUTCOME: ${{ needs.deploy-preview.outputs.stripe-webhook-outcome }}
-          BILLING_FUNCTIONS_OUTCOME: ${{ needs.deploy-preview.outputs.billing-functions-outcome }}
-          WEB_OUTCOME: ${{ needs.deploy-preview.outputs.web-outcome }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           MOBILE_JOB_RESULT: ${{ needs.deploy-preview-mobile.result }}
           MOBILE_CHANNEL: ${{ needs.deploy-preview-mobile.outputs.mobile-channel }}
           MOBILE_UPDATE_URL: ${{ needs.deploy-preview-mobile.outputs.mobile-update-url }}
@@ -428,110 +443,57 @@ jobs:
             const prefix = process.env.PREVIEW_PREFIX || 'pr-';
             const prNumber = context.payload.pull_request.number;
             const webUrl = domain ? `https://deploy.${domain}/${prefix}${prNumber}/` : '';
-            const runUrl = process.env.RUN_URL;
+            const mobileJobResult = process.env.MOBILE_JOB_RESULT;
+            const mobileChannel = process.env.MOBILE_CHANNEL;
+            const mobileUpdateUrl = process.env.MOBILE_UPDATE_URL;
+
             const bootstrapUrl = process.env.BOOTSTRAP_URL;
-            const isSignedCookies = process.env.ACCESS_MODE === 'signed-cookies';
-
-            const webOutcome          = process.env.WEB_OUTCOME;
-            const supabaseOutcome     = process.env.SUPABASE_OUTCOME;
-            const stripeSyncOutcome   = process.env.STRIPE_SYNC_OUTCOME;
-            const stripeWebhookOutcome = process.env.STRIPE_WEBHOOK_OUTCOME;
-            const billingFnsOutcome   = process.env.BILLING_FUNCTIONS_OUTCOME;
-            const mobileJobResult     = process.env.MOBILE_JOB_RESULT;
-            const mobileChannel       = process.env.MOBILE_CHANNEL;
-            const mobileUpdateUrl     = process.env.MOBILE_UPDATE_URL;
-
-            function statusCell(outcome, successLabel) {
-              if (outcome === 'success')   return `✅ ${successLabel}`;
-              if (outcome === 'failure')   return '❌ Failed';
-              if (outcome === 'skipped')   return '⏭️ Skipped';
-              if (outcome === 'cancelled') return '🚫 Cancelled';
-              return '—';
-            }
-
-            // Aggregate billing: any failure beats all; then cancelled; then success
-            const billingOutcomes = [stripeSyncOutcome, stripeWebhookOutcome, billingFnsOutcome];
-            let billingStatus;
-            if (billingOutcomes.some(o => o === 'failure'))        billingStatus = 'failure';
-            else if (billingOutcomes.some(o => o === 'cancelled')) billingStatus = 'cancelled';
-            else if (billingOutcomes.every(o => o === 'success'))  billingStatus = 'success';
-            else billingStatus = billingOutcomes.find(o => o && o !== 'success') || 'success';
-
-            const logsLink = `[View logs](${runUrl})`;
-            const webLink = (() => {
-              if (webOutcome !== 'success') return logsLink;
-              if (isSignedCookies && bootstrapUrl)
-                return `[Access preview →](${bootstrapUrl}) _(sets cookie, expires 7 days)_`;
-              return webUrl ? `[Preview →](${webUrl})` : '—';
-            })();
-
-            const mobileStatus =
-              mobileJobResult === 'skipped' ? 'skipped' :
-              (mobileJobResult === 'success' && !mobileUpdateUrl) ? 'skipped' :
-              mobileJobResult || 'skipped';
-            const mobileLinkCell = mobileJobResult === 'failure' ? logsLink : '—';
-
-            const table = [
-              '| Component | Status | Link |',
-              '|-----------|--------|------|',
-              `| 🌐 Web | ${statusCell(webOutcome, 'Deployed')} | ${webLink} |`,
-              `| 🗄️ Database | ${statusCell(supabaseOutcome, 'Migrated')} | ${supabaseOutcome === 'failure' ? logsLink : '—'} |`,
-              `| 💳 Billing | ${statusCell(billingStatus, 'Deployed')} | ${billingStatus === 'failure' ? logsLink : '—'} |`,
-              `| 📱 Mobile | ${statusCell(mobileStatus, 'Deployed')} | ${mobileLinkCell} |`,
-            ].join('\n');
-
-            // HH:MM PT timestamp
-            const now = new Date();
-            const timeStr = now.toLocaleString('en-US', {
-              timeZone: 'America/Los_Angeles',
-              hour: '2-digit',
-              minute: '2-digit',
-              hour12: false,
-            });
-            const tzStr = now.toLocaleString('en-US', {
-              timeZone: 'America/Los_Angeles',
-              timeZoneName: 'short',
-            }).split(', ').pop().split(' ').pop();
-
             const lines = [];
-            lines.push(marker);
-            lines.push('');
-            lines.push(table);
-            lines.push('');
-            lines.push(`_Last deployed: ${timeStr} ${tzStr}_`);
-
-            // Mobile detail section — only when mobile succeeded with an update URL
-            if (mobileJobResult !== 'skipped' && mobileJobResult !== 'failure' && mobileUpdateUrl) {
+            lines.push('<!-- pr-preview-links -->');
+            if (webUrl || bootstrapUrl) {
+              const isSignedCookies = process.env.ACCESS_MODE === 'signed-cookies';
+              if (isSignedCookies && bootstrapUrl) {
+                lines.push(`🔐 **Web preview (access link):** ${bootstrapUrl}`);
+                lines.push('');
+                lines.push('> _Click the link above to set your access cookie, then browse the preview. The link expires in 7 days._');
+              } else {
+                lines.push(`🌐 **Web preview:** ${webUrl}`);
+              }
+            }
+            if (mobileJobResult === 'skipped') {
+              // Mobile disabled via MOBILE_ENABLED=false — omit mobile section
+            } else if (mobileJobResult === 'failure') {
+              lines.push('');
+              lines.push('❌ **Mobile preview failed.** Check the **deploy-preview-mobile** job logs for details.');
+            } else if (mobileUpdateUrl) {
               const iosDownloadUrl = process.env.MOBILE_IOS_DOWNLOAD_URL;
               const androidDownloadUrl = process.env.MOBILE_ANDROID_DOWNLOAD_URL;
               const needsNativeBuild = process.env.NEEDS_NATIVE_BUILD === 'true';
-
-              lines.push('');
-              lines.push('---');
-              lines.push('');
+              
               lines.push(`📱 **Mobile preview:** Channel \`${mobileChannel}\``);
               lines.push('');
-
+              
+              // Show native build downloads if available
               if (iosDownloadUrl || androidDownloadUrl) {
                 lines.push('### 📱 Mobile Preview Builds');
                 lines.push('');
                 lines.push('**Native builds are available for download:**');
                 lines.push('');
-
+                
                 if (iosDownloadUrl) {
                   lines.push('**iOS Simulator Build:**');
                   lines.push(`- [Download .app file](${iosDownloadUrl})`);
                   lines.push('- Install with: `xcrun simctl install booted ~/Downloads/BeakerStack.app`');
                   lines.push('');
                 }
-
+                
                 if (androidDownloadUrl) {
                   lines.push('**Android Build (Device & Emulator):**');
                   lines.push(`- [Download .apk file](${androidDownloadUrl})`);
                   lines.push('- Install with: `adb install ~/Downloads/BeakerStack.apk`');
                   lines.push('');
                 }
-
+                
                 lines.push('**Note:** These builds include the preview Supabase configuration and are ready to use.');
                 lines.push('');
               } else if (needsNativeBuild) {
@@ -565,11 +527,23 @@ jobs:
                 lines.push(`**Alternative:** For local development, use: \`cd apps/mobile && npx expo start --dev-client\`, then press 'i' for iOS simulator.`);
                 lines.push('');
               }
-
+              
               lines.push('📖 See [Mobile Build Testing Guide](../../docs/MOBILE_BUILD_TESTING.md) for detailed instructions.');
             }
+            let body = lines.join('\n');
 
-            const body = lines.join('\n');
+            // Add timestamp in Pacific time
+            const now = new Date();
+            const pacificTime = now.toLocaleString('en-US', {
+              timeZone: 'America/Los_Angeles',
+              dateStyle: 'long',
+              timeStyle: 'short'
+            });
+            const timezone = now.toLocaleString('en-US', {
+              timeZone: 'America/Los_Angeles',
+              timeZoneName: 'short'
+            }).split(' ').pop();
+            body = `${body}\n\n---\n\n_Updated at: ${pacificTime} ${timezone}_`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -595,52 +569,6 @@ jobs:
                 body,
               });
             }
-
-  lighthouse:
-    if: >-
-      github.event.action != 'closed' &&
-      needs.deploy-preview.result == 'success' &&
-      needs.deploy-preview.outputs.access-mode != 'signed-cookies'
-    needs: [deploy-preview]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install @lhci/cli
-        run: npm install -g @lhci/cli@0.14
-
-      - name: Warm up preview URL
-        env:
-          PREVIEW_DOMAIN: ${{ vars.PR_PREVIEW_DOMAIN }}
-          PREVIEW_PREFIX: ${{ vars.PR_PREVIEW_PREFIX }}
-        run: |
-          set -euo pipefail
-          PREVIEW_PREFIX_VALUE="${PREVIEW_PREFIX:-pr-}"
-          URL="https://deploy.${PREVIEW_DOMAIN}/${PREVIEW_PREFIX_VALUE}${{ github.event.pull_request.number }}/"
-          echo "Warming up ${URL}"
-          curl -sf --max-time 30 --retry 5 --retry-delay 5 --retry-all-errors "${URL}" -o /dev/null
-          sleep 5
-
-      - name: Run Lighthouse CI
-        env:
-          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
-          PREVIEW_DOMAIN: ${{ vars.PR_PREVIEW_DOMAIN }}
-          PREVIEW_PREFIX: ${{ vars.PR_PREVIEW_PREFIX }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${LHCI_GITHUB_APP_TOKEN:-}" ]]; then
-            echo "LHCI_GITHUB_APP_TOKEN not set — skipping Lighthouse CI."
-            exit 0
-          fi
-          PREVIEW_PREFIX_VALUE="${PREVIEW_PREFIX:-pr-}"
-          URL="https://deploy.${PREVIEW_DOMAIN}/${PREVIEW_PREFIX_VALUE}${{ github.event.pull_request.number }}/"
-          lhci autorun --collect.url="${URL}"
 
   teardown-preview:
     if: github.event.action == 'closed' && (github.base_ref != 'develop' || github.head_ref != 'main')


### PR DESCRIPTION
## Summary

Fixes three issues that caused the PR Deployments panel to show nothing after a successful web preview deploy.

**Root causes fixed:**

- **Silent 202 drop**: `createDeployment` can return HTTP 202 (not 201) when the request can't be immediately fulfilled (environment rules, duplicate, etc.). `deployment.data` has a `message` field and no `id` in that case — the previous `if (deployment.data.id)` check silently skipped `createDeploymentStatus`, so no deployment ever appeared in the PR UI. Now logs a warning with the API response instead.
- **Stale rows on re-runs**: Each push created a new deployment row without deactivating the previous one. Now lists existing deployments for the same environment and marks them `inactive` before creating a fresh one — keeps the PR Deployments panel to one active row per PR.
- **Fork PRs**: `pull_request` events from forks run with a read-only token; `deployments: write` in the workflow header doesn't apply. Now detects fork PRs early and exits cleanly with a log message instead of failing silently.

**Also added:** `log_url` on `createDeploymentStatus` so the deployment row in GitHub's UI links directly to the Actions run that produced it.

**No changes to:** the sticky PR comment block, any other job, or deployment naming.

## Plan quote
> A. Fork guard + graceful error handling
> B. Deactivate previous deployments
> C. Fix the 202 / no-id case
> D. Add log_url

Closes #140

## Test plan
- [ ] Open or push to a same-repo PR into `develop` — deployment appears in PR Deployments panel with working link
- [ ] Push again — only one active row (previous marked inactive)
- [ ] Fork PR — CI step logs skip message, no error
- [ ] Existing sticky comment still posts/updates unchanged