### PR TITLE
feat(web): prerender-home with renderToStaticMarkup; unconditional createRoot (#175 PR 1/3)

### DIFF
--- a/apps/web/scripts/prerender-home.ts
+++ b/apps/web/scripts/prerender-home.ts
@@ -46,6 +46,10 @@ const routerBasename =
 // match (RR warns and renders nothing). Use the same pathname as publicHomeUrl path.
 const initialEntries = [homePath];
 
+// Layout wrapper classes mirror App.tsx ('bg-gray-50 dark:bg-gray-900') and RootLayout
+// ('flex min-h-screen flex-col'). Update these when the App layout changes to keep the
+// prerendered visual consistent with the hydrated page. No strict tree-match is required —
+// createRoot replaces this subtree on first render without hydration alignment constraints.
 const html = renderToStaticMarkup(
   createElement(
     ThemeProvider,

--- a/apps/web/scripts/prerender-home.ts
+++ b/apps/web/scripts/prerender-home.ts
@@ -4,7 +4,7 @@ import { join, dirname } from 'path';
 
 // Shim WebSocket for Node < 22 before any app module loads.
 // supabase-js checks globalThis.WebSocket at createClient() time (module load, not runtime).
-// renderToString never opens a socket, but the check throws on Node 20 without this.
+// renderToStaticMarkup never opens a socket, but the check throws on Node 20 without this.
 // Dynamic imports below ensure this assignment runs first (static imports are hoisted).
 if (typeof globalThis.WebSocket === 'undefined') {
   (globalThis as any).WebSocket = class WebSocket {
@@ -16,7 +16,7 @@ if (typeof globalThis.WebSocket === 'undefined') {
 }
 
 const { createElement } = await import('react');
-const { renderToString } = await import('react-dom/server');
+const { renderToStaticMarkup } = await import('react-dom/server');
 // MemoryRouter comes from the same react-router-dom instance as <Link> and other
 // router-aware components in LandingPage, so they share the same NavigationContext.
 // StaticRouter (from react-router-dom/server) is a separate sub-package with its
@@ -46,10 +46,7 @@ const routerBasename =
 // match (RR warns and renders nothing). Use the same pathname as publicHomeUrl path.
 const initialEntries = [homePath];
 
-// Render the same DOM structure as App.tsx (outer div) and RootLayout (inner divs + AppFooter).
-// These class names must stay in sync with App.tsx and RootLayout in App.tsx;
-// hydrateRoot requires the prerendered HTML to match the client-rendered tree exactly.
-const html = renderToString(
+const html = renderToStaticMarkup(
   createElement(
     ThemeProvider,
     null,

--- a/apps/web/scripts/prerender-home.ts
+++ b/apps/web/scripts/prerender-home.ts
@@ -4,7 +4,7 @@ import { join, dirname } from 'path';
 
 // Shim WebSocket for Node < 22 before any app module loads.
 // supabase-js checks globalThis.WebSocket at createClient() time (module load, not runtime).
-// renderToStaticMarkup never opens a socket, but the check throws on Node 20 without this.
+// renderToString never opens a socket, but the check throws on Node 20 without this.
 // Dynamic imports below ensure this assignment runs first (static imports are hoisted).
 if (typeof globalThis.WebSocket === 'undefined') {
   (globalThis as any).WebSocket = class WebSocket {
@@ -16,12 +16,15 @@ if (typeof globalThis.WebSocket === 'undefined') {
 }
 
 const { createElement } = await import('react');
-const { renderToStaticMarkup } = await import('react-dom/server');
+const { renderToString } = await import('react-dom/server');
 // MemoryRouter comes from the same react-router-dom instance as <Link> and other
 // router-aware components in LandingPage, so they share the same NavigationContext.
 // StaticRouter (from react-router-dom/server) is a separate sub-package with its
 // own bundled context, causing a null-context mismatch in vite-node's module graph.
 const { MemoryRouter } = await import('react-router-dom');
+// ThemeProvider needed because AppFooter renders ThemeToggle which calls useTheme().
+const { ThemeProvider } = await import('../src/contexts/ThemeContext');
+const { AppFooter } = await import('../src/components/AppFooter');
 const { LandingPage } = await import('../src/components/landing/LandingPage');
 
 const webRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -43,11 +46,27 @@ const routerBasename =
 // match (RR warns and renders nothing). Use the same pathname as publicHomeUrl path.
 const initialEntries = [homePath];
 
-const html = renderToStaticMarkup(
+// Render the same DOM structure as App.tsx (outer div) and RootLayout (inner divs + AppFooter).
+// These class names must stay in sync with App.tsx and RootLayout in App.tsx;
+// hydrateRoot requires the prerendered HTML to match the client-rendered tree exactly.
+const html = renderToString(
   createElement(
-    MemoryRouter,
-    { basename: routerBasename, initialEntries },
-    createElement(LandingPage)
+    ThemeProvider,
+    null,
+    createElement(
+      MemoryRouter,
+      { basename: routerBasename, initialEntries },
+      createElement(
+        'div',
+        { className: 'bg-gray-50 dark:bg-gray-900' },
+        createElement(
+          'div',
+          { className: 'flex min-h-screen flex-col' },
+          createElement('div', { className: 'flex-1' }, createElement(LandingPage)),
+          createElement(AppFooter)
+        )
+      )
+    )
   )
 );
 

--- a/apps/web/src/__tests__/main.test.tsx
+++ b/apps/web/src/__tests__/main.test.tsx
@@ -6,11 +6,13 @@ const mockRender = vi.fn();
 const mockCreateRoot = vi.fn(() => ({
   render: mockRender,
 }));
+const mockHydrateRoot = vi.fn();
 
 vi.mock('react-dom/client', () => ({
   default: {
     createRoot: mockCreateRoot,
   },
+  hydrateRoot: mockHydrateRoot,
 }));
 
 // Mock the supabase client
@@ -63,6 +65,7 @@ describe('main.tsx', () => {
     vi.clearAllMocks();
     mockCreateRoot.mockClear();
     mockRender.mockClear();
+    mockHydrateRoot.mockClear();
 
     // Reset modules to allow re-importing main.tsx
     vi.resetModules();
@@ -100,6 +103,23 @@ describe('main.tsx', () => {
     // Verify render was called with React.StrictMode
     const renderCall = mockRender.mock.calls[0][0];
     expect(renderCall.type).toBe(React.StrictMode);
+  });
+
+  it('should call hydrateRoot when root has prerendered content', async () => {
+    // Simulate prerendered HTML by adding a child element to #root
+    const prerendered = document.createElement('div');
+    rootElement!.appendChild(prerendered);
+
+    await import('../main');
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // hydrateRoot should be used for prerendered content
+    expect(mockHydrateRoot).toHaveBeenCalledWith(
+      rootElement,
+      expect.objectContaining({ type: React.StrictMode }),
+    );
+    // createRoot should NOT be called on the prerendered path
+    expect(mockCreateRoot).not.toHaveBeenCalled();
   });
 
   it('should render app with AuthProvider and ProfileProvider', async () => {

--- a/apps/web/src/__tests__/main.test.tsx
+++ b/apps/web/src/__tests__/main.test.tsx
@@ -55,6 +55,11 @@ vi.mock('../App', () => ({
   default: () => React.createElement('div', null, 'App Component'),
 }));
 
+// Mock HomePage — pre-warm import in main.tsx resolves this before hydrateRoot fires
+vi.mock('../pages/HomePage', () => ({
+  default: () => React.createElement('div', null, 'Home Page'),
+}));
+
 // Mock CSS import
 vi.mock('../index.css', () => ({}));
 
@@ -111,7 +116,8 @@ describe('main.tsx', () => {
     rootElement!.appendChild(prerendered);
 
     await import('../main');
-    await new Promise(resolve => setTimeout(resolve, 10));
+    // Allow the pre-warm import().then() microtask chain to resolve
+    await new Promise(resolve => setTimeout(resolve, 50));
 
     // hydrateRoot should be used for prerendered content
     expect(mockHydrateRoot).toHaveBeenCalledWith(

--- a/apps/web/src/__tests__/main.test.tsx
+++ b/apps/web/src/__tests__/main.test.tsx
@@ -6,13 +6,11 @@ const mockRender = vi.fn();
 const mockCreateRoot = vi.fn(() => ({
   render: mockRender,
 }));
-const mockHydrateRoot = vi.fn();
 
 vi.mock('react-dom/client', () => ({
   default: {
     createRoot: mockCreateRoot,
   },
-  hydrateRoot: mockHydrateRoot,
 }));
 
 // Mock the supabase client
@@ -55,11 +53,6 @@ vi.mock('../App', () => ({
   default: () => React.createElement('div', null, 'App Component'),
 }));
 
-// Mock HomePage — pre-warm import in main.tsx resolves this before hydrateRoot fires
-vi.mock('../pages/HomePage', () => ({
-  default: () => React.createElement('div', null, 'Home Page'),
-}));
-
 // Mock CSS import
 vi.mock('../index.css', () => ({}));
 
@@ -70,7 +63,6 @@ describe('main.tsx', () => {
     vi.clearAllMocks();
     mockCreateRoot.mockClear();
     mockRender.mockClear();
-    mockHydrateRoot.mockClear();
 
     // Reset modules to allow re-importing main.tsx
     vi.resetModules();
@@ -110,22 +102,18 @@ describe('main.tsx', () => {
     expect(renderCall.type).toBe(React.StrictMode);
   });
 
-  it('should call hydrateRoot when root has prerendered content', async () => {
+  it('should use createRoot even when root has prerendered content', async () => {
     // Simulate prerendered HTML by adding a child element to #root
     const prerendered = document.createElement('div');
     rootElement!.appendChild(prerendered);
 
     await import('../main');
-    // Allow the pre-warm import().then() microtask chain to resolve
-    await new Promise(resolve => setTimeout(resolve, 50));
+    await new Promise(resolve => setTimeout(resolve, 10));
 
-    // hydrateRoot should be used for prerendered content
-    expect(mockHydrateRoot).toHaveBeenCalledWith(
-      rootElement,
-      expect.objectContaining({ type: React.StrictMode }),
-    );
-    // createRoot should NOT be called on the prerendered path
-    expect(mockCreateRoot).not.toHaveBeenCalled();
+    // createRoot is always used — hydrateRoot was dropped due to structural
+    // fiber-tree mismatch between the hand-maintained prerender and App's full tree
+    expect(mockCreateRoot).toHaveBeenCalledWith(rootElement);
+    expect(mockRender).toHaveBeenCalled();
   });
 
   it('should render app with AuthProvider and ProfileProvider', async () => {

--- a/apps/web/src/components/AppFooter.tsx
+++ b/apps/web/src/components/AppFooter.tsx
@@ -9,7 +9,7 @@ export function AppFooter() {
     <footer className='border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900'>
       <div className='max-w-[1024px] mx-auto px-4 py-6 sm:px-6 lg:px-8'>
         <div className='flex flex-col items-center gap-3 sm:flex-row sm:justify-between'>
-          <p className='text-sm text-gray-500 dark:text-gray-400'>
+          <p suppressHydrationWarning className='text-sm text-gray-500 dark:text-gray-400'>
             &copy; {year} {LEGAL_CONFIG.legalEntityName}. All rights reserved.
           </p>
           <nav

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -16,6 +16,7 @@ export function ThemeToggle() {
         <button
           key={value}
           type='button'
+          suppressHydrationWarning
           onClick={() => setTheme(value)}
           aria-label={label}
           title={label}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM, { hydrateRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
@@ -17,7 +17,7 @@ if (!rootElement) {
 // Get base path from environment variable, defaulting to '/' for local development
 const basePath = import.meta.env.VITE_BASE_PATH || '/';
 
-ReactDOM.createRoot(rootElement).render(
+const app = (
   <React.StrictMode>
     <ThemeProvider>
       <AuthProvider supabaseClient={supabase}>
@@ -30,3 +30,11 @@ ReactDOM.createRoot(rootElement).render(
     </ThemeProvider>
   </React.StrictMode>
 );
+
+// Use hydrateRoot when prerendered HTML is present (home page served from
+// prerender-home.html), createRoot for all other routes where #root is empty.
+if (rootElement.childElementCount > 0) {
+  hydrateRoot(rootElement, app);
+} else {
+  ReactDOM.createRoot(rootElement).render(app);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM, { hydrateRoot } from 'react-dom/client';
+import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
@@ -17,7 +17,7 @@ if (!rootElement) {
 // Get base path from environment variable, defaulting to '/' for local development
 const basePath = import.meta.env.VITE_BASE_PATH || '/';
 
-const app = (
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <ThemeProvider>
       <AuthProvider supabaseClient={supabase}>
@@ -30,16 +30,3 @@ const app = (
     </ThemeProvider>
   </React.StrictMode>
 );
-
-// Use hydrateRoot when prerendered HTML is present (home page served from
-// prerender-home.html), createRoot for all other routes where #root is empty.
-if (rootElement.childElementCount > 0) {
-  // Pre-warm the home page bundle so React.lazy resolves from cache without suspending.
-  // App wraps Routes in <Suspense fallback={null}>; if HomePage suspends at hydrateRoot
-  // time, React shows null against the prerendered DOM — mismatch triggers error #418.
-  import('./pages/HomePage').then(() => {
-    hydrateRoot(rootElement, app);
-  });
-} else {
-  ReactDOM.createRoot(rootElement).render(app);
-}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -34,7 +34,12 @@ const app = (
 // Use hydrateRoot when prerendered HTML is present (home page served from
 // prerender-home.html), createRoot for all other routes where #root is empty.
 if (rootElement.childElementCount > 0) {
-  hydrateRoot(rootElement, app);
+  // Pre-warm the home page bundle so React.lazy resolves from cache without suspending.
+  // App wraps Routes in <Suspense fallback={null}>; if HomePage suspends at hydrateRoot
+  // time, React shows null against the prerendered DOM — mismatch triggers error #418.
+  import('./pages/HomePage').then(() => {
+    hydrateRoot(rootElement, app);
+  });
 } else {
   ReactDOM.createRoot(rootElement).render(app);
 }


### PR DESCRIPTION
## Summary

Part 1 of 3 for issue #175 (landing route bundle splitting / perf).

After deeper analysis of the React fiber-tree mismatch (see PR discussion), the approach was revised from hydrateRoot to unconditional createRoot:

- **`prerender-home.ts`**: uses `renderToStaticMarkup` (no hydration markers needed)  
  Generates a static HTML snapshot of the home page at build time for SEO and visual completeness. No `data-reactroot` attributes — this is not a hydration target.

- **`main.tsx`**: always uses `createRoot(...).render()`  
  Dropped the conditional `hydrateRoot` path. React 18's `createRoot` seamlessly replaces the `#root` subtree on first render without requiring a tree-shape match, eliminating the structural fiber-tree mismatch that caused React error #418.

- **`main.test.tsx`**: simplified — removed hydrateRoot mock and pre-warm test; added assertion that createRoot is used even when `#root` has prerendered content.

## Why not hydrateRoot?

The prerendered tree (`ThemeProvider → MemoryRouter → LandingPage`) is structurally different from the client tree (`StrictMode → ThemeProvider → AuthProvider → ProfileProvider → BrowserRouter → App → Suspense → Routes → RootLayout → HomePage`). React's fiber reconciler requires shape alignment for hydration — `suppressHydrationWarning` only covers attribute/text drift on leaf nodes, not depth/structure mismatches. createRoot with a pre-rendered SEO snapshot achieves the same load-time visual benefit without the mismatch risk.

## Test plan
- [ ] CI: tests + Lighthouse + preview all pass
- [ ] Preview: home page renders with content immediately visible (no blank flash)
- [ ] No browser console errors (no React error #418)