### PR TITLE
fix(cdn): HTTP/2+3 for all CloudFront distributions and cache headers for robots.txt (#143)

### DIFF
--- a/infra/aws/functions/PRPathRouter.js
+++ b/infra/aws/functions/PRPathRouter.js
@@ -16,10 +16,7 @@ function handler(event) {
     return {
       statusCode: 200,
       statusDescription: 'OK',
-      headers: {
-      'content-type': { value: 'text/plain' },
-      'cache-control': { value: 'public, max-age=3600' },
-    },
+      headers: { 'content-type': { value: 'text/plain' } },
       body: 'User-agent: *\nDisallow: /\nAllow: /' + previewPrefixBase + '\n',
     };
   }

--- a/infra/aws/functions/PRPathRouter.js
+++ b/infra/aws/functions/PRPathRouter.js
@@ -16,7 +16,10 @@ function handler(event) {
     return {
       statusCode: 200,
       statusDescription: 'OK',
-      headers: { 'content-type': { value: 'text/plain' } },
+      headers: {
+      'content-type': { value: 'text/plain' },
+      'cache-control': { value: 'public, max-age=3600' },
+    },
       body: 'User-agent: *\nDisallow: /\nAllow: /' + previewPrefixBase + '\n',
     };
   }

--- a/infra/aws/pr-preview-stack.yml
+++ b/infra/aws/pr-preview-stack.yml
@@ -478,6 +478,39 @@ Resources:
         Items:
           - !Ref CloudFrontSigningPublicKeyId
 
+  # Custom response headers policy — replicates the AWS managed SecurityHeadersPolicy
+  # (67f7725c-6f97-4210-82d7-5512b31e9d03) and adds Content-Security-Policy-Report-Only
+  # for Phase 1 violation monitoring before enforcement (issue #144).
+  # Phase 2 (issue #153): move CSP to SecurityHeadersConfig.ContentSecurityPolicy.
+  BeakerStackResponseHeadersPolicy:
+    Type: AWS::CloudFront::ResponseHeadersPolicy
+    Properties:
+      ResponseHeadersPolicyConfig:
+        Name: !Sub 'BeakerStack-SecurityHeaders-${AWS::StackName}'
+        SecurityHeadersConfig:
+          StrictTransportSecurity:
+            AccessControlMaxAgeSec: 63072000
+            IncludeSubdomains: true
+            Preload: true
+            Override: true
+          ContentTypeOptions:
+            Override: true
+          FrameOptions:
+            FrameOption: SAMEORIGIN
+            Override: true
+          ReferrerPolicy:
+            ReferrerPolicy: same-origin
+            Override: true
+          XSSProtection:
+            ModeBlock: true
+            Protection: true
+            Override: true
+        CustomHeadersConfig:
+          Items:
+            - Header: Content-Security-Policy-Report-Only
+              Value: "default-src 'self'; script-src 'self' 'sha256-FIEUlQEkz8Wc0NMOe90xjaENbkODxpO7+UD6KIqw/Ac='; connect-src 'self' https://*.supabase.co wss://*.supabase.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://placehold.co; font-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+              Override: true
+
   # Production CloudFront Distribution (beakerstack.com)
   ProdDistribution:
     Type: AWS::CloudFront::Distribution
@@ -505,7 +538,7 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
           Compress: true
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # CachingOptimized
-          ResponseHeadersPolicyId: 67f7725c-6f97-4210-82d7-5512b31e9d03 # SecurityHeadersPolicy
+          ResponseHeadersPolicyId: !Ref BeakerStackResponseHeadersPolicy
           # SPA fallback for client-side routing
           FunctionAssociations:
             - EventType: viewer-request
@@ -566,7 +599,7 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
           Compress: true
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # CachingOptimized
-          ResponseHeadersPolicyId: 67f7725c-6f97-4210-82d7-5512b31e9d03 # SecurityHeadersPolicy
+          ResponseHeadersPolicyId: !Ref BeakerStackResponseHeadersPolicy
           # SPA fallback for client-side routing
           FunctionAssociations:
             - EventType: viewer-request
@@ -632,7 +665,7 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
           Compress: true
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # CachingOptimized
-          ResponseHeadersPolicyId: 67f7725c-6f97-4210-82d7-5512b31e9d03 # SecurityHeadersPolicy
+          ResponseHeadersPolicyId: !Ref BeakerStackResponseHeadersPolicy
           # PRPathRouter handles /pr-N/* → S3 prefix routing
           FunctionAssociations:
             - EventType: viewer-request

--- a/infra/aws/pr-preview-stack.yml
+++ b/infra/aws/pr-preview-stack.yml
@@ -478,45 +478,13 @@ Resources:
         Items:
           - !Ref CloudFrontSigningPublicKeyId
 
-  # Custom response headers policy — replicates the AWS managed SecurityHeadersPolicy
-  # (67f7725c-6f97-4210-82d7-5512b31e9d03) and adds Content-Security-Policy-Report-Only
-  # for Phase 1 violation monitoring before enforcement (issue #144).
-  # Phase 2 (issue #153): move CSP to SecurityHeadersConfig.ContentSecurityPolicy.
-  BeakerStackResponseHeadersPolicy:
-    Type: AWS::CloudFront::ResponseHeadersPolicy
-    Properties:
-      ResponseHeadersPolicyConfig:
-        Name: !Sub 'BeakerStack-SecurityHeaders-${AWS::StackName}'
-        SecurityHeadersConfig:
-          StrictTransportSecurity:
-            AccessControlMaxAgeSec: 63072000
-            IncludeSubdomains: true
-            Preload: true
-            Override: true
-          ContentTypeOptions:
-            Override: true
-          FrameOptions:
-            FrameOption: SAMEORIGIN
-            Override: true
-          ReferrerPolicy:
-            ReferrerPolicy: same-origin
-            Override: true
-          XSSProtection:
-            ModeBlock: true
-            Protection: true
-            Override: true
-        CustomHeadersConfig:
-          Items:
-            - Header: Content-Security-Policy-Report-Only
-              Value: "default-src 'self'; script-src 'self' 'sha256-FIEUlQEkz8Wc0NMOe90xjaENbkODxpO7+UD6KIqw/Ac='; connect-src 'self' https://*.supabase.co wss://*.supabase.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://placehold.co; font-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
-              Override: true
-
   # Production CloudFront Distribution (beakerstack.com)
   ProdDistribution:
     Type: AWS::CloudFront::Distribution
     Properties:
       DistributionConfig:
         Enabled: true
+        HttpVersion: http2and3
         Comment: !Sub 'Production distribution for ${DomainName}'
         DefaultRootObject: index.html
         Aliases:
@@ -537,7 +505,7 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
           Compress: true
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # CachingOptimized
-          ResponseHeadersPolicyId: !Ref BeakerStackResponseHeadersPolicy
+          ResponseHeadersPolicyId: 67f7725c-6f97-4210-82d7-5512b31e9d03 # SecurityHeadersPolicy
           # SPA fallback for client-side routing
           FunctionAssociations:
             - EventType: viewer-request
@@ -563,6 +531,7 @@ Resources:
     Properties:
       DistributionConfig:
         Enabled: true
+        HttpVersion: http2and3
         Comment: !Sub 'Staging distribution for ${DomainName}'
         DefaultRootObject: index.html
         Aliases:
@@ -597,7 +566,7 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
           Compress: true
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # CachingOptimized
-          ResponseHeadersPolicyId: !Ref BeakerStackResponseHeadersPolicy
+          ResponseHeadersPolicyId: 67f7725c-6f97-4210-82d7-5512b31e9d03 # SecurityHeadersPolicy
           # SPA fallback for client-side routing
           FunctionAssociations:
             - EventType: viewer-request
@@ -628,6 +597,7 @@ Resources:
     Properties:
       DistributionConfig:
         Enabled: true
+        HttpVersion: http2and3
         Comment: !Sub 'Preview/Deploy distribution for ${DomainName} with path-based PR routing'
         DefaultRootObject: index.html
         Aliases:
@@ -662,7 +632,7 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
           Compress: true
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # CachingOptimized
-          ResponseHeadersPolicyId: !Ref BeakerStackResponseHeadersPolicy
+          ResponseHeadersPolicyId: 67f7725c-6f97-4210-82d7-5512b31e9d03 # SecurityHeadersPolicy
           # PRPathRouter handles /pr-N/* → S3 prefix routing
           FunctionAssociations:
             - EventType: viewer-request


### PR DESCRIPTION
Closes #143

## What

Two targeted fixes for the Lighthouse HTTP/1.1 and Cache TTL issues.

## Root causes & fixes

**HTTP/1.1 (7 requests)**

`HttpVersion` was not set on any of the three CloudFront distributions (`ProdDistribution`, `StagingDistribution`, `DeployDistribution`) in `infra/aws/pr-preview-stack.yml`. AWS CloudFront defaults to `http1.1` when the field is absent — this single missing field accounts for all 7 HTTP/1.1 requests in the report.

Fix: add `HttpVersion: http2and3` to each `DistributionConfig`. CloudFormation applies the change on the next stack update, which the existing `bootstrap-aws-stack.sh` script runs automatically on each PR deploy.

**Cache TTL: None**

The deploy script already sets correct `Cache-Control` metadata on S3 objects (`public,max-age=31536000,immutable` for hashed assets, `public,max-age=60` for HTML). The uncached response was the synthetic `/robots.txt` added in #152 — the CloudFront Function returned no `Cache-Control` header.

Fix: add `cache-control: public, max-age=3600` to the robots.txt synthetic response in `PRPathRouter.js`. 1-hour TTL is appropriate — the content is stable but shouldn't be cached indefinitely.

## Changes

| File | Change |
|---|---|
| `infra/aws/pr-preview-stack.yml` | `HttpVersion: http2and3` on all 3 distributions |
| `infra/aws/functions/PRPathRouter.js` | `cache-control: public, max-age=3600` on robots.txt synthetic response |

## No changes needed

- `scripts/pr-preview/deploy-web.sh` — S3 cache headers already correct
- `apps/web/vite.config.ts` — Vite asset fingerprinting already in use
