### PR TITLE
fix(web): share critical theme CSS for FOUC (inline + bundle)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,3 +1,5 @@
+@import './styles/critical-theme.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9,8 +9,7 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-
+  /* color-scheme: see critical-theme.css on html / html.dark (:root beats plain html if both declare it). */
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;

--- a/apps/web/src/styles/critical-theme.css
+++ b/apps/web/src/styles/critical-theme.css
@@ -1,0 +1,13 @@
+/*
+ * Critical background before Tailwind’s bundle loads (also inlined into index.html by vite.config.ts).
+ * Must stay aligned with LAYOUT.outer in src/lib/layoutConstants.ts (bg-gray-50 / dark:bg-gray-900).
+ */
+html {
+  background-color: #f9fafb;
+  color-scheme: light;
+}
+
+html.dark {
+  background-color: #111827;
+  color-scheme: dark;
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,7 +1,15 @@
+import { readFileSync } from 'node:fs';
+import path from 'path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig, loadEnv, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
-import path from 'path';
 import { BRANDING } from '../../packages/shared/src/config/branding';
+
+const viteConfigDir = path.dirname(fileURLToPath(import.meta.url));
+const criticalThemePath = path.join(
+  viteConfigDir,
+  'src/styles/critical-theme.css'
+);
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -16,6 +24,12 @@ export default defineConfig(({ mode }) => {
     name: 'html-branding-transform',
     transformIndexHtml(html: string) {
       let transformed = html.replace(/%APP_TITLE%/g, BRANDING.displayName);
+
+      const criticalCss = readFileSync(criticalThemePath, 'utf8').trim();
+      transformed = transformed.replace(
+        '</script>\n\n    <!-- Site-wide meta',
+        `</script>\n\n    <!-- Critical theme background — source: src/styles/critical-theme.css (also @import in index.css) -->\n    <style id="critical-theme-fouc">\n${criticalCss}\n    </style>\n\n    <!-- Site-wide meta`
+      );
 
       // Transform absolute paths in HTML to respect base path
       // Only transform if base path is not root (e.g., /pr-9)

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -49,6 +49,12 @@ export default defineConfig(({ mode }) => {
         );
       }
 
+      if (!transformed.includes('id="critical-theme-fouc"')) {
+        throw new Error(
+          'htmlBrandingPlugin: critical theme CSS was not injected — check index.html has </script> then <!-- Site-wide meta (two newlines between).'
+        );
+      }
+
       return transformed;
     },
   };


### PR DESCRIPTION
## Description

Adds `apps/web/src/styles/critical-theme.css` as the single source for `html` / `html.dark` background colors and `color-scheme` (aligned with `LAYOUT.outer`: Tailwind gray-50 / gray-900).

- `index.css` imports the file so the same rules ship in the built CSS bundle.
- `vite.config.ts` reads that file in `transformIndexHtml` and injects a `<style id="critical-theme-fouc">` immediately after the inline theme script so the correct background paints before the Tailwind bundle loads.

This branch is **ahead of `main` by multiple commits**; the FOUC change is in the latest commit. Review the full diff against `main` for the complete set of changes.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactoring
- [ ] Other (please describe)

## Merge Strategy Reminder

⚠️ **Important**: Please use the correct merge strategy when merging this PR:

- **If this PR targets `develop`**: Use **"Squash and merge"** ✅
- **If this PR targets `main`**: Use **"Create a merge commit"** ✅ (NOT squash merge)

Squash merging to `main` can cause conflicts when merging `develop` → `main` later.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if needed)
- [x] No new warnings generated
- [ ] Tests added/updated (if needed)
- [x] All tests pass locally

## Testing

- Ran `vite build` and confirmed `dist/index.html` contains the injected `critical-theme-fouc` block and bundled CSS includes the same rules.
- `vitest --run` and web `tsc --noEmit` passed via pre-commit.

## Related Issues

<!-- Optional: link dark-mode FOUC issue if tracked -->