### PR TITLE
feat(infra): CSP report-only mode (issue #144 Phase 1)

### DIFF
--- a/.github/workflows/check-csp-hash.yml
+++ b/.github/workflows/check-csp-hash.yml
@@ -1,0 +1,32 @@
+name: Check CSP Hash
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - 'apps/web/index.html'
+      - 'infra/aws/pr-preview-stack.yml'
+      - 'scripts/check-csp-hash.mjs'
+  pull_request:
+    paths:
+      - 'apps/web/index.html'
+      - 'infra/aws/pr-preview-stack.yml'
+      - 'scripts/check-csp-hash.mjs'
+      - '.github/workflows/check-csp-hash.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check-csp-hash:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Verify CSP inline-script hash
+        run: node scripts/check-csp-hash.mjs

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -8,7 +8,7 @@
     <!-- Anti-FOUC: apply dark class before first paint.
          Reads stored user preference first; falls back to OS preference.
          try/catch guards against CSP or private-browsing environments. -->
-    <script>
+    <script id="csp-inline-theme">
       (function () {
         try {
           var stored = localStorage.getItem('beakerstack:theme');

--- a/infra/aws/pr-preview-stack.yml
+++ b/infra/aws/pr-preview-stack.yml
@@ -478,6 +478,39 @@ Resources:
         Items:
           - !Ref CloudFrontSigningPublicKeyId
 
+  # Custom response headers policy — replicates the AWS managed SecurityHeadersPolicy
+  # (67f7725c-6f97-4210-82d7-5512b31e9d03) and adds Content-Security-Policy-Report-Only
+  # for Phase 1 violation monitoring before enforcement (issue #144).
+  # Phase 2 (issue #153): move CSP to SecurityHeadersConfig.ContentSecurityPolicy.
+  BeakerStackResponseHeadersPolicy:
+    Type: AWS::CloudFront::ResponseHeadersPolicy
+    Properties:
+      ResponseHeadersPolicyConfig:
+        Name: !Sub 'BeakerStack-SecurityHeaders-${AWS::StackName}'
+        SecurityHeadersConfig:
+          StrictTransportSecurity:
+            AccessControlMaxAgeSec: 63072000
+            IncludeSubdomains: true
+            Preload: true
+            Override: true
+          ContentTypeOptions:
+            Override: true
+          FrameOptions:
+            FrameOption: SAMEORIGIN
+            Override: true
+          ReferrerPolicy:
+            ReferrerPolicy: same-origin
+            Override: true
+          XSSProtection:
+            ModeBlock: true
+            Protection: true
+            Override: true
+        CustomHeadersConfig:
+          Items:
+            - Header: Content-Security-Policy-Report-Only
+              Value: "default-src 'self'; script-src 'self' 'sha256-FIEUlQEkz8Wc0NMOe90xjaENbkODxpO7+UD6KIqw/Ac='; connect-src 'self' https://*.supabase.co wss://*.supabase.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://placehold.co; font-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+              Override: true
+
   # Production CloudFront Distribution (beakerstack.com)
   ProdDistribution:
     Type: AWS::CloudFront::Distribution
@@ -504,7 +537,7 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
           Compress: true
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # CachingOptimized
-          ResponseHeadersPolicyId: 67f7725c-6f97-4210-82d7-5512b31e9d03 # SecurityHeadersPolicy
+          ResponseHeadersPolicyId: !Ref BeakerStackResponseHeadersPolicy
           # SPA fallback for client-side routing
           FunctionAssociations:
             - EventType: viewer-request
@@ -564,7 +597,7 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
           Compress: true
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # CachingOptimized
-          ResponseHeadersPolicyId: 67f7725c-6f97-4210-82d7-5512b31e9d03 # SecurityHeadersPolicy
+          ResponseHeadersPolicyId: !Ref BeakerStackResponseHeadersPolicy
           # SPA fallback for client-side routing
           FunctionAssociations:
             - EventType: viewer-request
@@ -629,7 +662,7 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
           Compress: true
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # CachingOptimized
-          ResponseHeadersPolicyId: 67f7725c-6f97-4210-82d7-5512b31e9d03 # SecurityHeadersPolicy
+          ResponseHeadersPolicyId: !Ref BeakerStackResponseHeadersPolicy
           # PRPathRouter handles /pr-N/* → S3 prefix routing
           FunctionAssociations:
             - EventType: viewer-request

--- a/scripts/check-csp-hash.mjs
+++ b/scripts/check-csp-hash.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Verifies that the SHA-256 hash of the inline theme script in apps/web/index.html
+ * matches the value recorded in the active CSP directive in
+ * infra/aws/pr-preview-stack.yml.
+ *
+ * Works for both phases:
+ *   Phase 1 (report-only): hash must appear in the Content-Security-Policy-Report-Only
+ *                          value under CustomHeadersConfig.
+ *   Phase 2 (enforcement): hash must appear in the ContentSecurityPolicy value under
+ *                          SecurityHeadersConfig.
+ *
+ * Run: node scripts/check-csp-hash.mjs
+ * CI: triggered on changes to index.html or pr-preview-stack.yml
+ */
+import { createHash } from 'crypto';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const htmlPath = resolve(root, 'apps/web/index.html');
+const cfnPath = resolve(root, 'infra/aws/pr-preview-stack.yml');
+
+const html = readFileSync(htmlPath, 'utf8');
+const cfn = readFileSync(cfnPath, 'utf8');
+
+// Extract content between <script id="csp-inline-theme"> and </script>
+const scriptMatch = html.match(/<script\b[^>]*\bid="csp-inline-theme"[^>]*>([\s\S]*?)<\/script>/);
+if (!scriptMatch) {
+  console.error('ERROR: <script id="csp-inline-theme"> not found in apps/web/index.html');
+  console.error('Add that id attribute to the inline theme script so this check can locate it.');
+  process.exit(1);
+}
+
+const hash = createHash('sha256').update(scriptMatch[1], 'utf8').digest('base64');
+const hashToken = `'sha256-${hash}'`;
+
+// Phase 1: Content-Security-Policy-Report-Only in CustomHeadersConfig
+// Matches: "- Header: Content-Security-Policy-Report-Only\n  Value: "..."
+const reportOnlyMatch = cfn.match(
+  /- Header:\s+Content-Security-Policy-Report-Only\s+Value:\s+"([^"]+)"/
+);
+
+// Phase 2: ContentSecurityPolicy in SecurityHeadersConfig
+// Matches: "ContentSecurityPolicy: "..."" (indented, within SecurityHeadersConfig block)
+const enforcementMatch = cfn.match(
+  /ContentSecurityPolicy:\s+"([^"]+)"/
+);
+
+const activeMatch = reportOnlyMatch || enforcementMatch;
+
+if (!activeMatch) {
+  console.error('ERROR: No CSP directive found in infra/aws/pr-preview-stack.yml.');
+  console.error('Expected either:');
+  console.error('  - Header: Content-Security-Policy-Report-Only  (Phase 1 / report-only)');
+  console.error('  - ContentSecurityPolicy: "..."                 (Phase 2 / enforcement)');
+  process.exit(1);
+}
+
+const cspValue = activeMatch[1];
+const phase = reportOnlyMatch ? 'Phase 1 (Content-Security-Policy-Report-Only)' : 'Phase 2 (ContentSecurityPolicy)';
+const location = reportOnlyMatch
+  ? 'CustomHeadersConfig → Content-Security-Policy-Report-Only Value'
+  : 'SecurityHeadersConfig → ContentSecurityPolicy';
+
+if (!cspValue.includes(hashToken)) {
+  console.error(`FAIL: CSP hash mismatch in ${phase}.\n`);
+  console.error('The inline theme script in apps/web/index.html has changed (or the hash');
+  console.error(`in infra/aws/pr-preview-stack.yml is stale).\n`);
+  console.error(`Update the sha256-... token in ${location}`);
+  console.error(`in infra/aws/pr-preview-stack.yml to:\n`);
+  console.error(`  ${hashToken}\n`);
+  process.exit(1);
+}
+
+console.log(`OK: CSP inline-script hash matches in ${phase} (${hashToken})`);


