### PR TITLE
perf: code splitting, CLS fix, self-hosted placeholders (issue #146 A+B+C)

### DIFF
--- a/apps/web/public/placeholder-feature.svg
+++ b/apps/web/public/placeholder-feature.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="560" height="315" viewBox="0 0 560 315">
+  <rect width="560" height="315" fill="#e5e7eb"/>
+  <text x="280" y="157" font-family="system-ui,sans-serif" font-size="18" fill="#9ca3af" text-anchor="middle" dominant-baseline="middle">Screenshot coming soon</text>
+</svg>

--- a/apps/web/public/placeholder-hero.svg
+++ b/apps/web/public/placeholder-hero.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="338" viewBox="0 0 600 338">
+  <rect width="600" height="338" fill="#e5e7eb"/>
+  <text x="300" y="169" font-family="system-ui,sans-serif" font-size="18" fill="#9ca3af" text-anchor="middle" dominant-baseline="middle">Screenshot coming soon</text>
+</svg>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,18 +3,18 @@ import { Routes, Route, Outlet } from 'react-router-dom';
 import { ProtectedRoute } from '@beakerstack/shared/components/auth/ProtectedRoute.web';
 import { BillingProviderLayout } from './billing/BillingProviderLayout';
 import { AppFooter } from './components/AppFooter';
-import LoginPage from './pages/LoginPage';
-import SignupPage from './pages/SignupPage';
-import DashboardPage from './pages/DashboardPage';
-import ProfilePage from './pages/ProfilePage';
-import AuthCallbackPage from './pages/AuthCallbackPage';
-import PolicyPage from './pages/PolicyPage';
-import BillingOverviewPage from './pages/billing/BillingOverviewPage';
-import BillingUsagePage from './pages/billing/BillingUsagePage';
-import BillingPlansPage from './pages/billing/BillingPlansPage';
-import BillingInvoicesPage from './pages/billing/BillingInvoicesPage';
 
 const HomePage = lazy(() => import('./pages/HomePage'));
+const LoginPage = lazy(() => import('./pages/LoginPage'));
+const SignupPage = lazy(() => import('./pages/SignupPage'));
+const DashboardPage = lazy(() => import('./pages/DashboardPage'));
+const ProfilePage = lazy(() => import('./pages/ProfilePage'));
+const AuthCallbackPage = lazy(() => import('./pages/AuthCallbackPage'));
+const PolicyPage = lazy(() => import('./pages/PolicyPage'));
+const BillingOverviewPage = lazy(() => import('./pages/billing/BillingOverviewPage'));
+const BillingUsagePage = lazy(() => import('./pages/billing/BillingUsagePage'));
+const BillingPlansPage = lazy(() => import('./pages/billing/BillingPlansPage'));
+const BillingInvoicesPage = lazy(() => import('./pages/billing/BillingInvoicesPage'));
 
 function RootLayout() {
   return (
@@ -30,50 +30,45 @@ function RootLayout() {
 function App() {
   return (
     <div className='bg-gray-50 dark:bg-gray-900'>
-      <Routes>
-        <Route element={<RootLayout />}>
-          <Route
-            path='/'
-            element={
-              <Suspense fallback={null}>
-                <HomePage />
-              </Suspense>
-            }
-          />
-          <Route path='/login' element={<LoginPage />} />
-          <Route path='/signup' element={<SignupPage />} />
-          <Route path='/terms' element={<PolicyPage policy='terms' />} />
-          <Route path='/privacy' element={<PolicyPage policy='privacy' />} />
-          <Route path='/refunds' element={<PolicyPage policy='refunds' />} />
-          <Route
-            path='/profile'
-            element={
-              <ProtectedRoute>
-                <ProfilePage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            element={
-              <ProtectedRoute>
-                <Outlet />
-              </ProtectedRoute>
-            }
-          >
-            <Route element={<BillingProviderLayout />}>
-              <Route path='/dashboard' element={<DashboardPage />} />
-              <Route path='/billing' element={<BillingOverviewPage />} />
-              <Route path='/billing/usage' element={<BillingUsagePage />} />
-              <Route path='/billing/plans' element={<BillingPlansPage />} />
-              <Route
-                path='/billing/invoices'
-                element={<BillingInvoicesPage />}
-              />
+      <Suspense fallback={null}>
+        <Routes>
+          <Route element={<RootLayout />}>
+            <Route path='/' element={<HomePage />} />
+            <Route path='/login' element={<LoginPage />} />
+            <Route path='/signup' element={<SignupPage />} />
+            <Route path='/terms' element={<PolicyPage policy='terms' />} />
+            <Route path='/privacy' element={<PolicyPage policy='privacy' />} />
+            <Route path='/refunds' element={<PolicyPage policy='refunds' />} />
+            <Route
+              path='/profile'
+              element={
+                <ProtectedRoute>
+                  <ProfilePage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              element={
+                <ProtectedRoute>
+                  <Outlet />
+                </ProtectedRoute>
+              }
+            >
+              <Route element={<BillingProviderLayout />}>
+                <Route path='/dashboard' element={<DashboardPage />} />
+                <Route path='/billing' element={<BillingOverviewPage />} />
+                <Route path='/billing/usage' element={<BillingUsagePage />} />
+                <Route path='/billing/plans' element={<BillingPlansPage />} />
+                <Route
+                  path='/billing/invoices'
+                  element={<BillingInvoicesPage />}
+                />
+              </Route>
             </Route>
+            <Route path='/auth/callback' element={<AuthCallbackPage />} />
           </Route>
-          <Route path='/auth/callback' element={<AuthCallbackPage />} />
-        </Route>
-      </Routes>
+        </Routes>
+      </Suspense>
     </div>
   );
 }

--- a/apps/web/src/components/landing/sections/PricingSection.tsx
+++ b/apps/web/src/components/landing/sections/PricingSection.tsx
@@ -31,7 +31,17 @@ function LandingPricingTable() {
 
   if (loading) {
     return (
-      <p className='mt-8 text-center text-sm text-gray-500'>Loading plans…</p>
+      <div
+        data-testid='pricing-skeleton'
+        className='grid grid-cols-1 gap-6 md:grid-cols-3'
+      >
+        {[0, 1, 2].map(i => (
+          <div
+            key={i}
+            className='h-96 rounded-xl border border-gray-200 bg-white animate-pulse dark:border-gray-700 dark:bg-gray-800'
+          />
+        ))}
+      </div>
     );
   }
 

--- a/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
@@ -126,13 +126,13 @@ describe('PricingSection', () => {
     );
   });
 
-  it('shows loading message while plans are loading', () => {
+  it('shows skeleton while plans are loading', () => {
     vi.mocked(usePlanCatalog).mockReturnValue({
       plans: [],
       loading: true,
     } as unknown as ReturnType<typeof usePlanCatalog>);
     renderSection();
-    expect(screen.getByText(/Loading plans/)).toBeInTheDocument();
+    expect(screen.getByTestId('pricing-skeleton')).toBeInTheDocument();
     expect(screen.queryByTestId('plan-card-free')).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/config/landing.ts
+++ b/apps/web/src/config/landing.ts
@@ -14,6 +14,11 @@ import {
   Bot,
 } from 'lucide-react';
 
+function publicUrl(filename: string): string {
+  const base = (import.meta.env.BASE_URL ?? '/').replace(/\/$/, '');
+  return `${base}/${filename.replace(/^\//, '')}`;
+}
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export interface NavLink {
@@ -138,7 +143,7 @@ export const landingConfig: LandingConfig = {
       'BeakerStack gives you auth, billing, and a cross-platform React foundation — with a three-environment CI/CD pipeline, PR previews, and a layered test suite ready for production.',
     primaryCta: { label: 'Get started free', href: '/signup' },
     secondaryCta: { label: 'See features', href: '#features' },
-    mediaSrc: 'https://placehold.co/600x338?text=BeakerStack',
+    mediaSrc: publicUrl('placeholder-hero.svg'),
     mediaAlt: 'BeakerStack dashboard screenshot',
     trustStrip: 'Built on React, React Native, Supabase, and Stripe.',
   },
@@ -217,7 +222,7 @@ export const landingConfig: LandingConfig = {
       body: 'Shared auth logic. Shared billing hooks. Shared business rules. Your React web app and React Native mobile app stay in sync without duplicating work. About 40–60% of the codebase is shared across platforms.',
       ctaLabel: 'Learn about mobile',
       ctaHref: '#features',
-      mediaSrc: 'https://placehold.co/560x315?text=Mobile+App',
+      mediaSrc: publicUrl('placeholder-feature.svg'),
       mediaAlt: 'Mobile app screenshot',
       mediaSide: 'right',
     },
@@ -227,7 +232,7 @@ export const landingConfig: LandingConfig = {
       ctaLabel: 'Read the landing README',
       ctaHref:
         'https://github.com/Artificer-Innovations/BeakerStack/blob/main/apps/web/src/components/landing/README.md',
-      mediaSrc: 'https://placehold.co/560x315?text=Marketing+config',
+      mediaSrc: publicUrl('placeholder-feature.svg'),
       mediaAlt: 'Landing page config file screenshot',
       mediaSide: 'left',
     },
@@ -237,7 +242,7 @@ export const landingConfig: LandingConfig = {
       ctaLabel: 'See the prerender script',
       ctaHref:
         'https://github.com/Artificer-Innovations/BeakerStack/blob/main/apps/web/scripts/prerender-home.ts',
-      mediaSrc: 'https://placehold.co/560x315?text=SEO+prerender',
+      mediaSrc: publicUrl('placeholder-feature.svg'),
       mediaAlt: 'Pre-rendered HTML and meta tags screenshot',
       mediaSide: 'right',
     },
@@ -246,7 +251,7 @@ export const landingConfig: LandingConfig = {
       body: 'Most templates stop at "add Stripe." BeakerStack includes plan gating, usage metering, upgrade prompts, a billing portal, and downgrade blockers — all wired to real Stripe products and ready for your plans.',
       ctaLabel: 'See billing docs',
       ctaHref: '#pricing',
-      mediaSrc: 'https://placehold.co/560x315?text=Billing+UI',
+      mediaSrc: publicUrl('placeholder-feature.svg'),
       mediaAlt: 'Billing plans UI screenshot',
       mediaSide: 'left',
     },
@@ -256,7 +261,7 @@ export const landingConfig: LandingConfig = {
       ctaLabel: 'Read the architecture docs',
       ctaHref:
         'https://github.com/Artificer-Innovations/BeakerStack/blob/main/ARCHITECTURE.md',
-      mediaSrc: 'https://placehold.co/560x315?text=Environments',
+      mediaSrc: publicUrl('placeholder-feature.svg'),
       mediaAlt: 'Three-environment pipeline diagram',
       mediaSide: 'right',
     },
@@ -266,7 +271,7 @@ export const landingConfig: LandingConfig = {
       ctaLabel: 'Read the quickstart',
       ctaHref:
         'https://github.com/Artificer-Innovations/BeakerStack/blob/main/QUICKSTART.md',
-      mediaSrc: 'https://placehold.co/560x315?text=Setup',
+      mediaSrc: publicUrl('placeholder-feature.svg'),
       mediaAlt: 'Setup guide screenshot',
       mediaSide: 'left',
     },


### PR DESCRIPTION
## Summary

Closes #146 (sub-tasks A, B, C). Sub-task D (TTFB / Cache-Control headers) is tracked in #159.

### A — Code splitting with `React.lazy()` + `Suspense`

All route-level page components in `App.tsx` are now loaded with `React.lazy()` dynamic imports. A single `<Suspense fallback={null}>` wraps `<Routes>` so every route chunk loads on demand, reducing the initial JS bundle parse and execute time.

### B — Pricing section CLS fix

`PricingSection` previously showed a short `<p>Loading plans…</p>` while `usePlanCatalog` resolved, then expanded to a tall 3-column plan grid — causing a large layout shift (CLS). Replaced it with a 3-column animated skeleton (`h-96`, matching the loaded grid height) so the space is reserved up front. Updated the companion test to assert `data-testid="pricing-skeleton"` instead of the removed text node.

### C — Self-hosted placeholder images

Created `apps/web/public/placeholder-hero.svg` (600×338) and `apps/web/public/placeholder-feature.svg` (560×315) as same-origin replacements for the `https://placehold.co/…` third-party URLs in `landing.ts`.

All 7 `mediaSrc` values now use a `publicUrl(filename)` helper that prepends `import.meta.env.BASE_URL` with consistent slash normalisation — handles both `/` (production) and `/pr-158/` (path-prefixed previews) correctly:

```ts
function publicUrl(filename: string): string {
  const base = (import.meta.env.BASE_URL ?? '/').replace(/\/$/, '');
  return `${base}/${filename.replace(/^\//, '')}`;
}
```

Removing the `placehold.co` dependency also unblocks dropping the `https://placehold.co` entry from `img-src` in the CSP (PR #154) once this merges.

## Test plan

- [ ] `pnpm --filter web test` — all tests pass, including updated `PricingSection` skeleton assertion
- [ ] `pnpm --filter web build` — build succeeds; verify chunk output shows separate route chunks (e.g. `LoginPage-*.js`)
- [ ] Open landing page in preview — placeholder images load from `/pr-158/placeholder-hero.svg` and `/pr-158/placeholder-feature.svg` (no `placehold.co` network requests)
- [ ] Open landing page with network throttled — pricing section shows skeleton grid then transitions to plan cards without layout shift
