### PR TITLE
feat(web): crossfade carousel in landing hero (issue #194)

### DIFF
--- a/apps/web/src/components/landing/LandingPage.tsx
+++ b/apps/web/src/components/landing/LandingPage.tsx
@@ -1,8 +1,7 @@
-import { Suspense, lazy } from 'react';
+import { Suspense, lazy, useMemo } from 'react';
 import { landingConfig } from '../../config/landing';
 import { Nav } from './sections/Nav';
-import { Hero } from './sections/Hero';
-import type { CarouselSlide } from './sections/Hero';
+import { Hero, buildCarouselSlides } from './sections/Hero';
 import { FeatureGrid } from './sections/FeatureGrid';
 import { FeatureRows } from './sections/FeatureRows';
 
@@ -23,20 +22,7 @@ const FinalCTA = lazy(() =>
 
 export function LandingPage() {
   const config = landingConfig;
-
-  const carouselSlides: CarouselSlide[] = [
-    {
-      subhead: config.hero.subhead,
-      mediaSrc: config.hero.mediaSrc,
-      mediaAlt: config.hero.mediaAlt,
-    },
-    ...config.featureRows.map(r => ({
-      label: r.title,
-      subhead: r.body,
-      mediaSrc: r.mediaSrc,
-      mediaAlt: r.mediaAlt,
-    })),
-  ];
+  const carouselSlides = useMemo(() => buildCarouselSlides(config), [config]);
 
   return (
     <div className='bg-white dark:bg-gray-950 min-h-screen'>

--- a/apps/web/src/components/landing/LandingPage.tsx
+++ b/apps/web/src/components/landing/LandingPage.tsx
@@ -2,6 +2,7 @@ import { Suspense, lazy } from 'react';
 import { landingConfig } from '../../config/landing';
 import { Nav } from './sections/Nav';
 import { Hero } from './sections/Hero';
+import type { CarouselSlide } from './sections/Hero';
 import { FeatureGrid } from './sections/FeatureGrid';
 import { FeatureRows } from './sections/FeatureRows';
 
@@ -9,7 +10,9 @@ const SocialProof = lazy(() =>
   import('./sections/SocialProof').then(m => ({ default: m.SocialProof }))
 );
 const PricingSection = lazy(() =>
-  import('./sections/PricingSection').then(m => ({ default: m.PricingSection }))
+  import('./sections/PricingSection').then(m => ({
+    default: m.PricingSection,
+  }))
 );
 const FAQ = lazy(() =>
   import('./sections/FAQ').then(m => ({ default: m.FAQ }))
@@ -21,11 +24,25 @@ const FinalCTA = lazy(() =>
 export function LandingPage() {
   const config = landingConfig;
 
+  const carouselSlides: CarouselSlide[] = [
+    {
+      subhead: config.hero.subhead,
+      mediaSrc: config.hero.mediaSrc,
+      mediaAlt: config.hero.mediaAlt,
+    },
+    ...config.featureRows.map(r => ({
+      label: r.title,
+      subhead: r.body,
+      mediaSrc: r.mediaSrc,
+      mediaAlt: r.mediaAlt,
+    })),
+  ];
+
   return (
     <div className='bg-white dark:bg-gray-950 min-h-screen'>
       <Nav config={{ ...config.nav, brand: config.brand }} />
       <main>
-        <Hero config={config.hero} />
+        <Hero config={config.hero} carouselSlides={carouselSlides} />
         <FeatureGrid config={config.featureGrid} />
         <FeatureRows config={config.featureRows} />
         <Suspense fallback={null}>

--- a/apps/web/src/components/landing/LandingPageSSR.tsx
+++ b/apps/web/src/components/landing/LandingPageSSR.tsx
@@ -1,7 +1,6 @@
 import { landingConfig } from '../../config/landing';
 import { Nav } from './sections/Nav';
-import { Hero } from './sections/Hero';
-import type { CarouselSlide } from './sections/Hero';
+import { Hero, buildCarouselSlides } from './sections/Hero';
 import { FeatureGrid } from './sections/FeatureGrid';
 import { FeatureRows } from './sections/FeatureRows';
 import { SocialProof } from './sections/SocialProof';
@@ -14,20 +13,7 @@ import { FinalCTA } from './sections/FinalCTA';
 // Suspense fallbacks under synchronous renderToString — use this file instead.
 export function LandingPageSSR() {
   const config = landingConfig;
-
-  const carouselSlides: CarouselSlide[] = [
-    {
-      subhead: config.hero.subhead,
-      mediaSrc: config.hero.mediaSrc,
-      mediaAlt: config.hero.mediaAlt,
-    },
-    ...config.featureRows.map(r => ({
-      label: r.title,
-      subhead: r.body,
-      mediaSrc: r.mediaSrc,
-      mediaAlt: r.mediaAlt,
-    })),
-  ];
+  const carouselSlides = buildCarouselSlides(config);
 
   return (
     <div className='bg-white dark:bg-gray-950 min-h-screen'>

--- a/apps/web/src/components/landing/LandingPageSSR.tsx
+++ b/apps/web/src/components/landing/LandingPageSSR.tsx
@@ -1,6 +1,7 @@
 import { landingConfig } from '../../config/landing';
 import { Nav } from './sections/Nav';
 import { Hero } from './sections/Hero';
+import type { CarouselSlide } from './sections/Hero';
 import { FeatureGrid } from './sections/FeatureGrid';
 import { FeatureRows } from './sections/FeatureRows';
 import { SocialProof } from './sections/SocialProof';
@@ -14,11 +15,25 @@ import { FinalCTA } from './sections/FinalCTA';
 export function LandingPageSSR() {
   const config = landingConfig;
 
+  const carouselSlides: CarouselSlide[] = [
+    {
+      subhead: config.hero.subhead,
+      mediaSrc: config.hero.mediaSrc,
+      mediaAlt: config.hero.mediaAlt,
+    },
+    ...config.featureRows.map(r => ({
+      label: r.title,
+      subhead: r.body,
+      mediaSrc: r.mediaSrc,
+      mediaAlt: r.mediaAlt,
+    })),
+  ];
+
   return (
     <div className='bg-white dark:bg-gray-950 min-h-screen'>
       <Nav config={{ ...config.nav, brand: config.brand }} />
       <main>
-        <Hero config={config.hero} />
+        <Hero config={config.hero} carouselSlides={carouselSlides} />
         <FeatureGrid config={config.featureGrid} />
         <FeatureRows config={config.featureRows} />
         <SocialProof config={config.socialProof} />

--- a/apps/web/src/components/landing/sections/Hero.tsx
+++ b/apps/web/src/components/landing/sections/Hero.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import type { LandingConfig } from '../../../config/landing';
 
@@ -40,24 +40,19 @@ const DEFAULT_INTERVAL_MS = 6000;
 
 export function Hero({ config, carouselSlides, intervalMs = DEFAULT_INTERVAL_MS }: HeroProps) {
   const slides = carouselSlides && carouselSlides.length > 1 ? carouselSlides : null;
-  const [activeIndex, setActiveIndex] = useState(0);
-  // prevIndex tracks the outgoing slide so its image stays mounted during the crossfade.
-  // Only the active and previous images are in the DOM at any time, preventing browsers
-  // from fetching all slide images on initial load (opacity/aria-hidden don't suppress fetches).
-  const [prevIndex, setPrevIndex] = useState<number | null>(null);
-  const activeIndexRef = useRef(0);
-
-  useEffect(() => {
-    activeIndexRef.current = activeIndex;
-  }, [activeIndex]);
+  // Combined state so the functional updater sees the current active index when multiple
+  // ticks fire before a re-render (e.g. fake timers advancing 300 ms in one act()).
+  const [carousel, setCarousel] = useState<{ active: number; prev: number | null }>({
+    active: 0,
+    prev: null,
+  });
+  const { active: activeIndex, prev: prevIndex } = carousel;
 
   useEffect(() => {
     if (!slides) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
     const id = setInterval(() => {
-      const current = activeIndexRef.current;
-      setPrevIndex(current);
-      setActiveIndex((current + 1) % slides.length);
+      setCarousel(s => ({ active: (s.active + 1) % slides.length, prev: s.active }));
     }, intervalMs);
     return () => clearInterval(id);
   }, [slides, intervalMs]);

--- a/apps/web/src/components/landing/sections/Hero.tsx
+++ b/apps/web/src/components/landing/sections/Hero.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import type { LandingConfig } from '../../../config/landing';
 
@@ -8,6 +8,25 @@ export interface CarouselSlide {
   subhead: string;
   mediaSrc: string;
   mediaAlt: string;
+}
+
+/** Derives the carousel slide list from landing config. Shared by LandingPage and LandingPageSSR. */
+export function buildCarouselSlides(
+  config: Pick<LandingConfig, 'hero' | 'featureRows'>
+): CarouselSlide[] {
+  return [
+    {
+      subhead: config.hero.subhead,
+      mediaSrc: config.hero.mediaSrc,
+      mediaAlt: config.hero.mediaAlt,
+    },
+    ...config.featureRows.map(r => ({
+      label: r.title,
+      subhead: r.body,
+      mediaSrc: r.mediaSrc,
+      mediaAlt: r.mediaAlt,
+    })),
+  ];
 }
 
 interface HeroProps {
@@ -22,14 +41,24 @@ const DEFAULT_INTERVAL_MS = 6000;
 export function Hero({ config, carouselSlides, intervalMs = DEFAULT_INTERVAL_MS }: HeroProps) {
   const slides = carouselSlides && carouselSlides.length > 1 ? carouselSlides : null;
   const [activeIndex, setActiveIndex] = useState(0);
+  // prevIndex tracks the outgoing slide so its image stays mounted during the crossfade.
+  // Only the active and previous images are in the DOM at any time, preventing browsers
+  // from fetching all slide images on initial load (opacity/aria-hidden don't suppress fetches).
+  const [prevIndex, setPrevIndex] = useState<number | null>(null);
+  const activeIndexRef = useRef(0);
+
+  useEffect(() => {
+    activeIndexRef.current = activeIndex;
+  }, [activeIndex]);
 
   useEffect(() => {
     if (!slides) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-    const id = setInterval(
-      () => setActiveIndex(i => (i + 1) % slides.length),
-      intervalMs
-    );
+    const id = setInterval(() => {
+      const current = activeIndexRef.current;
+      setPrevIndex(current);
+      setActiveIndex((current + 1) % slides.length);
+    }, intervalMs);
     return () => clearInterval(id);
   }, [slides, intervalMs]);
 
@@ -102,26 +131,31 @@ export function Hero({ config, carouselSlides, intervalMs = DEFAULT_INTERVAL_MS 
             )}
           </div>
 
-          {/* aspect-video gives the container a stable size; images are absolutely
-              stacked so only one is visible at a time. */}
+          {/* aspect-video gives the container a stable size. Only the active and previous
+              slide images are mounted — this prevents all images being fetched on load. */}
           <div className='rounded-xl overflow-hidden border border-gray-200 dark:border-gray-800 shadow-lg bg-gray-100 dark:bg-gray-900 aspect-video relative'>
             {slides ? (
-              slides.map((slide, i) => (
-                <img
-                  key={i}
-                  src={slide.mediaSrc}
-                  alt={slide.mediaAlt}
-                  aria-hidden={i !== activeIndex ? true : undefined}
-                  className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-700 ${
-                    i === activeIndex ? 'opacity-100' : 'opacity-0'
-                  }`}
-                  loading={i === 0 ? 'eager' : 'lazy'}
-                  width={600}
-                  height={338}
-                  decoding='async'
-                  {...(i === 0 ? ({ fetchPriority: 'high' } as object) : {})}
-                />
-              ))
+              slides.map((slide, i) => {
+                const isActive = i === activeIndex;
+                const isPrev = i === prevIndex;
+                if (!isActive && !isPrev) return null;
+                return (
+                  <img
+                    key={i}
+                    src={slide.mediaSrc}
+                    alt={slide.mediaAlt}
+                    aria-hidden={!isActive ? true : undefined}
+                    className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-700 ${
+                      isActive ? 'opacity-100' : 'opacity-0'
+                    }`}
+                    loading={i === 0 ? 'eager' : 'lazy'}
+                    width={600}
+                    height={338}
+                    decoding='async'
+                    {...(i === 0 ? ({ fetchPriority: 'high' } as object) : {})}
+                  />
+                );
+              })
             ) : (
               <img
                 src={config.mediaSrc}

--- a/apps/web/src/components/landing/sections/Hero.tsx
+++ b/apps/web/src/components/landing/sections/Hero.tsx
@@ -1,11 +1,38 @@
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import type { LandingConfig } from '../../../config/landing';
 
-interface HeroProps {
-  config: LandingConfig['hero'];
+export interface CarouselSlide {
+  /** Feature row title rendered as a small label above the subhead (omit for hero slide 0). */
+  label?: string;
+  subhead: string;
+  mediaSrc: string;
+  mediaAlt: string;
 }
 
-export function Hero({ config }: HeroProps) {
+interface HeroProps {
+  config: LandingConfig['hero'];
+  carouselSlides?: CarouselSlide[];
+  /** Auto-advance interval in ms. Exposed for tests; defaults to 6000. */
+  intervalMs?: number;
+}
+
+const DEFAULT_INTERVAL_MS = 6000;
+
+export function Hero({ config, carouselSlides, intervalMs = DEFAULT_INTERVAL_MS }: HeroProps) {
+  const slides = carouselSlides && carouselSlides.length > 1 ? carouselSlides : null;
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    if (!slides) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    const id = setInterval(
+      () => setActiveIndex(i => (i + 1) % slides.length),
+      intervalMs
+    );
+    return () => clearInterval(id);
+  }, [slides, intervalMs]);
+
   return (
     <section className='py-20 md:py-28'>
       <div className='max-w-[1200px] mx-auto px-6'>
@@ -19,9 +46,39 @@ export function Hero({ config }: HeroProps) {
             <h1 className='text-4xl md:text-5xl font-bold text-gray-900 dark:text-white leading-tight mb-4'>
               {config.headline}
             </h1>
-            <p className='text-lg text-gray-600 dark:text-gray-400 mb-8 max-w-lg'>
-              {config.subhead}
-            </p>
+
+            {slides ? (
+              // CSS grid stacking: all slides occupy the same cell so the tallest
+              // one sets the container height — CTAs never jump when copy length varies.
+              <div className='grid' aria-live='polite'>
+                {slides.map((slide, i) => (
+                  <div
+                    key={i}
+                    style={{ gridArea: '1 / 1 / 2 / 2' }}
+                    className={`transition-opacity duration-700 ${
+                      i === activeIndex
+                        ? 'opacity-100'
+                        : 'opacity-0 pointer-events-none select-none'
+                    }`}
+                    aria-hidden={i !== activeIndex ? true : undefined}
+                  >
+                    {slide.label && (
+                      <p className='text-sm font-semibold text-primary-600 dark:text-primary-400 mb-1'>
+                        {slide.label}
+                      </p>
+                    )}
+                    <p className='text-lg text-gray-600 dark:text-gray-400 mb-8 max-w-lg'>
+                      {slide.subhead}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className='text-lg text-gray-600 dark:text-gray-400 mb-8 max-w-lg'>
+                {config.subhead}
+              </p>
+            )}
+
             <div className='flex flex-wrap gap-3'>
               <Link
                 to={config.primaryCta.href}
@@ -45,17 +102,38 @@ export function Hero({ config }: HeroProps) {
             )}
           </div>
 
-          <div className='rounded-xl overflow-hidden border border-gray-200 dark:border-gray-800 shadow-lg bg-gray-100 dark:bg-gray-900 aspect-video flex items-center justify-center'>
-            <img
-              src={config.mediaSrc}
-              alt={config.mediaAlt}
-              className='w-full h-full object-cover'
-              loading='eager'
-              width={600}
-              height={338}
-              decoding='async'
-              {...({ fetchPriority: 'high' } as object)}
-            />
+          {/* aspect-video gives the container a stable size; images are absolutely
+              stacked so only one is visible at a time. */}
+          <div className='rounded-xl overflow-hidden border border-gray-200 dark:border-gray-800 shadow-lg bg-gray-100 dark:bg-gray-900 aspect-video relative'>
+            {slides ? (
+              slides.map((slide, i) => (
+                <img
+                  key={i}
+                  src={slide.mediaSrc}
+                  alt={slide.mediaAlt}
+                  aria-hidden={i !== activeIndex ? true : undefined}
+                  className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-700 ${
+                    i === activeIndex ? 'opacity-100' : 'opacity-0'
+                  }`}
+                  loading={i === 0 ? 'eager' : 'lazy'}
+                  width={600}
+                  height={338}
+                  decoding='async'
+                  {...(i === 0 ? ({ fetchPriority: 'high' } as object) : {})}
+                />
+              ))
+            ) : (
+              <img
+                src={config.mediaSrc}
+                alt={config.mediaAlt}
+                className='absolute inset-0 w-full h-full object-cover'
+                loading='eager'
+                width={600}
+                height={338}
+                decoding='async'
+                {...({ fetchPriority: 'high' } as object)}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/src/components/landing/sections/__tests__/Hero.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/Hero.test.tsx
@@ -162,13 +162,22 @@ describe('Hero', () => {
       });
     }
 
+    let originalMatchMedia: typeof window.matchMedia | undefined;
+
     beforeEach(() => {
       vi.useFakeTimers();
+      originalMatchMedia = window.matchMedia;
       mockMatchMedia(false);
     });
 
     afterEach(() => {
       vi.useRealTimers();
+      // Restore original matchMedia so the vi.fn() stub doesn't leak into other test files
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: originalMatchMedia,
+      });
     });
 
     it('renders slide 0 visible and others aria-hidden initially', () => {
@@ -184,14 +193,11 @@ describe('Hero', () => {
       expect(
         screen.getByText('Feature one body copy.').parentElement
       ).toHaveAttribute('aria-hidden', 'true');
-      // aria-hidden is directly on each <img>
+      // Only slide 0 image is mounted initially — other images are deferred until active
       expect(screen.getByAltText('Hero image')).not.toHaveAttribute(
         'aria-hidden'
       );
-      expect(screen.getByAltText('Feature one image')).toHaveAttribute(
-        'aria-hidden',
-        'true'
-      );
+      expect(screen.queryByAltText('Feature one image')).not.toBeInTheDocument();
     });
 
     it('advances to slide 1 after one interval', () => {
@@ -209,6 +215,7 @@ describe('Hero', () => {
       expect(
         screen.getByText('Feature one body copy.').parentElement
       ).not.toHaveAttribute('aria-hidden');
+      // Slide 0 stays mounted as the outgoing image (crossfade); slide 1 is newly active
       expect(screen.getByAltText('Hero image')).toHaveAttribute(
         'aria-hidden',
         'true'
@@ -247,20 +254,28 @@ describe('Hero', () => {
       ).not.toHaveAttribute('aria-hidden');
     });
 
-    it('renders slide 0 image with eager loading and others with lazy', () => {
+    it('renders slide 0 with eager loading; defers other images until active', () => {
       render(
         <MemoryRouter>
           <Hero config={baseConfig} carouselSlides={slides} intervalMs={100} />
         </MemoryRouter>
       );
+      // Initially only slide 0 is mounted
       expect(screen.getByAltText('Hero image')).toHaveAttribute(
         'loading',
         'eager'
       );
+      expect(screen.queryByAltText('Feature one image')).not.toBeInTheDocument();
+      // After first interval: slide 0 (outgoing) + slide 1 (active) both mounted
+      act(() => { vi.advanceTimersByTime(100); });
+      expect(screen.getByAltText('Hero image')).toHaveAttribute('loading', 'eager');
       expect(screen.getByAltText('Feature one image')).toHaveAttribute(
         'loading',
         'lazy'
       );
+      // After second interval: slide 1 (outgoing) + slide 2 (active); slide 0 unmounted
+      act(() => { vi.advanceTimersByTime(100); });
+      expect(screen.queryByAltText('Hero image')).not.toBeInTheDocument();
       expect(screen.getByAltText('Feature two image')).toHaveAttribute(
         'loading',
         'lazy'

--- a/apps/web/src/components/landing/sections/__tests__/Hero.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/Hero.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { Hero } from '../Hero';
+import type { CarouselSlide } from '../Hero';
 
 const baseConfig = {
   headline: 'Build the full stack. Not the scaffolding.',
@@ -45,7 +46,7 @@ describe('Hero', () => {
         <Hero config={baseConfig} />
       </MemoryRouter>
     );
-    const img = screen.getByRole('img', { name: 'Dashboard preview' });
+    const img = screen.getByAltText('Dashboard preview');
     expect(img).toHaveAttribute(
       'src',
       'https://placehold.co/600x338?text=Dashboard'
@@ -126,5 +127,154 @@ describe('Hero', () => {
       </MemoryRouter>
     );
     expect(screen.queryByText(/MIT licensed/)).not.toBeInTheDocument();
+  });
+
+  describe('crossfade carousel', () => {
+    const slides: CarouselSlide[] = [
+      {
+        subhead: 'Hero subhead text.',
+        mediaSrc: 'https://placehold.co/600x338?text=Hero',
+        mediaAlt: 'Hero image',
+      },
+      {
+        label: 'Feature one title',
+        subhead: 'Feature one body copy.',
+        mediaSrc: 'https://placehold.co/600x338?text=Feature1',
+        mediaAlt: 'Feature one image',
+      },
+      {
+        label: 'Feature two title',
+        subhead: 'Feature two body copy.',
+        mediaSrc: 'https://placehold.co/600x338?text=Feature2',
+        mediaAlt: 'Feature two image',
+      },
+    ];
+
+    function mockMatchMedia(prefersReducedMotion: boolean) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: vi.fn().mockReturnValue({
+          matches: prefersReducedMotion,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        }),
+      });
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      mockMatchMedia(false);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('renders slide 0 visible and others aria-hidden initially', () => {
+      render(
+        <MemoryRouter>
+          <Hero config={baseConfig} carouselSlides={slides} intervalMs={100} />
+        </MemoryRouter>
+      );
+      // aria-hidden lives on the slide container div; text is inside a <p> child
+      expect(
+        screen.getByText('Hero subhead text.').parentElement
+      ).not.toHaveAttribute('aria-hidden');
+      expect(
+        screen.getByText('Feature one body copy.').parentElement
+      ).toHaveAttribute('aria-hidden', 'true');
+      // aria-hidden is directly on each <img>
+      expect(screen.getByAltText('Hero image')).not.toHaveAttribute(
+        'aria-hidden'
+      );
+      expect(screen.getByAltText('Feature one image')).toHaveAttribute(
+        'aria-hidden',
+        'true'
+      );
+    });
+
+    it('advances to slide 1 after one interval', () => {
+      render(
+        <MemoryRouter>
+          <Hero config={baseConfig} carouselSlides={slides} intervalMs={100} />
+        </MemoryRouter>
+      );
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      expect(
+        screen.getByText('Hero subhead text.').parentElement
+      ).toHaveAttribute('aria-hidden', 'true');
+      expect(
+        screen.getByText('Feature one body copy.').parentElement
+      ).not.toHaveAttribute('aria-hidden');
+      expect(screen.getByAltText('Hero image')).toHaveAttribute(
+        'aria-hidden',
+        'true'
+      );
+      expect(screen.getByAltText('Feature one image')).not.toHaveAttribute(
+        'aria-hidden'
+      );
+    });
+
+    it('wraps back to slide 0 after all slides advance', () => {
+      render(
+        <MemoryRouter>
+          <Hero config={baseConfig} carouselSlides={slides} intervalMs={100} />
+        </MemoryRouter>
+      );
+      act(() => {
+        vi.advanceTimersByTime(300); // 3 intervals → wraps to index 0
+      });
+      expect(
+        screen.getByText('Hero subhead text.').parentElement
+      ).not.toHaveAttribute('aria-hidden');
+    });
+
+    it('does not advance when prefers-reduced-motion is set', () => {
+      mockMatchMedia(true);
+      render(
+        <MemoryRouter>
+          <Hero config={baseConfig} carouselSlides={slides} intervalMs={100} />
+        </MemoryRouter>
+      );
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(
+        screen.getByText('Hero subhead text.').parentElement
+      ).not.toHaveAttribute('aria-hidden');
+    });
+
+    it('renders slide 0 image with eager loading and others with lazy', () => {
+      render(
+        <MemoryRouter>
+          <Hero config={baseConfig} carouselSlides={slides} intervalMs={100} />
+        </MemoryRouter>
+      );
+      expect(screen.getByAltText('Hero image')).toHaveAttribute(
+        'loading',
+        'eager'
+      );
+      expect(screen.getByAltText('Feature one image')).toHaveAttribute(
+        'loading',
+        'lazy'
+      );
+      expect(screen.getByAltText('Feature two image')).toHaveAttribute(
+        'loading',
+        'lazy'
+      );
+    });
+
+    it('renders feature row label text for non-hero slides', () => {
+      render(
+        <MemoryRouter>
+          <Hero config={baseConfig} carouselSlides={slides} intervalMs={100} />
+        </MemoryRouter>
+      );
+      expect(screen.getByText('Feature one title')).toBeInTheDocument();
+      expect(screen.getByText('Feature two title')).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/pages/__tests__/HomePage.test.tsx
+++ b/apps/web/src/pages/__tests__/HomePage.test.tsx
@@ -45,7 +45,8 @@ vi.mock('@beakerstack/billing', async importOriginal => {
   };
 });
 
-// Stub the landing config so tests don't depend on placehold.co or Lucide icons
+// Stub the landing config so tests don't depend on placehold.co or Lucide icons.
+// featureRows includes one entry so LandingPage's carouselSlides map callback is covered.
 vi.mock('../../config/landing', () => ({
   landingConfig: {
     brand: { name: 'BeakerStack', tagline: 'Test tagline' },
@@ -58,7 +59,14 @@ vi.mock('../../config/landing', () => ({
       mediaAlt: 'Hero image',
     },
     featureGrid: { heading: 'Features', subhead: '', items: [] },
-    featureRows: [],
+    featureRows: [
+      {
+        title: 'Test feature',
+        body: 'Test feature body.',
+        mediaSrc: 'https://placehold.co/600x338',
+        mediaAlt: 'Test feature image',
+      },
+    ],
     pricing: { heading: 'Pricing', subhead: '' },
     faq: { heading: 'FAQ', items: [] },
     finalCta: {
@@ -77,6 +85,14 @@ vi.mock('../../../billing/beakerstackBillingConfig', () => ({
     displayName: 'Test',
   },
 }));
+
+// matchMedia is not implemented in jsdom; stub it so Hero's carousel useEffect
+// doesn't throw. matches:false lets the carousel start but tests don't check timing.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  configurable: true,
+  value: () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }),
+});
 
 describe('HomePage', () => {
   let mockSupabaseClient: SupabaseClient;

--- a/apps/web/src/pages/__tests__/HomePage.test.tsx
+++ b/apps/web/src/pages/__tests__/HomePage.test.tsx
@@ -46,7 +46,8 @@ vi.mock('@beakerstack/billing', async importOriginal => {
 });
 
 // Stub the landing config so tests don't depend on placehold.co or Lucide icons.
-// featureRows includes one entry so LandingPage's carouselSlides map callback is covered.
+// featureRows includes one complete entry so LandingPage's carouselSlides map
+// callback (lines 34-37) is covered. All FeatureRows fields are required.
 vi.mock('../../config/landing', () => ({
   landingConfig: {
     brand: { name: 'BeakerStack', tagline: 'Test tagline' },
@@ -65,6 +66,9 @@ vi.mock('../../config/landing', () => ({
         body: 'Test feature body.',
         mediaSrc: 'https://placehold.co/600x338',
         mediaAlt: 'Test feature image',
+        mediaSide: 'right',
+        ctaHref: '/signup',
+        ctaLabel: 'Learn more',
       },
     ],
     pricing: { heading: 'Pricing', subhead: '' },


### PR DESCRIPTION
Closes #194

## Summary

- Adds auto-advancing crossfade carousel to the landing page Hero section
- Headline, eyebrow, CTAs, and trust strip remain static; only the subhead text and hero image crossfade
- CSS opacity transitions only — no JS animation libraries
- CSS grid stacking (`gridArea: "1 / 1 / 2 / 2"`) prevents CTA jump when slide copy lengths differ
- `prefers-reduced-motion` respected: carousel pauses when set
- `intervalMs` prop exposed for test controllability (default 6 s)
- Slide 0 retains `loading="eager"` + `fetchPriority="high"` for LCP
- SSR-safe: `useState(0)` renders slide 0 opaque in `renderToStaticMarkup`; `useEffect` never fires in prerender
- Rebased on develop (includes lazy-load refactor from #181)

## Tests

6 new `crossfade carousel` tests in `Hero.test.tsx`:
- Initial visibility (slide 0 visible, others `aria-hidden`)
- Auto-advance after one interval
- Wrap-around after all slides
- No advance when `prefers-reduced-motion`
- Correct `loading` attributes per slide index
- Feature row label text rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)