### PR TITLE
feat(billing): static marketing pricing table (issue #163)

### DIFF
--- a/apps/web/src/billing/__tests__/staticPlanAdapter.test.ts
+++ b/apps/web/src/billing/__tests__/staticPlanAdapter.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BillingPlanConfig } from '@beakerstack/billing';
+
+vi.mock('../beakerstackBillingConfig', () => ({
+  beakerstackBillingConfig: {
+    productId: 'beakerstack',
+    plans: [] as BillingPlanConfig[],
+  },
+}));
+
+import { configPlanToStaticPlan, getStaticPlans } from '../staticPlanAdapter';
+import { beakerstackBillingConfig } from '../beakerstackBillingConfig';
+
+const mockedConfig = beakerstackBillingConfig as unknown as {
+  productId: string;
+  plans: Partial<BillingPlanConfig>[];
+};
+
+const fullPlan: BillingPlanConfig = {
+  id: 'test_pro',
+  displayName: 'Pro',
+  description: 'Pro plan',
+  priceCents: 1900,
+  billingPeriod: 'monthly',
+  stripePriceIdMonthly: 'price_monthly_123',
+  stripePriceIdAnnual: 'price_annual_123',
+  stripeProductId: 'prod_123',
+  features: { feature_a: true, limit: 10 },
+  usageLimits: { ai_summarize: 500 },
+  trialPeriodDays: 5,
+  isPublic: true,
+  displayOrder: 2,
+};
+
+describe('configPlanToStaticPlan', () => {
+  it('maps all fields from BillingPlanConfig to Plan', () => {
+    const plan = configPlanToStaticPlan(fullPlan, 0);
+    expect(plan.id).toBe('test_pro');
+    expect(plan.product_id).toBe('beakerstack');
+    expect(plan.display_name).toBe('Pro');
+    expect(plan.description).toBe('Pro plan');
+    expect(plan.price_cents).toBe(1900);
+    expect(plan.billing_period).toBe('monthly');
+    expect(plan.stripe_price_id_monthly).toBe('price_monthly_123');
+    expect(plan.stripe_price_id_annual).toBe('price_annual_123');
+    expect(plan.stripe_product_id).toBe('prod_123');
+    expect(plan.features).toEqual({ feature_a: true, limit: 10 });
+    expect(plan.usage_limits).toEqual({ ai_summarize: 500 });
+    expect(plan.trial_period_days).toBe(5);
+    expect(plan.is_public).toBe(true);
+    expect(plan.display_order).toBe(2);
+  });
+
+  it('defaults description to null when absent', () => {
+    const { description: _, ...withoutDesc } = fullPlan;
+    const plan = configPlanToStaticPlan(withoutDesc as BillingPlanConfig, 0);
+    expect(plan.description).toBeNull();
+  });
+
+  it('defaults trial_period_days to 0 when absent', () => {
+    const { trialPeriodDays: _, ...withoutTrial } = fullPlan;
+    const plan = configPlanToStaticPlan(withoutTrial as BillingPlanConfig, 0);
+    expect(plan.trial_period_days).toBe(0);
+  });
+
+  it('defaults is_public to true when absent', () => {
+    const { isPublic: _, ...withoutPublic } = fullPlan;
+    const plan = configPlanToStaticPlan(withoutPublic as BillingPlanConfig, 0);
+    expect(plan.is_public).toBe(true);
+  });
+
+  it('defaults display_order to array index when absent', () => {
+    const { displayOrder: _, ...withoutOrder } = fullPlan;
+    const plan = configPlanToStaticPlan(withoutOrder as BillingPlanConfig, 3);
+    expect(plan.display_order).toBe(3);
+  });
+
+  it('maps null Stripe fields to null', () => {
+    const plan = configPlanToStaticPlan(
+      { ...fullPlan, stripePriceIdMonthly: null, stripePriceIdAnnual: null, stripeProductId: null },
+      0
+    );
+    expect(plan.stripe_price_id_monthly).toBeNull();
+    expect(plan.stripe_price_id_annual).toBeNull();
+    expect(plan.stripe_product_id).toBeNull();
+  });
+});
+
+describe('getStaticPlans', () => {
+  beforeEach(() => {
+    mockedConfig.plans = [];
+  });
+
+  it('filters out non-public plans', () => {
+    mockedConfig.plans = [
+      { ...fullPlan, id: 'public_plan', isPublic: true, displayOrder: 1 },
+      { ...fullPlan, id: 'private_plan', isPublic: false, displayOrder: 2 },
+    ];
+    const plans = getStaticPlans();
+    expect(plans).toHaveLength(1);
+    expect(plans[0].id).toBe('public_plan');
+  });
+
+  it('includes plans with isPublic omitted (defaults to visible)', () => {
+    const { isPublic: _, ...withoutPublic } = fullPlan;
+    mockedConfig.plans = [withoutPublic as BillingPlanConfig];
+    const plans = getStaticPlans();
+    expect(plans).toHaveLength(1);
+  });
+
+  it('sorts plans by displayOrder ascending', () => {
+    mockedConfig.plans = [
+      { ...fullPlan, id: 'order_3', displayOrder: 3 },
+      { ...fullPlan, id: 'order_1', displayOrder: 1 },
+      { ...fullPlan, id: 'order_2', displayOrder: 2 },
+    ];
+    const plans = getStaticPlans();
+    expect(plans.map(p => p.id)).toEqual(['order_1', 'order_2', 'order_3']);
+  });
+
+  it('uses array index as fallback display_order when absent', () => {
+    const { displayOrder: _, ...withoutOrder } = fullPlan;
+    mockedConfig.plans = [
+      { ...withoutOrder, id: 'a' } as BillingPlanConfig,
+      { ...withoutOrder, id: 'b' } as BillingPlanConfig,
+    ];
+    const plans = getStaticPlans();
+    expect(plans[0].display_order).toBe(0);
+    expect(plans[1].display_order).toBe(1);
+  });
+});

