### PR TITLE
fix: block all Summarize buttons while any summarize RPC is in flight

### DIFF
--- a/apps/web/src/components/dashboard/CollectionDetail.tsx
+++ b/apps/web/src/components/dashboard/CollectionDetail.tsx
@@ -62,6 +62,9 @@ export function CollectionDetail({ collection, addItem, onActivity }: Props) {
   const [addErr, setAddErr] = useState<string | null>(null);
   const [featureToast, setFeatureToast] = useState<string | null>(null);
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Tracks how many summarize RPCs are currently in flight. A ref (not state)
+  // so the guard in onSummarize always sees the current value without a stale closure.
+  const inFlightRef = useRef(0);
 
   // Reset per-item summarize state when the selected collection changes.
   useEffect(() => {
@@ -82,7 +85,8 @@ export function CollectionDetail({ collection, addItem, onActivity }: Props) {
 
   const onSummarize = useCallback(
     async (itemIndex: number) => {
-      if (!collection || usageExceeded || summarizeBusy.size > 0) return;
+      if (!collection || usageExceeded || inFlightRef.current > 0) return;
+      inFlightRef.current += 1;
       setSummarizeBusy(prev => new Set(prev).add(itemIndex));
       setSummarizeErrors(prev => {
         const next = new Map(prev);
@@ -121,6 +125,7 @@ export function CollectionDetail({ collection, addItem, onActivity }: Props) {
           new Map(prev).set(itemIndex, mapUnknownError(e))
         );
       } finally {
+        inFlightRef.current -= 1;
         setSummarizeBusy(prev => {
           const next = new Set(prev);
           next.delete(itemIndex);
@@ -251,9 +256,8 @@ export function CollectionDetail({ collection, addItem, onActivity }: Props) {
                   <span className='text-sm font-medium text-gray-800 dark:text-gray-200'>
                     Item {i + 1}
                   </span>
-                  <button
-                    type='button'
-                    disabled={anySummarizeBusy || usageExceeded || usageLoading}
+                  {/* Wrapper span carries the tooltip so it's visible even when the button is disabled */}
+                  <span
                     title={
                       usageExceeded
                         ? 'AI summarize limit reached'
@@ -261,16 +265,27 @@ export function CollectionDetail({ collection, addItem, onActivity }: Props) {
                           ? 'Another item is being summarized'
                           : undefined
                     }
-                    onClick={() => void onSummarize(i)}
-                    className='inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50'
                   >
-                    <Sparkles className='h-3 w-3' aria-hidden />
-                    {isBusy
-                      ? '…'
-                      : usageExceeded
-                        ? 'Limit reached'
-                        : 'Summarize'}
-                  </button>
+                    <button
+                      type='button'
+                      disabled={anySummarizeBusy || usageExceeded || usageLoading}
+                      aria-describedby={anySummarizeBusy && !isBusy ? `summarize-wait-${i}` : undefined}
+                      onClick={() => void onSummarize(i)}
+                      className='inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50'
+                    >
+                      <Sparkles className='h-3 w-3' aria-hidden />
+                      {isBusy
+                        ? '…'
+                        : usageExceeded
+                          ? 'Limit reached'
+                          : 'Summarize'}
+                    </button>
+                    {anySummarizeBusy && !isBusy && (
+                      <span id={`summarize-wait-${i}`} className='sr-only'>
+                        Another item is being summarized. Please wait.
+                      </span>
+                    )}
+                  </span>
                 </div>
                 {err && (
                   <p className='mt-1 text-xs text-red-600' role='alert'>{err.message}</p>

--- a/apps/web/src/components/dashboard/CollectionDetail.tsx
+++ b/apps/web/src/components/dashboard/CollectionDetail.tsx
@@ -82,7 +82,7 @@ export function CollectionDetail({ collection, addItem, onActivity }: Props) {
 
   const onSummarize = useCallback(
     async (itemIndex: number) => {
-      if (!collection || usageExceeded) return;
+      if (!collection || usageExceeded || summarizeBusy.size > 0) return;
       setSummarizeBusy(prev => new Set(prev).add(itemIndex));
       setSummarizeErrors(prev => {
         const next = new Map(prev);
@@ -154,6 +154,7 @@ export function CollectionDetail({ collection, addItem, onActivity }: Props) {
   }
 
   const itemRows = Array.from({ length: itemCount }, (_, i) => i);
+  const anySummarizeBusy = summarizeBusy.size > 0;
 
   return (
     <div>
@@ -252,11 +253,13 @@ export function CollectionDetail({ collection, addItem, onActivity }: Props) {
                   </span>
                   <button
                     type='button'
-                    disabled={isBusy || usageExceeded || usageLoading}
+                    disabled={anySummarizeBusy || usageExceeded || usageLoading}
                     title={
                       usageExceeded
                         ? 'AI summarize limit reached'
-                        : undefined
+                        : anySummarizeBusy && !isBusy
+                          ? 'Another item is being summarized'
+                          : undefined
                     }
                     onClick={() => void onSummarize(i)}
                     className='inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50'


### PR DESCRIPTION
## Problem
Each Summarize button only disabled itself while its own RPC call was pending. A user with one remaining summarize event could click two different item rows before the first `refreshUsage()` resolved — both would read `usageExceeded: false` and both would fire the RPC, resulting in an unexpected billing error on the second call.

## Fix
Derive `anySummarizeBusy = summarizeBusy.size > 0` and use it to disable **all** Summarize buttons while any call is in flight. The active row still shows `…`; idle rows show a tooltip explaining why they're blocked. The callback also guards against this race directly.

Closes #188