### PR TITLE
fix(web): make AuthShell eager to eliminate page-load flash (issue #208)

### DIFF
--- a/apps/web/src/__tests__/main.test.tsx
+++ b/apps/web/src/__tests__/main.test.tsx
@@ -55,7 +55,7 @@ describe('main.tsx', () => {
 
   it('should use createRoot even when root has prerendered content', async () => {
     const prerendered = document.createElement('div');
-    rootElement!.appendChild(prerendered);
+    if (rootElement) rootElement.appendChild(prerendered);
 
     await import('../main');
     await new Promise(resolve => setTimeout(resolve, 10));
@@ -66,7 +66,7 @@ describe('main.tsx', () => {
     expect(mockRender).toHaveBeenCalled();
   });
 
-  it('should render with ThemeProvider wrapping lazy AuthShell', async () => {
+  it('should render with ThemeProvider wrapping AuthShell directly', async () => {
     await import('../main');
     await new Promise(resolve => setTimeout(resolve, 10));
 
@@ -78,9 +78,10 @@ describe('main.tsx', () => {
     expect(themeProvider).toBeDefined();
     expect(themeProvider.type).toBeDefined();
 
-    const suspense = themeProvider.props.children;
-    expect(suspense).toBeDefined();
-    expect(suspense.type).toBe(React.Suspense);
+    // AuthShell is now imported eagerly — no Suspense wrapper
+    const authShell = themeProvider.props.children;
+    expect(authShell).toBeDefined();
+    expect(authShell.type).not.toBe(React.Suspense);
   });
 
   it('should use default base path when VITE_BASE_PATH is not set', async () => {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,7 @@
-import React, { lazy, Suspense } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { AuthShell } from './AuthShell';
 import './index.css';
 
 const rootElement = document.getElementById('root');
@@ -11,16 +12,10 @@ if (!rootElement) {
 
 const basePath = import.meta.env.VITE_BASE_PATH || '/';
 
-const AuthShell = lazy(() =>
-  import('./AuthShell').then(m => ({ default: m.AuthShell }))
-);
-
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <ThemeProvider>
-      <Suspense>
-        <AuthShell basePath={basePath} />
-      </Suspense>
+      <AuthShell basePath={basePath} />
     </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary

Companion to #210 (Mei's CSS html/body background fix). Closes #208 together.

**Problem:** `main.tsx` lazy-loads `AuthShell` inside `<Suspense>` with no fallback. While the lazy chunk loads, Suspense renders `null` — `createRoot` commits this empty state and the browser paints a blank root. Since the body has no background color of its own, it shows white by default:

- **Dark mode:** pre-rendered dark content → white/blank → content (white flash)
- **Light mode:** pre-rendered content → blank gray-50 (after #210) → content (blank flash)

**Fix:** Import `AuthShell` synchronously. With an eager import, React renders the full tree in one synchronous commit — the browser never paints an empty root. The `<Suspense>` wrapper is removed since nothing at this level is lazy any more. Lazy splits inside `App.tsx` (individual route pages) are unaffected.

**Trade-off:** `supabase-vendor` now loads with the initial page instead of being deferred until `AuthShell` is needed. Acceptable short-term. PR #205 (PublicShell / AuthenticatedApp split) re-establishes Supabase deferral for authenticated routes — once that lands, this eager import is the right permanent state.

## Test plan

- [ ] Hard-reload with dark theme: no white flash, content stays visible through initial paint
- [ ] Hard-reload with light theme: no blank gap, content stays visible through initial paint
- [ ] CI green
- [ ] No regressions on auth flow, routing, or billing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)