--- a/apps/web/src/billing/__tests__/staticPlanAdapter.test.ts
+++ b/apps/web/src/billing/__tests__/staticPlanAdapter.test.ts
@@ -52,25 +52,25 @@ describe('configPlanToStaticPlan', () => {
   });
 
   it('defaults description to null when absent', () => {
-    const { description: _, ...withoutDesc } = fullPlan;
+    const { description: _description, ...withoutDesc } = fullPlan;
     const plan = configPlanToStaticPlan(withoutDesc as BillingPlanConfig, 0);
     expect(plan.description).toBeNull();
   });
 
   it('defaults trial_period_days to 0 when absent', () => {
-    const { trialPeriodDays: _, ...withoutTrial } = fullPlan;
+    const { trialPeriodDays: _trialPeriodDays, ...withoutTrial } = fullPlan;
     const plan = configPlanToStaticPlan(withoutTrial as BillingPlanConfig, 0);
     expect(plan.trial_period_days).toBe(0);
   });
 
   it('defaults is_public to true when absent', () => {
-    const { isPublic: _, ...withoutPublic } = fullPlan;
+    const { isPublic: _isPublic, ...withoutPublic } = fullPlan;
     const plan = configPlanToStaticPlan(withoutPublic as BillingPlanConfig, 0);
     expect(plan.is_public).toBe(true);
   });
 
   it('defaults display_order to array index when absent', () => {
-    const { displayOrder: _, ...withoutOrder } = fullPlan;
+    const { displayOrder: _displayOrder, ...withoutOrder } = fullPlan;
     const plan = configPlanToStaticPlan(withoutOrder as BillingPlanConfig, 3);
     expect(plan.display_order).toBe(3);
   });
