### PR TITLE
refactor(web): extract shared layout class constants

### DIFF
--- a/apps/web/scripts/prerender-home.ts
+++ b/apps/web/scripts/prerender-home.ts
@@ -28,6 +28,7 @@ const { AppFooter } = await import('../src/components/AppFooter');
 // LandingPageSSR eagerly imports all sections. LandingPage uses React.lazy() for
 // below-fold sections, which resolve as empty Suspense fallbacks under renderToStaticMarkup.
 const { LandingPageSSR } = await import('../src/components/landing/LandingPageSSR');
+const { LAYOUT } = await import('../src/lib/layoutConstants');
 
 const webRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -48,10 +49,6 @@ const routerBasename =
 // match (RR warns and renders nothing). Use the same pathname as publicHomeUrl path.
 const initialEntries = [homePath];
 
-// Layout wrapper classes mirror App.tsx ('bg-gray-50 dark:bg-gray-900') and RootLayout
-// ('flex min-h-screen flex-col'). Update these when the App layout changes to keep the
-// prerendered visual consistent with the hydrated page. No strict tree-match is required —
-// createRoot replaces this subtree on first render without hydration alignment constraints.
 const html = renderToStaticMarkup(
   createElement(
     ThemeProvider,
@@ -61,11 +58,11 @@ const html = renderToStaticMarkup(
       { basename: routerBasename, initialEntries },
       createElement(
         'div',
-        { className: 'bg-gray-50 dark:bg-gray-900' },
+        { className: LAYOUT.outer },
         createElement(
           'div',
-          { className: 'flex min-h-screen flex-col' },
-          createElement('div', { className: 'flex-1' }, createElement(LandingPageSSR)),
+          { className: LAYOUT.shell },
+          createElement('div', { className: LAYOUT.content }, createElement(LandingPageSSR)),
           createElement(AppFooter)
         )
       )

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,6 +4,7 @@ import { ProtectedRoute } from '@beakerstack/shared/components/auth/ProtectedRou
 import { BillingProviderLayout } from './billing/BillingProviderLayout';
 import { AppFooter } from './components/AppFooter';
 import { AppErrorBoundary } from './components/AppErrorBoundary';
+import { LAYOUT } from './lib/layoutConstants';
 
 function PageFallback() {
   return (
@@ -31,8 +32,8 @@ const BillingInvoicesPage = lazy(
 
 function RootLayout() {
   return (
-    <div className='flex min-h-screen flex-col'>
-      <div className='flex-1'>
+    <div className={LAYOUT.shell}>
+      <div className={LAYOUT.content}>
         <Outlet />
       </div>
       <AppFooter />
@@ -42,7 +43,7 @@ function RootLayout() {
 
 function App() {
   return (
-    <div className='bg-gray-50 dark:bg-gray-900'>
+    <div className={LAYOUT.outer}>
       <AppErrorBoundary>
         <Suspense fallback={<PageFallback />}>
           <Routes>

--- a/apps/web/src/lib/layoutConstants.ts
+++ b/apps/web/src/lib/layoutConstants.ts
@@ -1,0 +1,5 @@
+export const LAYOUT = {
+  outer: 'bg-gray-50 dark:bg-gray-900',
+  shell: 'flex min-h-screen flex-col',
+  content: 'flex-1',
+} as const;


### PR DESCRIPTION
Closes #195

## Summary
- Adds `apps/web/src/lib/layout-constants.ts` with `LAYOUT.outer`, `LAYOUT.shell`, `LAYOUT.content` constants
- `App.tsx` (`App` function + `RootLayout`) imports and uses `LAYOUT` instead of inline strings
- `prerender-home.ts` imports `LAYOUT` from the same file; removes the manual sync comment

The sync between `App.tsx` and `prerender-home.ts` is now structural — a rename in one file is a compile error in the other — rather than relying on a comment reminder.

## Test plan
- [ ] CI passes (no behaviour change — refactor only)
- [ ] Review that `layout-constants.ts` exports match the strings previously in `App.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)