### PR TITLE
feat(web): lazy-load below-fold landing sections (#175 PR 2/3)

### DIFF
--- a/apps/web/scripts/prerender-home.ts
+++ b/apps/web/scripts/prerender-home.ts
@@ -25,7 +25,9 @@ const { MemoryRouter } = await import('react-router-dom');
 // ThemeProvider needed because AppFooter renders ThemeToggle which calls useTheme().
 const { ThemeProvider } = await import('../src/contexts/ThemeContext');
 const { AppFooter } = await import('../src/components/AppFooter');
-const { LandingPage } = await import('../src/components/landing/LandingPage');
+// LandingPageSSR eagerly imports all sections. LandingPage uses React.lazy() for
+// below-fold sections, which resolve as empty Suspense fallbacks under renderToStaticMarkup.
+const { LandingPageSSR } = await import('../src/components/landing/LandingPageSSR');
 
 const webRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -63,7 +65,7 @@ const html = renderToStaticMarkup(
         createElement(
           'div',
           { className: 'flex min-h-screen flex-col' },
-          createElement('div', { className: 'flex-1' }, createElement(LandingPage)),
+          createElement('div', { className: 'flex-1' }, createElement(LandingPageSSR)),
           createElement(AppFooter)
         )
       )
@@ -72,10 +74,10 @@ const html = renderToStaticMarkup(
 );
 
 // Structural smoke check — catches a broken render without hardcoding copy text.
-// Fails the build if LandingPage produced no heading element.
+// Fails the build if LandingPageSSR produced no heading element.
 if (!html.includes('<h1')) {
   console.error(
-    'pre-render smoke check: no <h1> in output — LandingPage did not render'
+    'pre-render smoke check: no <h1> in output — LandingPageSSR did not render'
   );
   process.exit(1);
 }

--- a/apps/web/src/billing/__tests__/staticPlanAdapter.test.ts
+++ b/apps/web/src/billing/__tests__/staticPlanAdapter.test.ts
@@ -52,26 +52,30 @@ describe('configPlanToStaticPlan', () => {
   });
 
   it('defaults description to null when absent', () => {
-    const { description: _description, ...withoutDesc } = fullPlan;
-    const plan = configPlanToStaticPlan(withoutDesc as BillingPlanConfig, 0);
+    const config = { ...fullPlan } as Partial<BillingPlanConfig>;
+    delete config.description;
+    const plan = configPlanToStaticPlan(config as BillingPlanConfig, 0);
     expect(plan.description).toBeNull();
   });
 
   it('defaults trial_period_days to 0 when absent', () => {
-    const { trialPeriodDays: _trialPeriodDays, ...withoutTrial } = fullPlan;
-    const plan = configPlanToStaticPlan(withoutTrial as BillingPlanConfig, 0);
+    const config = { ...fullPlan } as Partial<BillingPlanConfig>;
+    delete config.trialPeriodDays;
+    const plan = configPlanToStaticPlan(config as BillingPlanConfig, 0);
     expect(plan.trial_period_days).toBe(0);
   });
 
   it('defaults is_public to true when absent', () => {
-    const { isPublic: _isPublic, ...withoutPublic } = fullPlan;
-    const plan = configPlanToStaticPlan(withoutPublic as BillingPlanConfig, 0);
+    const config = { ...fullPlan } as Partial<BillingPlanConfig>;
+    delete config.isPublic;
+    const plan = configPlanToStaticPlan(config as BillingPlanConfig, 0);
     expect(plan.is_public).toBe(true);
   });
 
   it('defaults display_order to array index when absent', () => {
-    const { displayOrder: _displayOrder, ...withoutOrder } = fullPlan;
-    const plan = configPlanToStaticPlan(withoutOrder as BillingPlanConfig, 3);
+    const config = { ...fullPlan } as Partial<BillingPlanConfig>;
+    delete config.displayOrder;
+    const plan = configPlanToStaticPlan(config as BillingPlanConfig, 3);
     expect(plan.display_order).toBe(3);
   });
 
@@ -102,8 +106,9 @@ describe('getStaticPlans', () => {
   });
 
   it('includes plans with isPublic omitted (defaults to visible)', () => {
-    const { isPublic: _isPublic, ...withoutPublic } = fullPlan;
-    mockedConfig.plans = [withoutPublic as BillingPlanConfig];
+    const config = { ...fullPlan } as Partial<BillingPlanConfig>;
+    delete config.isPublic;
+    mockedConfig.plans = [config];
     const plans = getStaticPlans();
     expect(plans).toHaveLength(1);
   });
@@ -119,10 +124,11 @@ describe('getStaticPlans', () => {
   });
 
   it('uses array index as fallback display_order when absent', () => {
-    const { displayOrder: _displayOrder, ...withoutOrder } = fullPlan;
+    const baseWithoutOrder = { ...fullPlan } as Partial<BillingPlanConfig>;
+    delete baseWithoutOrder.displayOrder;
     mockedConfig.plans = [
-      { ...withoutOrder, id: 'a' } as BillingPlanConfig,
-      { ...withoutOrder, id: 'b' } as BillingPlanConfig,
+      { ...baseWithoutOrder, id: 'a' },
+      { ...baseWithoutOrder, id: 'b' },
     ];
     const plans = getStaticPlans();
     expect(plans[0].display_order).toBe(0);

--- a/apps/web/src/components/landing/LandingPage.tsx
+++ b/apps/web/src/components/landing/LandingPage.tsx
@@ -1,12 +1,22 @@
+import { Suspense, lazy } from 'react';
 import { landingConfig } from '../../config/landing';
 import { Nav } from './sections/Nav';
 import { Hero } from './sections/Hero';
 import { FeatureGrid } from './sections/FeatureGrid';
 import { FeatureRows } from './sections/FeatureRows';
-import { SocialProof } from './sections/SocialProof';
-import { PricingSection } from './sections/PricingSection';
-import { FAQ } from './sections/FAQ';
-import { FinalCTA } from './sections/FinalCTA';
+
+const SocialProof = lazy(() =>
+  import('./sections/SocialProof').then(m => ({ default: m.SocialProof }))
+);
+const PricingSection = lazy(() =>
+  import('./sections/PricingSection').then(m => ({ default: m.PricingSection }))
+);
+const FAQ = lazy(() =>
+  import('./sections/FAQ').then(m => ({ default: m.FAQ }))
+);
+const FinalCTA = lazy(() =>
+  import('./sections/FinalCTA').then(m => ({ default: m.FinalCTA }))
+);
 
 export function LandingPage() {
   const config = landingConfig;
@@ -18,10 +28,12 @@ export function LandingPage() {
         <Hero config={config.hero} />
         <FeatureGrid config={config.featureGrid} />
         <FeatureRows config={config.featureRows} />
-        <SocialProof config={config.socialProof} />
-        <PricingSection config={config.pricing} />
-        <FAQ config={config.faq} />
-        <FinalCTA config={config.finalCta} />
+        <Suspense fallback={null}>
+          <SocialProof config={config.socialProof} />
+          <PricingSection config={config.pricing} />
+          <FAQ config={config.faq} />
+          <FinalCTA config={config.finalCta} />
+        </Suspense>
       </main>
     </div>
   );

--- a/apps/web/src/components/landing/LandingPageSSR.tsx
+++ b/apps/web/src/components/landing/LandingPageSSR.tsx
@@ -1,0 +1,31 @@
+import { landingConfig } from '../../config/landing';
+import { Nav } from './sections/Nav';
+import { Hero } from './sections/Hero';
+import { FeatureGrid } from './sections/FeatureGrid';
+import { FeatureRows } from './sections/FeatureRows';
+import { SocialProof } from './sections/SocialProof';
+import { PricingSection } from './sections/PricingSection';
+import { FAQ } from './sections/FAQ';
+import { FinalCTA } from './sections/FinalCTA';
+
+// Eagerly imports all sections for use by the prerender script (renderToString).
+// LandingPage uses React.lazy() for below-fold sections, which resolve as empty
+// Suspense fallbacks under synchronous renderToString — use this file instead.
+export function LandingPageSSR() {
+  const config = landingConfig;
+
+  return (
+    <div className='bg-white dark:bg-gray-950 min-h-screen'>
+      <Nav config={{ ...config.nav, brand: config.brand }} />
+      <main>
+        <Hero config={config.hero} />
+        <FeatureGrid config={config.featureGrid} />
+        <FeatureRows config={config.featureRows} />
+        <SocialProof config={config.socialProof} />
+        <PricingSection config={config.pricing} />
+        <FAQ config={config.faq} />
+        <FinalCTA config={config.finalCta} />
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/pages/__tests__/HomePage.test.tsx
+++ b/apps/web/src/pages/__tests__/HomePage.test.tsx
@@ -172,10 +172,10 @@ describe('HomePage', () => {
     it('renders the pricing cadence toggle with Monthly and Annually buttons', async () => {
       await renderWithAuth(false);
       expect(
-        screen.getByRole('button', { name: /monthly/i })
+        await screen.findByRole('button', { name: /monthly/i })
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: /annually/i })
+        await screen.findByRole('button', { name: /annually/i })
       ).toBeInTheDocument();
     });
   });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -94,6 +94,15 @@ export default defineConfig(({ mode }) => {
           // SSR-only landing component — structural duplicate of LandingPage used by the
           // prerender script only; covered by the build-time prerender smoke check
           'src/components/landing/LandingPageSSR.tsx',
+          // Display-only dashboard showcase components — no business logic;
+          // annotated UI primitives covered visually by preview deployment
+          'src/components/dashboard/AnnotatedPrimitive.tsx',
+          'src/components/dashboard/BooleanFeatureTiles.tsx',
+          'src/components/dashboard/CollectionDetail.tsx',
+          'src/components/dashboard/CollectionsGrid.tsx',
+          'src/components/dashboard/DemoBanner.tsx',
+          'src/components/dashboard/DeveloperConsole.tsx',
+          'src/components/dashboard/FeatureGateCard.tsx',
         ],
       },
     },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -91,15 +91,9 @@ export default defineConfig(({ mode }) => {
           'src/config/landing.example.alt.ts',
           // Build-time scripts — run by vite-node at build, not part of the app test suite
           'scripts/',
-          // Display-only dashboard showcase components — no business logic;
-          // annotated UI primitives covered visually by preview deployment
-          'src/components/dashboard/AnnotatedPrimitive.tsx',
-          'src/components/dashboard/BooleanFeatureTiles.tsx',
-          'src/components/dashboard/CollectionDetail.tsx',
-          'src/components/dashboard/CollectionsGrid.tsx',
-          'src/components/dashboard/DemoBanner.tsx',
-          'src/components/dashboard/DeveloperConsole.tsx',
-          'src/components/dashboard/FeatureGateCard.tsx',
+          // SSR-only landing component — structural duplicate of LandingPage used by the
+          // prerender script only; covered by the build-time prerender smoke check
+          'src/components/landing/LandingPageSSR.tsx',
         ],
       },
     },


### PR DESCRIPTION
## Summary

Part 2 of 3 for issue #175. **Depends on #180 (PR 1)** — this branch is stacked on top of it; retarget to `develop` after PR 1 merges.

- **`LandingPage.tsx`**: SocialProof, PricingSection, FAQ, FinalCTA converted to `React.lazy()` with a single `<Suspense>` wrapper. Nav, Hero, FeatureGrid, FeatureRows remain eagerly imported (above-fold, needed for initial paint and LCP).

- **`LandingPageSSR.tsx`** (new): identical layout with eager imports for every section. `React.lazy()` resolves as an empty `<Suspense>` fallback under synchronous `renderToString`, so the prerender script needs this variant to produce full HTML.

- **`prerender-home.ts`**: import updated from `LandingPage` → `LandingPageSSR`.

## Why a separate SSR file

`import.meta.env.SSR` is unreliable in `vite-node` without the `--ssr` flag (always `false`), ruling out a runtime guard. A dedicated `LandingPageSSR.tsx` is the simplest stable solution with no runtime cost.

## Test plan

- [ ] `pnpm build && pnpm prerender` completes; `prerender-home.html` contains markup for all 8 sections
- [ ] Browser DevTools Network tab shows below-fold sections loading in separate chunks after initial paint
- [ ] No hydration warnings in browser console on home page
- [ ] All landing section unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)