### PR TITLE
fix(web): set html/body background to prevent dark-mode FOUC

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2,6 +2,19 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Match the app's outermost div (LAYOUT.outer = 'bg-gray-50 dark:bg-gray-900').
+ * The inline anti-FOUC script adds .dark to <html> before first paint, but
+ * without these rules the page background stays white (browser default) until
+ * React renders — causing a visible flash.
+ */
+html {
+  background-color: #f9fafb; /* gray-50 */
+}
+html.dark {
+  background-color: #111827; /* gray-900 */
+}
+
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;


### PR DESCRIPTION
## Problem

Two flash symptoms reported in #208:

1. **Dark mode white flash** — the anti-FOUC inline script in `index.html` adds `.dark` to `<html>` before first paint, but without a matching `background-color` rule on `html` the page background stays white (browser default) until React renders its top-level `bg-gray-900` div.

2. **Light mode blank page** — `main.tsx` wraps lazy `AuthShell` in `<Suspense>` with no fallback, so React shows nothing while the chunk loads. This is addressed separately by #205 (synchronous `PublicShell` import).

## Fix

Add two CSS rules to `index.css` that mirror `LAYOUT.outer`:

```css
html { background-color: #f9fafb; }   /* gray-50, same as bg-gray-50 */
html.dark { background-color: #111827; } /* gray-900, same as dark:bg-gray-900 */
```

With this in place, the inline theme script sets `.dark` and the CSS immediately applies the correct background — no React render required.

## Scope

- One file changed: `apps/web/src/index.css`
- No JS touched; no lazy-loading behaviour affected
- Compatible with the post-#205 architecture (these rules work regardless of whether `AuthShell` or `PublicShell` is the root shell)

## Testing

- [ ] Hard-reload with `prefers-color-scheme: dark` — no white flash before content appears
- [ ] Hard-reload with `prefers-color-scheme: light` — background is immediately gray-50, not white
- [ ] Toggle dark mode — background transitions correctly