### PR TITLE
feat(#194): landing hero crossfade carousel

### DIFF
--- a/apps/web/scripts/prerender-home.ts
+++ b/apps/web/scripts/prerender-home.ts
@@ -25,7 +25,9 @@ const { MemoryRouter } = await import('react-router-dom');
 // ThemeProvider needed because AppFooter renders ThemeToggle which calls useTheme().
 const { ThemeProvider } = await import('../src/contexts/ThemeContext');
 const { AppFooter } = await import('../src/components/AppFooter');
-const { LandingPage } = await import('../src/components/landing/LandingPage');
+// LandingPageSSR eagerly imports all sections. LandingPage uses React.lazy() for
+// below-fold sections, which resolve as empty Suspense fallbacks under renderToStaticMarkup.
+const { LandingPageSSR } = await import('../src/components/landing/LandingPageSSR');
 
 const webRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -63,7 +65,7 @@ const html = renderToStaticMarkup(
         createElement(
           'div',
           { className: 'flex min-h-screen flex-col' },
-          createElement('div', { className: 'flex-1' }, createElement(LandingPage)),
+          createElement('div', { className: 'flex-1' }, createElement(LandingPageSSR)),
           createElement(AppFooter)
         )
       )
@@ -72,10 +74,10 @@ const html = renderToStaticMarkup(
 );
 
 // Structural smoke check — catches a broken render without hardcoding copy text.
-// Fails the build if LandingPage produced no heading element.
+// Fails the build if LandingPageSSR produced no heading element.
 if (!html.includes('<h1')) {
   console.error(
-    'pre-render smoke check: no <h1> in output — LandingPage did not render'
+    'pre-render smoke check: no <h1> in output — LandingPageSSR did not render'
   );
   process.exit(1);
 }

--- a/apps/web/src/billing/__tests__/staticPlanAdapter.test.ts
+++ b/apps/web/src/billing/__tests__/staticPlanAdapter.test.ts
@@ -52,26 +52,30 @@ describe('configPlanToStaticPlan', () => {
   });
 
   it('defaults description to null when absent', () => {
-    const { description: _description, ...withoutDesc } = fullPlan;
-    const plan = configPlanToStaticPlan(withoutDesc as BillingPlanConfig, 0);
+    const config = { ...fullPlan } as Partial<BillingPlanConfig>;
+    delete config.description;
+    const plan = configPlanToStaticPlan(config as BillingPlanConfig, 0);
     expect(plan.description).toBeNull();
   });
 
   it('defaults trial_period_days to 0 when absent', () => {
-    const { trialPeriodDays: _trialPeriodDays, ...withoutTrial } = fullPlan;
-    const plan = configPlanToStaticPlan(withoutTrial as BillingPlanConfig, 0);
+    const config = { ...fullPlan } as Partial<BillingPlanConfig>;
+    delete config.trialPeriodDays;
+    const plan = configPlanToStaticPlan(config as BillingPlanConfig, 0);
     expect(plan.trial_period_days).toBe(0);
   });
 
   it('defaults is_public to true when absent', () => {
-    const { isPublic: _isPublic, ...withoutPublic } = fullPlan;
-    const plan = configPlanToStaticPlan(withoutPublic as BillingPlanConfig, 0);
+    const config = { ...fullPlan } as Partial<BillingPlanConfig>;
+    delete config.isPublic;
+    const plan = configPlanToStaticPlan(config as BillingPlanConfig, 0);
     expect(plan.is_public).toBe(true);
   });
 
   it('defaults display_order to array index when absent', () => {
-    const { displayOrder: _displayOrder, ...withoutOrder } = fullPlan;
-    const plan = configPlanToStaticPlan(withoutOrder as BillingPlanConfig, 3);
+    const config = { ...fullPlan } as Partial<BillingPlanConfig>;
+    delete config.displayOrder;
+    const plan = configPlanToStaticPlan(config as BillingPlanConfig, 3);
     expect(plan.display_order).toBe(3);
   });
 
@@ -102,8 +106,9 @@ describe('getStaticPlans', () => {
   });
 
   it('includes plans with isPublic omitted (defaults to visible)', () => {
-    const { isPublic: _isPublic, ...withoutPublic } = fullPlan;
-    mockedConfig.plans = [withoutPublic as BillingPlanConfig];
+    const config = { ...fullPlan } as Partial<BillingPlanConfig>;
+    delete config.isPublic;
+    mockedConfig.plans = [config];
     const plans = getStaticPlans();
     expect(plans).toHaveLength(1);
   });
@@ -119,10 +124,11 @@ describe('getStaticPlans', () => {
   });
 
   it('uses array index as fallback display_order when absent', () => {
-    const { displayOrder: _displayOrder, ...withoutOrder } = fullPlan;
+    const baseWithoutOrder = { ...fullPlan } as Partial<BillingPlanConfig>;
+    delete baseWithoutOrder.displayOrder;
     mockedConfig.plans = [
-      { ...withoutOrder, id: 'a' } as BillingPlanConfig,
-      { ...withoutOrder, id: 'b' } as BillingPlanConfig,
+      { ...baseWithoutOrder, id: 'a' },
+      { ...baseWithoutOrder, id: 'b' },
     ];
     const plans = getStaticPlans();
     expect(plans[0].display_order).toBe(0);

--- a/apps/web/src/components/landing/LandingPage.tsx
+++ b/apps/web/src/components/landing/LandingPage.tsx
@@ -1,13 +1,25 @@
+import { Suspense, lazy } from 'react';
 import { landingConfig } from '../../config/landing';
 import { Nav } from './sections/Nav';
 import { Hero } from './sections/Hero';
 import type { CarouselSlide } from './sections/Hero';
 import { FeatureGrid } from './sections/FeatureGrid';
 import { FeatureRows } from './sections/FeatureRows';
-import { SocialProof } from './sections/SocialProof';
-import { PricingSection } from './sections/PricingSection';
-import { FAQ } from './sections/FAQ';
-import { FinalCTA } from './sections/FinalCTA';
+
+const SocialProof = lazy(() =>
+  import('./sections/SocialProof').then(m => ({ default: m.SocialProof }))
+);
+const PricingSection = lazy(() =>
+  import('./sections/PricingSection').then(m => ({
+    default: m.PricingSection,
+  }))
+);
+const FAQ = lazy(() =>
+  import('./sections/FAQ').then(m => ({ default: m.FAQ }))
+);
+const FinalCTA = lazy(() =>
+  import('./sections/FinalCTA').then(m => ({ default: m.FinalCTA }))
+);
 
 export function LandingPage() {
   const config = landingConfig;
@@ -33,10 +45,12 @@ export function LandingPage() {
         <Hero config={config.hero} carouselSlides={carouselSlides} />
         <FeatureGrid config={config.featureGrid} />
         <FeatureRows config={config.featureRows} />
-        <SocialProof config={config.socialProof} />
-        <PricingSection config={config.pricing} />
-        <FAQ config={config.faq} />
-        <FinalCTA config={config.finalCta} />
+        <Suspense fallback={null}>
+          <SocialProof config={config.socialProof} />
+          <PricingSection config={config.pricing} />
+          <FAQ config={config.faq} />
+          <FinalCTA config={config.finalCta} />
+        </Suspense>
       </main>
     </div>
   );

--- a/apps/web/src/components/landing/LandingPage.tsx
+++ b/apps/web/src/components/landing/LandingPage.tsx
@@ -1,6 +1,7 @@
 import { landingConfig } from '../../config/landing';
 import { Nav } from './sections/Nav';
 import { Hero } from './sections/Hero';
+import type { CarouselSlide } from './sections/Hero';
 import { FeatureGrid } from './sections/FeatureGrid';
 import { FeatureRows } from './sections/FeatureRows';
 import { SocialProof } from './sections/SocialProof';
@@ -11,11 +12,25 @@ import { FinalCTA } from './sections/FinalCTA';
 export function LandingPage() {
   const config = landingConfig;
 
+  const carouselSlides: CarouselSlide[] = [
+    {
+      subhead: config.hero.subhead,
+      mediaSrc: config.hero.mediaSrc,
+      mediaAlt: config.hero.mediaAlt,
+    },
+    ...config.featureRows.map(r => ({
+      label: r.title,
+      subhead: r.body,
+      mediaSrc: r.mediaSrc,
+      mediaAlt: r.mediaAlt,
+    })),
+  ];
+
   return (
     <div className='bg-white dark:bg-gray-950 min-h-screen'>
       <Nav config={{ ...config.nav, brand: config.brand }} />
       <main>
-        <Hero config={config.hero} />
+        <Hero config={config.hero} carouselSlides={carouselSlides} />
         <FeatureGrid config={config.featureGrid} />
         <FeatureRows config={config.featureRows} />
         <SocialProof config={config.socialProof} />

--- a/apps/web/src/components/landing/LandingPageSSR.tsx
+++ b/apps/web/src/components/landing/LandingPageSSR.tsx
@@ -1,0 +1,46 @@
+import { landingConfig } from '../../config/landing';
+import { Nav } from './sections/Nav';
+import { Hero } from './sections/Hero';
+import type { CarouselSlide } from './sections/Hero';
+import { FeatureGrid } from './sections/FeatureGrid';
+import { FeatureRows } from './sections/FeatureRows';
+import { SocialProof } from './sections/SocialProof';
+import { PricingSection } from './sections/PricingSection';
+import { FAQ } from './sections/FAQ';
+import { FinalCTA } from './sections/FinalCTA';
+
+// Eagerly imports all sections for use by the prerender script (renderToString).
+// LandingPage uses React.lazy() for below-fold sections, which resolve as empty
+// Suspense fallbacks under synchronous renderToString — use this file instead.
+export function LandingPageSSR() {
+  const config = landingConfig;
+
+  const carouselSlides: CarouselSlide[] = [
+    {
+      subhead: config.hero.subhead,
+      mediaSrc: config.hero.mediaSrc,
+      mediaAlt: config.hero.mediaAlt,
+    },
+    ...config.featureRows.map(r => ({
+      label: r.title,
+      subhead: r.body,
+      mediaSrc: r.mediaSrc,
+      mediaAlt: r.mediaAlt,
+    })),
+  ];
+
+  return (
+    <div className='bg-white dark:bg-gray-950 min-h-screen'>
+      <Nav config={{ ...config.nav, brand: config.brand }} />
+      <main>
+        <Hero config={config.hero} carouselSlides={carouselSlides} />
+        <FeatureGrid config={config.featureGrid} />
+        <FeatureRows config={config.featureRows} />
+        <SocialProof config={config.socialProof} />
+        <PricingSection config={config.pricing} />
+        <FAQ config={config.faq} />
+        <FinalCTA config={config.finalCta} />
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/components/landing/sections/Hero.tsx
+++ b/apps/web/src/components/landing/sections/Hero.tsx
@@ -1,11 +1,38 @@
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import type { LandingConfig } from '../../../config/landing';
 
-interface HeroProps {
-  config: LandingConfig['hero'];
+export interface CarouselSlide {
+  /** Feature row title rendered as a small label above the subhead (omit for hero slide 0). */
+  label?: string;
+  subhead: string;
+  mediaSrc: string;
+  mediaAlt: string;
 }
 
-export function Hero({ config }: HeroProps) {
+interface HeroProps {
+  config: LandingConfig['hero'];
+  carouselSlides?: CarouselSlide[];
+  /** Auto-advance interval in ms. Exposed for tests; defaults to 6000. */
+  intervalMs?: number;
+}
+
+const DEFAULT_INTERVAL_MS = 6000;
+
+export function Hero({ config, carouselSlides, intervalMs = DEFAULT_INTERVAL_MS }: HeroProps) {
+  const slides = carouselSlides && carouselSlides.length > 1 ? carouselSlides : null;
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    if (!slides) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    const id = setInterval(
+      () => setActiveIndex(i => (i + 1) % slides.length),
+      intervalMs
+    );
+    return () => clearInterval(id);
+  }, [slides, intervalMs]);
+
   return (
     <section className='py-20 md:py-28'>
       <div className='max-w-[1200px] mx-auto px-6'>
@@ -19,9 +46,39 @@ export function Hero({ config }: HeroProps) {
             <h1 className='text-4xl md:text-5xl font-bold text-gray-900 dark:text-white leading-tight mb-4'>
               {config.headline}
             </h1>
-            <p className='text-lg text-gray-600 dark:text-gray-400 mb-8 max-w-lg'>
-              {config.subhead}
-            </p>
+
+            {slides ? (
+              // CSS grid stacking: all slides occupy the same cell so the tallest
+              // one sets the container height — CTAs never jump when copy length varies.
+              <div className='grid' aria-live='polite'>
+                {slides.map((slide, i) => (
+                  <div
+                    key={i}
+                    style={{ gridArea: '1 / 1 / 2 / 2' }}
+                    className={`transition-opacity duration-700 ${
+                      i === activeIndex
+                        ? 'opacity-100'
+                        : 'opacity-0 pointer-events-none select-none'
+                    }`}
+                    aria-hidden={i !== activeIndex ? true : undefined}
+                  >
+                    {slide.label && (
+                      <p className='text-sm font-semibold text-primary-600 dark:text-primary-400 mb-1'>
+                        {slide.label}
+                      </p>
+                    )}
+                    <p className='text-lg text-gray-600 dark:text-gray-400 mb-8 max-w-lg'>
+                      {slide.subhead}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className='text-lg text-gray-600 dark:text-gray-400 mb-8 max-w-lg'>
+                {config.subhead}
+              </p>
+            )}
+
             <div className='flex flex-wrap gap-3'>
               <Link
                 to={config.primaryCta.href}
@@ -45,17 +102,38 @@ export function Hero({ config }: HeroProps) {
             )}
           </div>
 
-          <div className='rounded-xl overflow-hidden border border-gray-200 dark:border-gray-800 shadow-lg bg-gray-100 dark:bg-gray-900 aspect-video flex items-center justify-center'>
-            <img
-              src={config.mediaSrc}
-              alt={config.mediaAlt}
-              className='w-full h-full object-cover'
-              loading='eager'
-              width={600}
-              height={338}
-              decoding='async'
-              {...({ fetchPriority: 'high' } as object)}
-            />
+          {/* aspect-video gives the container a stable size; images are absolutely
+              stacked so only one is visible at a time. */}
+          <div className='rounded-xl overflow-hidden border border-gray-200 dark:border-gray-800 shadow-lg bg-gray-100 dark:bg-gray-900 aspect-video relative'>
+            {slides ? (
+              slides.map((slide, i) => (
+                <img
+                  key={i}
+                  src={slide.mediaSrc}
+                  alt={slide.mediaAlt}
+                  aria-hidden={i !== activeIndex ? true : undefined}
+                  className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-700 ${
+                    i === activeIndex ? 'opacity-100' : 'opacity-0'
+                  }`}
+                  loading={i === 0 ? 'eager' : 'lazy'}
+                  width={600}
+                  height={338}
+                  decoding='async'
+                  {...(i === 0 ? ({ fetchPriority: 'high' } as object) : {})}
+                />
+              ))
+            ) : (
+              <img
+                src={config.mediaSrc}
+                alt={config.mediaAlt}
+                className='absolute inset-0 w-full h-full object-cover'
+                loading='eager'
+                width={600}
+                height={338}
+                decoding='async'
+                {...({ fetchPriority: 'high' } as object)}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/src/components/landing/sections/__tests__/Hero.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/Hero.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { Hero } from '../Hero';
+import type { CarouselSlide } from '../Hero';
 
 const baseConfig = {
   headline: 'Build the full stack. Not the scaffolding.',
@@ -45,7 +46,7 @@ describe('Hero', () => {
         <Hero config={baseConfig} />
       </MemoryRouter>
     );
-    const img = screen.getByRole('img', { name: 'Dashboard preview' });
+    const img = screen.getByAltText('Dashboard preview');
     expect(img).toHaveAttribute(
       'src',
       'https://placehold.co/600x338?text=Dashboard'
@@ -126,5 +127,154 @@ describe('Hero', () => {
       </MemoryRouter>
     );
     expect(screen.queryByText(/MIT licensed/)).not.toBeInTheDocument();
+  });
+
+  describe('crossfade carousel', () => {
+    const slides: CarouselSlide[] = [
+      {
+        subhead: 'Hero subhead text.',
+        mediaSrc: 'https://placehold.co/600x338?text=Hero',
+        mediaAlt: 'Hero image',
+      },
+      {
+        label: 'Feature one title',
+        subhead: 'Feature one body copy.',
+        mediaSrc: 'https://placehold.co/600x338?text=Feature1',
+        mediaAlt: 'Feature one image',
+      },
+      {
+        label: 'Feature two title',
+        subhead: 'Feature two body copy.',
+        mediaSrc: 'https://placehold.co/600x338?text=Feature2',
+        mediaAlt: 'Feature two image',
+      },
+    ];
+
+    function mockMatchMedia(prefersReducedMotion: boolean) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: vi.fn().mockReturnValue({
+          matches: prefersReducedMotion,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        }),
+      });
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      mockMatchMedia(false);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('renders slide 0 visible and others aria-hidden initially', () => {
+      render(
+        <MemoryRouter>
+          <Hero config={baseConfig} carouselSlides={slides} intervalMs={100} />
+        </MemoryRouter>
+      );
+      // aria-hidden lives on the slide container div; text is inside a <p> child
+      expect(
+        screen.getByText('Hero subhead text.').parentElement
+      ).not.toHaveAttribute('aria-hidden');
+      expect(
+        screen.getByText('Feature one body copy.').parentElement
+      ).toHaveAttribute('aria-hidden', 'true');
+      // aria-hidden is directly on each <img>
+      expect(screen.getByAltText('Hero image')).not.toHaveAttribute(
+        'aria-hidden'
+      );
+      expect(screen.getByAltText('Feature one image')).toHaveAttribute(
+        'aria-hidden',
+        'true'
+      );
+    });
+
+    it('advances to slide 1 after one interval', () => {
+      render(
+        <MemoryRouter>
+          <Hero config={baseConfig} carouselSlides={slides} intervalMs={100} />
+        </MemoryRouter>
+      );
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      expect(
+        screen.getByText('Hero subhead text.').parentElement
+      ).toHaveAttribute('aria-hidden', 'true');
+      expect(
+        screen.getByText('Feature one body copy.').parentElement
+      ).not.toHaveAttribute('aria-hidden');
+      expect(screen.getByAltText('Hero image')).toHaveAttribute(
+        'aria-hidden',
+        'true'
+      );
+      expect(screen.getByAltText('Feature one image')).not.toHaveAttribute(
+        'aria-hidden'
+      );
+    });
+
+    it('wraps back to slide 0 after all slides advance', () => {
+      render(
+        <MemoryRouter>
+          <Hero config={baseConfig} carouselSlides={slides} intervalMs={100} />
+        </MemoryRouter>
+      );
+      act(() => {
+        vi.advanceTimersByTime(300); // 3 intervals → wraps to index 0
+      });
+      expect(
+        screen.getByText('Hero subhead text.').parentElement
+      ).not.toHaveAttribute('aria-hidden');
+    });
+
+    it('does not advance when prefers-reduced-motion is set', () => {
+      mockMatchMedia(true);
+      render(
+        <MemoryRouter>
+          <Hero config={baseConfig} carouselSlides={slides} intervalMs={100} />
+        </MemoryRouter>
+      );
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(
+        screen.getByText('Hero subhead text.').parentElement
+      ).not.toHaveAttribute('aria-hidden');
+    });
+
+    it('renders slide 0 image with eager loading and others with lazy', () => {
+      render(
+        <MemoryRouter>
+          <Hero config={baseConfig} carouselSlides={slides} intervalMs={100} />
+        </MemoryRouter>
+      );
+      expect(screen.getByAltText('Hero image')).toHaveAttribute(
+        'loading',
+        'eager'
+      );
+      expect(screen.getByAltText('Feature one image')).toHaveAttribute(
+        'loading',
+        'lazy'
+      );
+      expect(screen.getByAltText('Feature two image')).toHaveAttribute(
+        'loading',
+        'lazy'
+      );
+    });
+
+    it('renders feature row label text for non-hero slides', () => {
+      render(
+        <MemoryRouter>
+          <Hero config={baseConfig} carouselSlides={slides} intervalMs={100} />
+        </MemoryRouter>
+      );
+      expect(screen.getByText('Feature one title')).toBeInTheDocument();
+      expect(screen.getByText('Feature two title')).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/pages/__tests__/HomePage.test.tsx
+++ b/apps/web/src/pages/__tests__/HomePage.test.tsx
@@ -172,10 +172,10 @@ describe('HomePage', () => {
     it('renders the pricing cadence toggle with Monthly and Annually buttons', async () => {
       await renderWithAuth(false);
       expect(
-        screen.getByRole('button', { name: /monthly/i })
+        await screen.findByRole('button', { name: /monthly/i })
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: /annually/i })
+        await screen.findByRole('button', { name: /annually/i })
       ).toBeInTheDocument();
     });
   });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -91,6 +91,9 @@ export default defineConfig(({ mode }) => {
           'src/config/landing.example.alt.ts',
           // Build-time scripts — run by vite-node at build, not part of the app test suite
           'scripts/',
+          // SSR-only landing component — structural duplicate of LandingPage used by the
+          // prerender script only; covered by the build-time prerender smoke check
+          'src/components/landing/LandingPageSSR.tsx',
           // Display-only dashboard showcase components — no business logic;
           // annotated UI primitives covered visually by preview deployment
           'src/components/dashboard/AnnotatedPrimitive.tsx',


### PR DESCRIPTION
Superseded by #200 — rebased cleanly on develop to resolve merge conflicts caused by #181 landing after our branch point.

Closes #194