### PR TITLE
fix: align dashboard content width with header/footer

### DIFF
--- a/apps/web/src/components/dashboard/DeveloperConsole.tsx
+++ b/apps/web/src/components/dashboard/DeveloperConsole.tsx
@@ -121,7 +121,7 @@ interface DeveloperConsoleProps {
 export function DeveloperConsole({ activityLog }: DeveloperConsoleProps) {
   return (
     <div className='w-full border-t border-slate-700 bg-slate-900 text-slate-100'>
-      <div className='mx-auto max-w-[1400px] px-4 py-6 sm:px-6'>
+      <div className='mx-auto max-w-[1024px] px-4 py-6 sm:px-6'>
         <p className='text-xs font-semibold uppercase tracking-widest text-slate-400 mb-5'>
           Developer Console
         </p>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -62,7 +62,7 @@ export default function DashboardPage() {
     <div className='min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col'>
       <AppHeader supabaseClient={supabase} />
 
-      <main className='flex-1 w-full max-w-[1400px] mx-auto px-4 py-6 sm:px-6 space-y-6'>
+      <main className='flex-1 w-full max-w-[1024px] mx-auto px-4 py-6 sm:px-6 space-y-6'>
         <DemoBanner />
 
         <AnnotatedPrimitive


### PR DESCRIPTION
## Summary
- `DashboardPage <main>` and `DeveloperConsole` inner container both used `max-w-[1400px]`, while `AppHeader` and `AppFooter` both cap at `max-w-[1024px]`. On wide viewports the dashboard content and console spilled outside the chrome width.
- Changed both to `max-w-[1024px]` to match.

Closes #192