### PR TITLE
fix: do not cancel CI on PR title/body edits

### DIFF
--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -21,7 +21,7 @@ permissions:
 
 concurrency:
   group: pr-preview-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !(github.event.action == 'edited' && !github.event.changes.base) }}
 
 jobs:
   preview-scope:


### PR DESCRIPTION
Closes #161

## What

Makes `cancel-in-progress` conditional so CI is not cancelled when a PR's title or description is edited while a workflow run is active.

## Root cause

The `concurrency` block uses a single group per PR number with `cancel-in-progress: true`. Every `pull_request` event type — including `edited` — fires into that group. When a title/body edit triggers a new run, GitHub cancels the in-flight CI run before any job condition (`preview-scope` if:) can save it.

## Change

```yaml
# before
cancel-in-progress: true

# after
cancel-in-progress: ${{ !(github.event.action == 'edited' && !github.event.changes.base) }}
```

**Logic:**
- `synchronize` (new commit): `cancel-in-progress = true` — new push supersedes old run ✓
- `edited` title/body only: `cancel-in-progress = false` — don't cancel in-flight CI ✓
- `edited` base branch changed: `cancel-in-progress = true` — base change may need redeploy ✓
- `closed`: `cancel-in-progress = true` — cleanup run supersedes preview build ✓

`github.event.changes.base` is an object (truthy) when the PR base branch changes, and absent/falsy for title/body-only edits — this is the existing signal already used by the `preview-scope` job condition.