@@ -102,7 +102,7 @@ describe('getStaticPlans', () => {
   });
 
   it('includes plans with isPublic omitted (defaults to visible)', () => {
-    const { isPublic: _, ...withoutPublic } = fullPlan;
+    const { isPublic: _isPublic, ...withoutPublic } = fullPlan;
     mockedConfig.plans = [withoutPublic as BillingPlanConfig];
     const plans = getStaticPlans();
     expect(plans).toHaveLength(1);
@@ -119,7 +119,7 @@ describe('getStaticPlans', () => {
   });
 
   it('uses array index as fallback display_order when absent', () => {
-    const { displayOrder: _, ...withoutOrder } = fullPlan;
+    const { displayOrder: _displayOrder, ...withoutOrder } = fullPlan;
     mockedConfig.plans = [
       { ...withoutOrder, id: 'a' } as BillingPlanConfig,
       { ...withoutOrder, id: 'b' } as BillingPlanConfig,

--- a/apps/web/src/billing/staticPlanAdapter.ts
+++ b/apps/web/src/billing/staticPlanAdapter.ts
@@ -1,0 +1,31 @@
+import type { Plan, BillingPlanConfig } from '@beakerstack/billing';
+import { beakerstackBillingConfig } from './beakerstackBillingConfig';
+
+export function configPlanToStaticPlan(
+  plan: BillingPlanConfig,
+  index: number
+): Plan {
+  return {
+    id: plan.id,
+    product_id: beakerstackBillingConfig.productId,
+    display_name: plan.displayName,
+    description: plan.description ?? null,
+    price_cents: plan.priceCents,
+    billing_period: plan.billingPeriod,
+    stripe_price_id_monthly: plan.stripePriceIdMonthly ?? null,
+    stripe_price_id_annual: plan.stripePriceIdAnnual ?? null,
+    stripe_product_id: plan.stripeProductId ?? null,
+    features: plan.features as Record<string, boolean | number>,
+    usage_limits: plan.usageLimits as Record<string, number>,
+    trial_period_days: plan.trialPeriodDays ?? 0,
+    is_public: plan.isPublic ?? true,
+    display_order: plan.displayOrder ?? index,
+  };
+}
+
+export function getStaticPlans(): Plan[] {
+  return (beakerstackBillingConfig.plans as BillingPlanConfig[])
+    .filter(p => p.isPublic !== false)
+    .sort((a, b) => (a.displayOrder ?? 0) - (b.displayOrder ?? 0))
+    .map((p, i) => configPlanToStaticPlan(p, i));
+}

--- a/apps/web/src/components/billing/CadenceToggle.web.tsx
+++ b/apps/web/src/components/billing/CadenceToggle.web.tsx
@@ -1,4 +1,5 @@
 import { usePlanCatalog } from '@beakerstack/billing';
+import type { Plan } from '@beakerstack/billing';
 import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { beakerstackBillingConfig } from '../../billing/beakerstackBillingConfig';
@@ -7,12 +8,12 @@ import {
   formatCadenceToggleSavingsBadge,
 } from '../../billing/billingSyncDisplay';
 
-/**
- * URL sync: `?cadence=annual` | `?cadence=monthly` (default monthly = omit param or monthly).
- */
-export function CadenceToggle() {
+export function getCadenceFromSearch(search: URLSearchParams) {
+  return search.get('cadence') === 'annual' ? 'annual' : 'monthly';
+}
+
+function CadenceToggleView({ plans }: { plans: Plan[] }) {
   const [search, setSearch] = useSearchParams();
-  const { plans } = usePlanCatalog<typeof beakerstackBillingConfig>();
   const savings = useMemo(() => cadenceAnnualSavingsFromPlans(plans), [plans]);
   const annualBadgeText = useMemo(
     () => formatCadenceToggleSavingsBadge(savings),
@@ -29,6 +30,7 @@ export function CadenceToggle() {
     },
     [search, setSearch]
   );
+
   return (
     <div className='flex items-center justify-center gap-1'>
       <div className='inline-flex rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-1 shadow-sm'>
@@ -73,6 +75,19 @@ export function CadenceToggle() {
   );
 }
 
-export function getCadenceFromSearch(search: URLSearchParams) {
-  return search.get('cadence') === 'annual' ? 'annual' : 'monthly';
+function CadenceToggleFromCatalog() {
+  const { plans } = usePlanCatalog<typeof beakerstackBillingConfig>();
+  return <CadenceToggleView plans={plans} />;
+}
+
+/**
+ * Billing cadence toggle. Reads/sets `?cadence=annual` (omitted = monthly) via React Router search params.
+ * Pass `plans` to bypass the Supabase catalog lookup (e.g. on anonymous marketing pages).
+ */
+export function CadenceToggle({ plans }: { plans?: Plan[] } = {}) {
+  return plans != null ? (
+    <CadenceToggleView plans={plans} />
+  ) : (
+    <CadenceToggleFromCatalog />
+  );
 }

--- a/apps/web/src/components/billing/__tests__/CadenceToggle.test.tsx
+++ b/apps/web/src/components/billing/__tests__/CadenceToggle.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { Plan } from '@beakerstack/billing';
+import { CadenceToggle } from '../CadenceToggle.web';
+
+// When static plans are provided, usePlanCatalog must never be invoked.
+vi.mock('@beakerstack/billing', () => ({
+  usePlanCatalog: vi.fn(() => {
+    throw new Error('usePlanCatalog must not be called when plans prop is provided');
+  }),
+}));
+
+vi.mock('../../../billing/billingSyncDisplay', () => ({
+  cadenceAnnualSavingsFromPlans: vi.fn(() => ({ kind: 'none' as const })),
+  formatCadenceToggleSavingsBadge: vi.fn(() => null),
+}));
+
+const mockPlans: Plan[] = [
+  {
+    id: 'free',
+    product_id: 'test',
+    display_name: 'Free',
+    description: null,
+    price_cents: 0,
+    billing_period: 'free',
+    stripe_price_id_monthly: null,
+    stripe_price_id_annual: null,
+    stripe_product_id: null,
+    features: {},
+    usage_limits: {},
+    trial_period_days: 0,
+    is_public: true,
+    display_order: 1,
+  },
+  {
+    id: 'pro',
+    product_id: 'test',
+    display_name: 'Pro',
+    description: null,
+    price_cents: 1900,
+    billing_period: 'monthly',
+    stripe_price_id_monthly: null,
+    stripe_price_id_annual: null,
+    stripe_product_id: null,
+    features: {},
+    usage_limits: {},
+    trial_period_days: 0,
+    is_public: true,
+    display_order: 2,
+  },
+];
+
+describe('CadenceToggle with static plans', () => {
+  it('renders without calling usePlanCatalog when plans prop is provided', () => {
+    expect(() =>
+      render(
+        <MemoryRouter>
+          <CadenceToggle plans={mockPlans} />
+        </MemoryRouter>
+      )
+    ).not.toThrow();
+  });
+
+  it('renders Monthly and Annually buttons', () => {
+    render(
+      <MemoryRouter>
+        <CadenceToggle plans={mockPlans} />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('button', { name: /monthly/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /annually/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/landing/sections/PricingSection.tsx
+++ b/apps/web/src/components/landing/sections/PricingSection.tsx
@@ -1,7 +1,8 @@
+import { useMemo } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { BillingProvider, usePlanCatalog } from '@beakerstack/billing';
-import { supabase } from '../../../lib/supabase';
+import { BillingConfigProvider } from '@beakerstack/billing';
 import { beakerstackBillingConfig } from '../../../billing/beakerstackBillingConfig';
+import { getStaticPlans } from '../../../billing/staticPlanAdapter';
 import { PlanCard } from '../../billing/PlanCard.web';
 import {
   CadenceToggle,
@@ -18,37 +19,16 @@ interface PricingSectionProps {
   config: LandingConfig['pricing'];
 }
 
-function appBasePath(): string {
-  if (typeof window === 'undefined') return '';
-  return `${window.location.origin}${(import.meta.env.BASE_URL || '/').replace(/\/$/, '')}`;
-}
-
-function LandingPricingTable() {
+function StaticPricingTable() {
   const navigate = useNavigate();
   const [search] = useSearchParams();
   const cadence = getCadenceFromSearch(search);
-  const { plans, loading } = usePlanCatalog<typeof beakerstackBillingConfig>();
-
-  if (loading) {
-    return (
-      <div
-        data-testid='pricing-skeleton'
-        className='grid grid-cols-1 gap-6 md:grid-cols-3'
-      >
-        {[0, 1, 2].map(i => (
-          <div
-            key={i}
-            className='h-96 rounded-xl border border-gray-200 bg-white animate-pulse dark:border-gray-700 dark:bg-gray-800'
-          />
-        ))}
-      </div>
-    );
-  }
+  const plans = useMemo(() => getStaticPlans(), []);
 
   return (
     <div>
       <div className='mb-8'>
-        <CadenceToggle />
+        <CadenceToggle plans={plans} />
       </div>
       <div className='grid grid-cols-1 gap-6 md:grid-cols-3'>
         {plans.map(plan => {
@@ -113,8 +93,6 @@ function LandingPricingTable() {
 }
 
 export function PricingSection({ config }: PricingSectionProps) {
-  const base = appBasePath();
-
   return (
     <section
       id='pricing'
@@ -129,15 +107,9 @@ export function PricingSection({ config }: PricingSectionProps) {
             {config.subhead}
           </p>
         </div>
-        <BillingProvider<typeof beakerstackBillingConfig>
-          supabase={supabase}
-          config={beakerstackBillingConfig}
-          checkoutSuccessUrl={`${base}/billing?checkout=success`}
-          checkoutCancelUrl={`${base}/billing/plans?checkout=cancel`}
-          portalReturnUrl={`${base}/billing`}
-        >
-          <LandingPricingTable />
-        </BillingProvider>
+        <BillingConfigProvider config={beakerstackBillingConfig}>
+          <StaticPricingTable />
+        </BillingConfigProvider>
         {config.disclaimer && (
           <p className='mt-8 text-center text-sm text-gray-500 dark:text-gray-400 max-w-2xl mx-auto'>
             {config.disclaimer}

--- a/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
@@ -9,6 +9,7 @@ const mockNavigate = vi.hoisted(() => vi.fn());
 const getCadenceFromSearchMock = vi.hoisted(() =>
   vi.fn((_search: URLSearchParams): 'monthly' | 'annual' => 'monthly')
 );
+const getStaticPlansMock = vi.hoisted(() => vi.fn());
 
 vi.mock('react-router-dom', async importOriginal => {
   const actual = await importOriginal<typeof import('react-router-dom')>();
@@ -19,15 +20,15 @@ vi.mock('react-router-dom', async importOriginal => {
 });
 
 vi.mock('@beakerstack/billing', () => ({
-  BillingProvider: ({ children }: { children: React.ReactNode }) => (
+  BillingConfigProvider: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
-  usePlanCatalog: vi.fn(),
 }));
-vi.mock('../../../../lib/supabase', () => ({ supabase: {} }));
-vi.mock('../../../../billing/beakerstackBillingConfig', () => ({
-  beakerstackBillingConfig: { plans: [] },
+
+vi.mock('../../../../billing/staticPlanAdapter', () => ({
+  getStaticPlans: getStaticPlansMock,
 }));
+
 vi.mock('../../../billing/PlanCard.web', () => ({
   PlanCard: ({
     plan,
@@ -45,23 +46,23 @@ vi.mock('../../../billing/PlanCard.web', () => ({
     </button>
   ),
 }));
+
 vi.mock('../../../billing/CadenceToggle.web', () => ({
   CadenceToggle: () => <div data-testid='cadence-toggle'>Toggle</div>,
   getCadenceFromSearch: (search: URLSearchParams) =>
     getCadenceFromSearchMock(search),
 }));
+
 vi.mock('../../../../billing/billingSyncDisplay', () => ({
   annualListCentsFromSync: vi.fn(() => 22800),
   planAnnualSavingsCopy: vi.fn(() => ({ kind: 'months', months: 2 })),
   formatSavingsCalloutFromCopy: vi.fn(() => '2 Months Free'),
 }));
 
-import { usePlanCatalog } from '@beakerstack/billing';
-
 const mockPlans = [
-  { id: 'free', display_name: 'Free', price_cents: 0, features: [] },
-  { id: 'pro', display_name: 'Pro', price_cents: 1900, features: [] },
-  { id: 'team', display_name: 'Team', price_cents: 4900, features: [] },
+  { id: 'free', display_name: 'Free', price_cents: 0, features: {} },
+  { id: 'pro', display_name: 'Pro', price_cents: 1900, features: {} },
+  { id: 'team', display_name: 'Team', price_cents: 4900, features: {} },
 ];
 
 const baseConfig: LandingConfig['pricing'] = {
@@ -81,10 +82,7 @@ describe('PricingSection', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
     getCadenceFromSearchMock.mockReturnValue('monthly');
-    vi.mocked(usePlanCatalog).mockReturnValue({
-      plans: mockPlans,
-      loading: false,
-    } as unknown as ReturnType<typeof usePlanCatalog>);
+    getStaticPlansMock.mockReturnValue(mockPlans);
   });
 
   it('renders heading and subhead', () => {
@@ -102,7 +100,7 @@ describe('PricingSection', () => {
     expect(screen.getByTestId('cadence-toggle')).toBeInTheDocument();
   });
 
-  it('renders a plan card for each plan', () => {
+  it('renders a plan card for each static plan immediately (no loading state)', () => {
     renderSection();
     expect(screen.getByTestId('plan-card-free')).toHaveTextContent('Free');
     expect(screen.getByTestId('plan-card-pro')).toHaveTextContent('Pro');
@@ -124,16 +122,6 @@ describe('PricingSection', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       '/signup?plan=pro&cadence=annual'
     );
-  });
-
-  it('shows skeleton while plans are loading', () => {
-    vi.mocked(usePlanCatalog).mockReturnValue({
-      plans: [],
-      loading: true,
-    } as unknown as ReturnType<typeof usePlanCatalog>);
-    renderSection();
-    expect(screen.getByTestId('pricing-skeleton')).toBeInTheDocument();
-    expect(screen.queryByTestId('plan-card-free')).not.toBeInTheDocument();
   });
 
   it('renders disclaimer when provided', () => {

--- a/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
@@ -19,11 +19,15 @@ vi.mock('react-router-dom', async importOriginal => {
   };
 });
 
-vi.mock('@beakerstack/billing', () => ({
-  BillingConfigProvider: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
-}));
+vi.mock('@beakerstack/billing', async importOriginal => {
+  const actual = await importOriginal<typeof import('@beakerstack/billing')>();
+  return {
+    ...actual,
+    BillingConfigProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+  };
+});
 
 vi.mock('../../../../billing/staticPlanAdapter', () => ({
   getStaticPlans: getStaticPlansMock,

--- a/packages/billing/src/BillingConfigProvider.test.tsx
+++ b/packages/billing/src/BillingConfigProvider.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { BillingConfigProvider } from './BillingConfigProvider.js';
+import { useBillingConfig } from './hooks/useBillingConfig.js';
+import { defineBillingConfig } from './schema.js';
+
+const testConfig = defineBillingConfig({
+  productId: 'test',
+  displayName: 'Test Product',
+  plans: [
+    {
+      id: 'test_free',
+      displayName: 'Free',
+      priceCents: 0,
+      billingPeriod: 'free',
+      features: {},
+      usageLimits: {},
+    },
+  ],
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <BillingConfigProvider config={testConfig}>{children}</BillingConfigProvider>
+  );
+}
+
+describe('BillingConfigProvider', () => {
+  it('provides config via useBillingConfig', () => {
+    const { result } = renderHook(() => useBillingConfig(), { wrapper });
+    expect(result.current.productId).toBe('test');
+    expect(result.current.displayName).toBe('Test Product');
+  });
+
+  it('exposes plans array from config', () => {
+    const { result } = renderHook(() => useBillingConfig(), { wrapper });
+    expect(result.current.plans).toHaveLength(1);
+    expect(result.current.plans[0].id).toBe('test_free');
+  });
+
+  it('throws when used outside BillingConfigProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => renderHook(() => useBillingConfig())).toThrow(
+        'useBillingConfig must be used within BillingProvider'
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/billing/src/BillingConfigProvider.tsx
+++ b/packages/billing/src/BillingConfigProvider.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+import { BillingConfigReactContext } from './context.js';
+import type { ProductBillingConfig } from './schema.js';
+
+export interface BillingConfigProviderProps<C extends ProductBillingConfig> {
+  config: C;
+  children: ReactNode;
+}
+
+export function BillingConfigProvider<C extends ProductBillingConfig>({
+  config,
+  children,
+}: BillingConfigProviderProps<C>) {
+  return (
+    <BillingConfigReactContext.Provider value={config}>
+      {children}
+    </BillingConfigReactContext.Provider>
+  );
+}

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -28,6 +28,10 @@ export {
   BillingProvider,
   type BillingProviderProps,
 } from './BillingProvider.js';
+export {
+  BillingConfigProvider,
+  type BillingConfigProviderProps,
+} from './BillingConfigProvider.js';
 export type {
   Plan,
   PlanId,


### PR DESCRIPTION
## Summary

Closes #163.

Eliminates the Supabase dependency from the anonymous marketing pricing section by driving it entirely from the bundled `beakerstackBillingConfig` object and billing-sync data.

### Changes

**`packages/billing`**
- **`BillingConfigProvider`** (new) — thin React context provider that wraps only `BillingConfigReactContext`. Satisfies `useBillingConfig()` inside `PlanCard` without connecting to Supabase.
- **`index.ts`** — exports `BillingConfigProvider`.

**`apps/web`**
- **`billing/staticPlanAdapter.ts`** (new) — `configPlanToStaticPlan` maps camelCase `BillingPlanConfig` → snake_case `Plan`. `getStaticPlans()` filters public plans, sorts by `displayOrder`, and returns the full list from config.
- **`components/billing/CadenceToggle.web.tsx`** — view/container split (`CadenceToggleView` / `CadenceToggleFromCatalog`) so passing a `plans` prop skips `usePlanCatalog` without violating React hook rules.
- **`components/landing/sections/PricingSection.tsx`** — drops `BillingProvider` / Supabase. Wraps in `BillingConfigProvider` and calls `getStaticPlans()` in `useMemo`. No async loading state — renders synchronously.

### Architecture notes

- `BillingConfigProvider` wraps only `BillingConfigReactContext`, not the full `BillingReactContext` — no fake Supabase client needed.
- `getStaticPlans()` is called inside `useMemo(fn, [])` (not at module level) so it's mockable in Vitest via `vi.hoisted`.
- Pre-render benefit: `prerender-home.ts` now captures real plan cards in the static HTML instead of a loading placeholder, since rendering is fully synchronous.

### Tests

- `BillingConfigProvider.test.tsx` — verifies `useBillingConfig()` resolves correctly and throws outside the provider.
- `staticPlanAdapter.test.ts` — field mapping, defaults (`trial_period_days`, `is_public`, `display_order`, `description`), null Stripe fields.
- `CadenceToggle.test.tsx` — mocks `usePlanCatalog` to throw; confirms it's never called when `plans` prop is provided.
- `PricingSection.test.tsx` — updated: removes loading-state test, verifies plans render immediately, cadence nav, disclaimer.

## Test plan

- [ ] `pnpm test --filter @beakerstack/billing` — BillingConfigProvider tests pass
- [ ] `pnpm test --filter web` — staticPlanAdapter, CadenceToggle, PricingSection tests pass
- [ ] Smoke: home page pricing section renders all 3 plan cards with no network requests to Supabase
- [ ] Annual cadence toggle switches prices and appends `&cadence=annual` to signup URL
- [ ] Disclaimer renders when `config.disclaimer` is set, absent otherwise

🤖 Generated with [Claude Code](https://claude.ai/claude-code)