### PR TITLE
fix(csp): allow Supabase Storage origins in img-src (#183)

### DIFF
--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -75,6 +75,9 @@ jobs:
       SUPABASE_PREVIEW_DB_PASSWORD: ${{ secrets.SUPABASE_PREVIEW_DB_PASSWORD }}
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_PREVIEW_DB_URL: ${{ secrets.SUPABASE_PREVIEW_DB_URL }}
+      PRODUCTION_SUPABASE_URL: ${{ secrets.PRODUCTION_SUPABASE_URL }}
+      STAGING_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+      PREVIEW_SUPABASE_URL: ${{ secrets.PREVIEW_SUPABASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/infra/aws/pr-preview-stack.yml
+++ b/infra/aws/pr-preview-stack.yml
@@ -30,6 +30,12 @@ Metadata:
           - PreviewAccessControl
           - StagingAccessControl
           - CloudFrontSigningPublicKeyId
+      - Label:
+          default: Supabase Origins (CSP)
+        Parameters:
+          - ProductionSupabaseUrl
+          - StagingSupabaseUrl
+          - PreviewSupabaseUrl
     ParameterLabels:
       DomainName:
         default: Root domain (e.g. beakerstack.com)
@@ -51,6 +57,12 @@ Metadata:
         default: Access control mode for staging distribution
       CloudFrontSigningPublicKeyId:
         default: CloudFront public key ID for signed-cookie validation (leave blank when using public mode)
+      ProductionSupabaseUrl:
+        default: Production Supabase bare origin (e.g. https://abc.supabase.co)
+      StagingSupabaseUrl:
+        default: Staging Supabase bare origin (e.g. https://def.supabase.co)
+      PreviewSupabaseUrl:
+        default: PR preview Supabase bare origin (e.g. https://ghi.supabase.co)
 
 Parameters:
   DomainName:
@@ -101,6 +113,27 @@ Parameters:
     Description: >
       ID of the CloudFront public key used to validate signed cookies. Required when
       PreviewAccessControl or StagingAccessControl is signed-cookies.
+  ProductionSupabaseUrl:
+    Type: String
+    Default: ''
+    Description: >
+      Bare origin of the production Supabase project (e.g. https://abc.supabase.co).
+      Added to img-src in the CSP to allow Supabase Storage profile images.
+      Sourced from PRODUCTION_SUPABASE_URL GitHub secret — path suffix stripped by bootstrap script.
+  StagingSupabaseUrl:
+    Type: String
+    Default: ''
+    Description: >
+      Bare origin of the staging Supabase project (e.g. https://def.supabase.co).
+      Added to img-src in the CSP to allow Supabase Storage profile images.
+      Sourced from STAGING_SUPABASE_URL GitHub secret — path suffix stripped by bootstrap script.
+  PreviewSupabaseUrl:
+    Type: String
+    Default: ''
+    Description: >
+      Bare origin of the PR preview Supabase project (e.g. https://ghi.supabase.co).
+      Added to img-src in the CSP to allow Supabase Storage profile images.
+      Sourced from PREVIEW_SUPABASE_URL GitHub secret — path suffix stripped by bootstrap script.
 
 Conditions:
   UseProvidedLogsBucketName: !Not [!Equals [!Ref LogsBucketName, '']]
@@ -508,7 +541,11 @@ Resources:
         CustomHeadersConfig:
           Items:
             - Header: Content-Security-Policy-Report-Only
-              Value: "default-src 'self'; script-src 'self' 'sha256-FIEUlQEkz8Wc0NMOe90xjaENbkODxpO7+UD6KIqw/Ac='; connect-src 'self' https://*.supabase.co wss://*.supabase.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://placehold.co; font-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+              # img-src lists specific Supabase project origins rather than the *.supabase.co
+              # wildcard so only our own storage buckets are permitted, not arbitrary Supabase
+              # tenants. Origins are sourced from per-environment GitHub secrets and injected
+              # via CloudFormation parameters — empty values are harmless (CSP ignores whitespace).
+              Value: !Sub "default-src 'self'; script-src 'self' 'sha256-FIEUlQEkz8Wc0NMOe90xjaENbkODxpO7+UD6KIqw/Ac='; connect-src 'self' https://*.supabase.co wss://*.supabase.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://placehold.co ${ProductionSupabaseUrl} ${StagingSupabaseUrl} ${PreviewSupabaseUrl}; font-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
               Override: true
 
   # Production CloudFront Distribution (beakerstack.com)

--- a/scripts/check-csp-hash.mjs
+++ b/scripts/check-csp-hash.mjs
@@ -25,6 +25,10 @@ const cfnPath = resolve(root, 'infra/aws/pr-preview-stack.yml');
 const html = readFileSync(htmlPath, 'utf8');
 const cfn = readFileSync(cfnPath, 'utf8');
 
+// Strip YAML line comments before matching so that comment lines between a
+// Header: entry and its Value: entry don't break the whitespace bridge in the regex.
+const cfnNoComments = cfn.replace(/^\s*#.*$/gm, '');
+
 // Extract content between <script id="csp-inline-theme"> and </script>
 const scriptMatch = html.match(/<script\b[^>]*\bid="csp-inline-theme"[^>]*>([\s\S]*?)<\/script>/);
 if (!scriptMatch) {
@@ -37,15 +41,15 @@ const hash = createHash('sha256').update(scriptMatch[1], 'utf8').digest('base64'
 const hashToken = `'sha256-${hash}'`;
 
 // Phase 1: Content-Security-Policy-Report-Only in CustomHeadersConfig
-// Matches: "- Header: Content-Security-Policy-Report-Only\n  Value: "..."
+// Matches: "- Header: Content-Security-Policy-Report-Only\n  Value: [!Sub ]"..."
 // Also matches the !Sub variant used when CloudFormation parameters are interpolated.
-const reportOnlyMatch = cfn.match(
+const reportOnlyMatch = cfnNoComments.match(
   /- Header:\s+Content-Security-Policy-Report-Only\s+Value:\s+(?:!Sub\s+)?"([^"]+)"/
 );
 
 // Phase 2: ContentSecurityPolicy in SecurityHeadersConfig
 // Matches: "ContentSecurityPolicy: "..."" (indented, within SecurityHeadersConfig block)
-const enforcementMatch = cfn.match(
+const enforcementMatch = cfnNoComments.match(
   /ContentSecurityPolicy:\s+"([^"]+)"/
 );
 
@@ -68,7 +72,7 @@ const location = reportOnlyMatch
 if (!cspValue.includes(hashToken)) {
   console.error(`FAIL: CSP hash mismatch in ${phase}.\n`);
   console.error('The inline theme script in apps/web/index.html has changed (or the hash');
-  console.error(`in infra/aws/pr-preview-stack.yml is stale).\n`);
+  console.error(`in infra/aws/pr-preview-stack.yml is stale.\n`);
   console.error(`Update the sha256-... token in ${location}`);
   console.error(`in infra/aws/pr-preview-stack.yml to:\n`);
   console.error(`  ${hashToken}\n`);

--- a/scripts/check-csp-hash.mjs
+++ b/scripts/check-csp-hash.mjs
@@ -38,8 +38,9 @@ const hashToken = `'sha256-${hash}'`;
 
 // Phase 1: Content-Security-Policy-Report-Only in CustomHeadersConfig
 // Matches: "- Header: Content-Security-Policy-Report-Only\n  Value: "..."
+// Also matches the !Sub variant used when CloudFormation parameters are interpolated.
 const reportOnlyMatch = cfn.match(
-  /- Header:\s+Content-Security-Policy-Report-Only\s+Value:\s+"([^"]+)"/
+  /- Header:\s+Content-Security-Policy-Report-Only\s+Value:\s+(?:!Sub\s+)?"([^"]+)"/
 );
 
 // Phase 2: ContentSecurityPolicy in SecurityHeadersConfig

--- a/scripts/pr-preview/bootstrap-aws-stack.sh
+++ b/scripts/pr-preview/bootstrap-aws-stack.sh
@@ -1077,6 +1077,24 @@ build_parameter_overrides() {
   if [[ -n "${LOGS_BUCKET_OVERRIDE}" ]]; then
     PARAMETER_OVERRIDES+=("LogsBucketName=${LOGS_BUCKET_OVERRIDE}")
   fi
+
+  # Extract bare origin (scheme + host only) from each Supabase URL and pass to CloudFormation
+  # for the CSP img-src directive. The env vars may include a path suffix (e.g. /rest/v1), which
+  # would malform the directive — strip it here so CloudFormation receives a clean origin.
+  for _supabase_entry in \
+      "PRODUCTION_SUPABASE_URL:ProductionSupabaseUrl" \
+      "STAGING_SUPABASE_URL:StagingSupabaseUrl" \
+      "PREVIEW_SUPABASE_URL:PreviewSupabaseUrl"; do
+    _env_var="${_supabase_entry%%:*}"
+    _cfn_param="${_supabase_entry##*:}"
+    _raw_url="${!_env_var:-}"
+    if [[ -n "${_raw_url}" ]]; then
+      _url="${_raw_url%/}"                        # strip trailing slash
+      _scheme="${_url%%://*}"                     # e.g. https
+      _host="${_url#*://}"; _host="${_host%%/*}"  # strip scheme then any path
+      PARAMETER_OVERRIDES+=("${_cfn_param}=${_scheme}://${_host}")
+    fi
+  done
 }
 
 # Empty AWS_PROFILE in the environment makes AWS CLI try profile "" ("config profile () could not be found").

--- a/scripts/pr-preview/bootstrap-aws-stack.sh
+++ b/scripts/pr-preview/bootstrap-aws-stack.sh
@@ -1092,7 +1092,15 @@ build_parameter_overrides() {
       _url="${_raw_url%/}"                        # strip trailing slash
       _scheme="${_url%%://*}"                     # e.g. https
       _host="${_url#*://}"; _host="${_host%%/*}"  # strip scheme then any path
-      PARAMETER_OVERRIDES+=("${_cfn_param}=${_scheme}://${_host}")
+      _origin="${_scheme}://${_host}"
+      # Validate: must be https with a single hostname containing only safe chars.
+      # Rejects values with spaces, semicolons, or other CSP-special characters that
+      # would malform the directive or broaden img-src beyond the intended origins.
+      if [[ "${_origin}" =~ ^https://[A-Za-z0-9._-]+$ ]]; then
+        PARAMETER_OVERRIDES+=("${_cfn_param}=${_origin}")
+      else
+        log "WARN" "Skipping ${_cfn_param}: '${_origin}' is not a valid HTTPS origin — check the ${_env_var} secret value"
+      fi
     fi
   done
 }

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -1625,7 +1625,16 @@ async function phaseAws(flags, rl, acc) {
   }
 
   logInfo('Running bootstrap-aws-stack.sh (outputs go to .env.aws.generated.local)');
-  const code = runInteractive('bash', args, { cwd: REPO_ROOT, env: childProcessEnvForSpawn() });
+  // Merge accumulated Supabase URLs into the child environment so bootstrap-aws-stack.sh
+  // can inject them into the CloudFormation CSP parameters. These values live in acc (not
+  // process.env) because they were discovered interactively during this setup session.
+  const bootstrapEnv = {
+    ...childProcessEnvForSpawn(),
+    ...(acc.PRODUCTION_SUPABASE_URL && { PRODUCTION_SUPABASE_URL: acc.PRODUCTION_SUPABASE_URL }),
+    ...(acc.STAGING_SUPABASE_URL && { STAGING_SUPABASE_URL: acc.STAGING_SUPABASE_URL }),
+    ...(acc.PREVIEW_SUPABASE_URL && { PREVIEW_SUPABASE_URL: acc.PREVIEW_SUPABASE_URL }),
+  };
+  const code = runInteractive('bash', args, { cwd: REPO_ROOT, env: bootstrapEnv });
   if (code !== 0) {
     logWarn(
       'AWS bootstrap failed. Common causes: retained S3 buckets for this apex (see preflight), duplicate CloudFront aliases, IAM permissions, or ACM in us-east-1. Scroll up for [DIAG] lines from bootstrap-aws-stack.sh.',


### PR DESCRIPTION
## Summary

Fixes #183 — Supabase profile images blocked by CloudFront CSP.

- **`infra/aws/pr-preview-stack.yml`**: Adds three CloudFormation parameters (`ProductionSupabaseUrl`, `StagingSupabaseUrl`, `PreviewSupabaseUrl`) with empty defaults. Updates `img-src` from the hardcoded `https://placehold.co` to include all three via `!Sub`. Adds a comment explaining why specific origins are used over `*.supabase.co` (only our own buckets, not arbitrary Supabase tenants).
- **`scripts/pr-preview/bootstrap-aws-stack.sh`**: Reads `PRODUCTION_SUPABASE_URL`, `STAGING_SUPABASE_URL`, and `PREVIEW_SUPABASE_URL` env vars; strips any path suffix (e.g. `/rest/v1`) to extract a clean bare origin; appends as CloudFormation parameter overrides.
- **`.github/workflows/pr-preview-environment.yml`**: Adds the three Supabase URL secrets to the job-level `env` block so `bootstrap-aws-stack.sh` can read them.

Production and staging deploy workflows do not call `bootstrap-aws-stack.sh` (they resolve stack outputs and upload files only), so no changes are needed there — all three environment URLs are passed through the single PR preview bootstrap run that manages the shared CloudFormation stack.

## Test plan

- [ ] Open a PR to trigger `pr-preview-environment.yml`; confirm bootstrap step exits 0
- [ ] Confirm CloudFormation stack update shows `BeakerStackResponseHeadersPolicy` changed with the three Supabase origins in `img-src`
- [ ] Load a page with a user profile image on preview; confirm no CSP violation in browser console
- [ ] Confirm CSP report-only header on production still includes all three origins after next bootstrap run

🤖 Generated with [Claude Code](https://claude.com/claude-code)