### PR TITLE
fix(web): decorative nav logo alt for a11y (#145)

### DIFF
--- a/apps/web/src/components/landing/sections/Nav.tsx
+++ b/apps/web/src/components/landing/sections/Nav.tsx
@@ -34,7 +34,7 @@ export function Nav({ config }: NavProps) {
     >
       <div className='max-w-[1200px] mx-auto px-6 flex items-center justify-between h-16'>
         <Link to='/' className='flex items-center gap-2'>
-          <img src={logoSrc} alt={config.brand.name} className='w-8 h-8' />
+          <img src={logoSrc} alt='' className='w-8 h-8' />
           <span className='font-semibold text-lg text-gray-900 dark:text-white'>
             {config.brand.name}
           </span>

--- a/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
@@ -47,7 +47,13 @@ describe('Nav', () => {
         <Nav config={configNoLogo} />
       </MemoryRouter>
     );
-    const img = screen.getByRole('img', { name: 'BeakerStack' });
+    const brandLink = screen.getByRole('link', { name: 'BeakerStack' });
+    const img = brandLink.querySelector('img');
+    expect(img).not.toBeNull();
+    if (!img) {
+      throw new Error('expected brand logo img');
+    }
+    expect(img.getAttribute('alt')).toBe('');
     expect(img.getAttribute('src')).toBe('/pr-42/demo-flask-icon.svg');
     Object.defineProperty(window, 'location', {
       configurable: true,

--- a/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/Nav.test.tsx
@@ -49,7 +49,6 @@ describe('Nav', () => {
     );
     const brandLink = screen.getByRole('link', { name: 'BeakerStack' });
     const img = brandLink.querySelector('img');
-    expect(img).not.toBeNull();
     if (!img) {
       throw new Error('expected brand logo img');
     }


### PR DESCRIPTION
## Summary

Resolves redundant accessible text on the landing nav brand mark (Lighthouse/axe **image-redundant-alt**).

## Changes

- Set the logo `<img>` to `alt=""` in `Nav.tsx` so the link name comes from the adjacent brand text only.
- Update the PR-preview logo path test to locate the image via the brand link and assert empty `alt`, without non-null assertions (ESLint).

## Verification

- `eslint` clean on touched files; pre-commit hooks passed on commit.

Closes #145