### PR TITLE
fix(web): inline background color to eliminate FOUC on page load

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -19,6 +19,13 @@
         } catch (_) {}
       })();
     </script>
+    <!-- Pin background before Tailwind CSS loads so dark users never see a
+         white flash and light users never see a raw-white-to-styled jump.
+         Values mirror the app's root bg-gray-50 / dark:bg-gray-900 classes. -->
+    <style>
+      html { background-color: #f9fafb; color-scheme: light; }
+      html.dark { background-color: #111827; color-scheme: dark; }
+    </style>
 
     <!-- Site-wide meta — canonical and og:url are home-only and are injected into
          prerender-home.html by scripts/prerender-home.ts; adding them here would


### PR DESCRIPTION
## Problem

Closes #208.

Dark-mode users see a white flash on every page load; light-mode users see a blank jump before content appears.

**Root cause:** The existing inline script in `index.html` correctly applies the `dark` class before first paint, but the Tailwind CSS bundle is a separate file that must be fetched before its rules (e.g. `html.dark { background: #111827 }`) take effect. Between "script ran" and "CSS loaded" the browser renders with its default white background.

## Fix

Add a two-rule inline `<style>` block immediately after the existing anti-FOUC script:

```html
<style>
  html { background-color: #f9fafb; color-scheme: light; }
  html.dark { background-color: #111827; color-scheme: dark; }
</style>
```

- **`#f9fafb`** = Tailwind `gray-50` — matches the app's root `bg-gray-50` (light)
- **`#111827`** = Tailwind `gray-900` — matches the app's root `dark:bg-gray-900` (dark)
- **`color-scheme`** makes scrollbars and native controls also respect the theme without waiting for CSS

No extra network requests; the style is inlined in the HTML.

## Test plan

- [ ] Hard-reload with DevTools throttled to Slow 3G; dark theme — no white flash
- [ ] Hard-reload with DevTools throttled to Slow 3G; light theme — no bare-background jump
- [ ] CI green