### PR DESCRIPTION
## Summary

- Replaces the AWS managed `SecurityHeadersPolicy` (`67f7725c-...`) with a custom `AWS::CloudFront::ResponseHeadersPolicy` across all three CloudFront distributions (Prod, Staging, Deploy/Preview)
- New policy replicates all existing security headers (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, X-XSS-Protection) and adds a `Content-Security-Policy-Report-Only` header for Phase 1 violation monitoring
- Adds `id="csp-inline-theme"` to the anti-FOUC inline script in `index.html` so the CI hash check can locate it reliably
- Adds `scripts/check-csp-hash.mjs` + `.github/workflows/check-csp-hash.yml` — CI asserts the inline script SHA-256 matches the hash in the CloudFormation policy; prints the corrected hash and instructions if it fails

## CSP string

```
default-src 'self';
script-src 'self' 'sha256-FIEUlQEkz8Wc0NMOe90xjaENbkODxpO7+UD6KIqw/Ac=';
connect-src 'self' https://*.supabase.co wss://*.supabase.co;
style-src 'self' 'unsafe-inline';
img-src 'self' data: https://placehold.co;
font-src 'self';
object-src 'none';
frame-ancestors 'none';
base-uri 'self';
form-action 'self'
```

The `sha256-...` value covers the exact bytes of the anti-FOUC theme script in `index.html` — no `unsafe-inline` needed in `script-src`.

## Test plan

- [ ] Deploy to staging and check browser console for any CSP violations across auth, billing, and dashboard flows
- [ ] Confirm `Content-Security-Policy-Report-Only` header is present in CloudFront responses
- [ ] Run the CI hash check locally: `node scripts/check-csp-hash.mjs`
- [ ] Monitor 24–72 hours of staging traffic for violations before approving Phase 2 (#153)

Closes #144 (Phase 1). Phase 2 enforcement tracked in #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)