### PR TITLE
fix: prevent white screen after login (#164)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
   },
   plugins: ['@typescript-eslint'],
   rules: {
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
     '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,15 @@ import { Routes, Route, Outlet } from 'react-router-dom';
 import { ProtectedRoute } from '@beakerstack/shared/components/auth/ProtectedRoute.web';
 import { BillingProviderLayout } from './billing/BillingProviderLayout';
 import { AppFooter } from './components/AppFooter';
+import { AppErrorBoundary } from './components/AppErrorBoundary';
+
+function PageFallback() {
+  return (
+    <div className='min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900'>
+      <div className='inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600' />
+    </div>
+  );
+}
 
 const HomePage = lazy(() => import('./pages/HomePage'));
 const LoginPage = lazy(() => import('./pages/LoginPage'));
@@ -11,10 +20,14 @@ const DashboardPage = lazy(() => import('./pages/DashboardPage'));
 const ProfilePage = lazy(() => import('./pages/ProfilePage'));
 const AuthCallbackPage = lazy(() => import('./pages/AuthCallbackPage'));
 const PolicyPage = lazy(() => import('./pages/PolicyPage'));
-const BillingOverviewPage = lazy(() => import('./pages/billing/BillingOverviewPage'));
+const BillingOverviewPage = lazy(
+  () => import('./pages/billing/BillingOverviewPage')
+);
 const BillingUsagePage = lazy(() => import('./pages/billing/BillingUsagePage'));
 const BillingPlansPage = lazy(() => import('./pages/billing/BillingPlansPage'));
-const BillingInvoicesPage = lazy(() => import('./pages/billing/BillingInvoicesPage'));
+const BillingInvoicesPage = lazy(
+  () => import('./pages/billing/BillingInvoicesPage')
+);
 
 function RootLayout() {
   return (
@@ -30,45 +43,53 @@ function RootLayout() {
 function App() {
   return (
     <div className='bg-gray-50 dark:bg-gray-900'>
-      <Suspense fallback={null}>
-        <Routes>
-          <Route element={<RootLayout />}>
-            <Route path='/' element={<HomePage />} />
-            <Route path='/login' element={<LoginPage />} />
-            <Route path='/signup' element={<SignupPage />} />
-            <Route path='/terms' element={<PolicyPage policy='terms' />} />
-            <Route path='/privacy' element={<PolicyPage policy='privacy' />} />
-            <Route path='/refunds' element={<PolicyPage policy='refunds' />} />
-            <Route
-              path='/profile'
-              element={
-                <ProtectedRoute>
-                  <ProfilePage />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              element={
-                <ProtectedRoute>
-                  <Outlet />
-                </ProtectedRoute>
-              }
-            >
-              <Route element={<BillingProviderLayout />}>
-                <Route path='/dashboard' element={<DashboardPage />} />
-                <Route path='/billing' element={<BillingOverviewPage />} />
-                <Route path='/billing/usage' element={<BillingUsagePage />} />
-                <Route path='/billing/plans' element={<BillingPlansPage />} />
-                <Route
-                  path='/billing/invoices'
-                  element={<BillingInvoicesPage />}
-                />
+      <AppErrorBoundary>
+        <Suspense fallback={<PageFallback />}>
+          <Routes>
+            <Route element={<RootLayout />}>
+              <Route path='/' element={<HomePage />} />
+              <Route path='/login' element={<LoginPage />} />
+              <Route path='/signup' element={<SignupPage />} />
+              <Route path='/terms' element={<PolicyPage policy='terms' />} />
+              <Route
+                path='/privacy'
+                element={<PolicyPage policy='privacy' />}
+              />
+              <Route
+                path='/refunds'
+                element={<PolicyPage policy='refunds' />}
+              />
+              <Route
+                path='/profile'
+                element={
+                  <ProtectedRoute>
+                    <ProfilePage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                element={
+                  <ProtectedRoute>
+                    <Outlet />
+                  </ProtectedRoute>
+                }
+              >
+                <Route element={<BillingProviderLayout />}>
+                  <Route path='/dashboard' element={<DashboardPage />} />
+                  <Route path='/billing' element={<BillingOverviewPage />} />
+                  <Route path='/billing/usage' element={<BillingUsagePage />} />
+                  <Route path='/billing/plans' element={<BillingPlansPage />} />
+                  <Route
+                    path='/billing/invoices'
+                    element={<BillingInvoicesPage />}
+                  />
+                </Route>
               </Route>
+              <Route path='/auth/callback' element={<AuthCallbackPage />} />
             </Route>
-            <Route path='/auth/callback' element={<AuthCallbackPage />} />
-          </Route>
-        </Routes>
-      </Suspense>
+          </Routes>
+        </Suspense>
+      </AppErrorBoundary>
     </div>
   );
 }

--- a/apps/web/src/components/AppErrorBoundary.tsx
+++ b/apps/web/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+interface State {
+  error: Error | null;
+}
+
+export class AppErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  State
+> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('[AppErrorBoundary]', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className='min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4'>
+          <div className='max-w-md text-center'>
+            <p className='text-gray-900 dark:text-white font-semibold'>
+              Something went wrong.
+            </p>
+            <button
+              type='button'
+              onClick={() => window.location.reload()}
+              className='mt-4 text-sm text-indigo-600 hover:text-indigo-500'
+            >
+              Reload page
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/apps/web/src/components/AppErrorBoundary.tsx
+++ b/apps/web/src/components/AppErrorBoundary.tsx
@@ -14,10 +14,6 @@ export class AppErrorBoundary extends React.Component<
     return { error };
   }
 
-  componentDidCatch(error: Error, info: React.ErrorInfo) {
-    console.error('[AppErrorBoundary]', error, info.componentStack);
-  }
-
   render() {
     if (this.state.error) {
       return (

--- a/apps/web/src/components/__tests__/AppErrorBoundary.test.tsx
+++ b/apps/web/src/components/__tests__/AppErrorBoundary.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AppErrorBoundary } from '../AppErrorBoundary';
+
+function Bomb({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('test error');
+  return <div>OK</div>;
+}
+
+describe('AppErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('renders children when there is no error', () => {
+    render(
+      <AppErrorBoundary>
+        <Bomb shouldThrow={false} />
+      </AppErrorBoundary>
+    );
+    expect(screen.getByText('OK')).toBeDefined();
+  });
+
+  it('renders the error fallback when a child throws', () => {
+    render(
+      <AppErrorBoundary>
+        <Bomb shouldThrow={true} />
+      </AppErrorBoundary>
+    );
+    expect(screen.getByText('Something went wrong.')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Reload page' })).toBeDefined();
+  });
+
+  it('reload button calls window.location.reload', async () => {
+    const reloadSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: reloadSpy },
+      writable: true,
+    });
+
+    const user = userEvent.setup();
+    render(
+      <AppErrorBoundary>
+        <Bomb shouldThrow={true} />
+      </AppErrorBoundary>
+    );
+    await user.click(screen.getByRole('button', { name: 'Reload page' }));
+    expect(reloadSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/billing/src/hooks/useUsage.ts
+++ b/packages/billing/src/hooks/useUsage.ts
@@ -83,31 +83,40 @@ export function useUsage<
   useEffect(() => {
     if (!userId || typeof supabase.channel !== 'function') return;
     const filter = `user_id=eq.${userId}`;
-    const ch = supabase
-      .channel(
-        `billing_usage_aggregates:${config.productId}:${userId}:${meterKey}`
-      )
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'billing_usage_aggregates',
-          filter,
-        },
-        payload => {
-          const row = (payload.new ?? payload.old) as
-            | { product_id?: string; event_type?: string }
-            | undefined;
-          if (
-            row?.product_id === config.productId &&
-            row?.event_type === meterKey
-          ) {
-            void fetchUsageRef.current();
-          }
+    const ch = supabase.channel(
+      `billing_usage_aggregates:${config.productId}:${userId}:${meterKey}`
+    );
+
+    // Guard against StrictMode double-effect and remount races: if the channel
+    // is already subscribed (removeChannel is async so cleanup may lag), skip
+    // re-attaching handlers — adding .on() after subscribe() throws.
+    if (ch.state !== 'closed' && ch.state !== 'errored') {
+      return () => {
+        void supabase.removeChannel(ch);
+      };
+    }
+
+    ch.on(
+      'postgres_changes',
+      {
+        event: '*',
+        schema: 'public',
+        table: 'billing_usage_aggregates',
+        filter,
+      },
+      payload => {
+        const row = (payload.new ?? payload.old) as
+          | { product_id?: string; event_type?: string }
+          | undefined;
+        if (
+          row?.product_id === config.productId &&
+          row?.event_type === meterKey
+        ) {
+          void fetchUsageRef.current();
         }
-      )
-      .subscribe();
+      }
+    ).subscribe();
+
     return () => {
       void supabase.removeChannel(ch);
     };

--- a/packages/billing/src/hooks/useUsage.ts
+++ b/packages/billing/src/hooks/useUsage.ts
@@ -90,7 +90,7 @@ export function useUsage<
     // Guard against StrictMode double-effect and remount races: if the channel
     // is already subscribed (removeChannel is async so cleanup may lag), skip
     // re-attaching handlers — adding .on() after subscribe() throws.
-    if (ch.state !== 'closed' && ch.state !== 'errored') {
+    if (ch.state === 'joined' || ch.state === 'joining') {
       return () => {
         void supabase.removeChannel(ch);
       };

--- a/packages/shared-tests/__tests__/hooks/useAuth.test.ts
+++ b/packages/shared-tests/__tests__/hooks/useAuth.test.ts
@@ -101,6 +101,26 @@ describe('useAuth', () => {
     });
   });
 
+  it('should set user and session directly after signIn resolves, before onAuthStateChange fires', async () => {
+    const { mockClient, mockUser, mockSession } = createMockSupabaseClient();
+    const { result } = renderHook(() => useAuth(mockClient));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.signIn('test@example.com', 'password123');
+    });
+
+    // user/session must be populated immediately when signIn resolves so that
+    // callers who navigate() right after see a non-null user in ProtectedRoute
+    // (guards against the race condition where only onAuthStateChange set them).
+    expect(result.current.user).toEqual(mockUser);
+    expect(result.current.session).toEqual(mockSession);
+    expect(result.current.loading).toBe(false);
+  });
+
   it('should handle sign up with email and password', async () => {
     const { mockClient } = createMockSupabaseClient();
     const { result } = renderHook(() => useAuth(mockClient));

--- a/packages/shared/src/hooks/useAuth.ts
+++ b/packages/shared/src/hooks/useAuth.ts
@@ -37,18 +37,23 @@ export function useAuth(supabaseClient: SupabaseClient): AuthHookReturn {
     setLoading(true);
     setError(null);
 
-    const { error } = await supabaseClient.auth.signInWithPassword({
+    const { data, error } = await supabaseClient.auth.signInWithPassword({
       email,
       password,
     });
 
-    setLoading(false);
-
     if (error) {
+      setLoading(false);
       const errorObj = new Error(error.message);
       setError(errorObj);
       throw errorObj;
     }
+
+    // Set user/session immediately so callers that navigate() after signIn()
+    // see a non-null user before onAuthStateChange fires asynchronously.
+    setSession(data.session ?? null);
+    setUser(data.user ?? null);
+    setLoading(false);
   };
 
   const signUp = async (email: string, password: string): Promise<void> => {


### PR DESCRIPTION
## Summary

- **Auth race condition**: `signIn()` now sets `user`/`session` state directly from the `signInWithPassword` response before returning, so `ProtectedRoute` sees a non-null user when the caller navigates immediately after `signIn` resolves — previously only `onAuthStateChange` (async) set these, causing a `loading=false, user=null` redirect to `/`.
- **White screen on slow connections**: `<Suspense fallback={null}>` caused a literal blank screen during lazy chunk loading. Replaced with a spinner fallback and wrapped the route tree in a new `AppErrorBoundary` so chunk-load failures show an error UI instead of crashing silently.
- **useUsage realtime double-subscribe**: Guard added to check `ch.state` before attaching `postgres_changes` handlers — prevents the "cannot add callbacks after subscribe()" error that StrictMode double-effects (and the navigation remount from the auth race) could trigger.

Adds regression test: asserts `user`/`session` are non-null immediately when `signIn()` resolves, before `onAuthStateChange` fires.

## Test plan

- [ ] Log in on mobile Chrome (throttle to Slow 3G) — should see spinner during chunk load, not white screen
- [ ] Log in successfully — should land on dashboard, no redirect bounce to `/`
- [ ] Log in with wrong credentials — should show error, not white screen
- [ ] Run `useAuth` test suite — new regression test should pass
- [ ] Trigger a billing usage update in dev with StrictMode — no "cannot add callbacks after subscribe()" error in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)