### PR TITLE
fix(mobile): billing Realtime, RN checkout guard, and nested list warning

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -2,13 +2,18 @@ import { useEffect } from 'react';
 import { StatusBar } from 'expo-status-bar';
 import Constants from 'expo-constants';
 import * as Updates from 'expo-updates';
+import { BillingProvider } from '@beakerstack/billing';
 import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
 // Import from native-specific file for correct types
 import { configureGoogleSignIn } from '@beakerstack/shared/hooks/useAuth.native';
 import { Logger } from '@beakerstack/shared/utils/logger';
+import { beakerstackBillingConfig } from './src/billing/beakerstackBillingConfig';
+import { getMobileBillingProviderUrls } from './src/billing/mobileBillingUrls';
 import { supabase } from './src/lib/supabase';
 import { AppNavigator } from './src/navigation/AppNavigator';
+
+const mobileBillingUrls = getMobileBillingProviderUrls();
 
 export default function App() {
   useEffect(() => {
@@ -105,8 +110,16 @@ export default function App() {
   return (
     <AuthProvider supabaseClient={supabase}>
       <ProfileProvider supabaseClient={supabase}>
-        <AppNavigator />
-        <StatusBar style='auto' />
+        <BillingProvider<typeof beakerstackBillingConfig>
+          supabase={supabase}
+          config={beakerstackBillingConfig}
+          checkoutSuccessUrl={mobileBillingUrls.checkoutSuccessUrl}
+          checkoutCancelUrl={mobileBillingUrls.checkoutCancelUrl}
+          portalReturnUrl={mobileBillingUrls.portalReturnUrl}
+        >
+          <AppNavigator />
+          <StatusBar style='auto' />
+        </BillingProvider>
       </ProfileProvider>
     </AuthProvider>
   );

--- a/apps/mobile/__tests__/App.test.tsx
+++ b/apps/mobile/__tests__/App.test.tsx
@@ -19,6 +19,12 @@ jest.mock('expo-constants', () => ({
   },
 }));
 
+jest.mock('@beakerstack/billing', () => ({
+  __esModule: true,
+  BillingProvider: ({ children }: { children: React.ReactNode }) => children,
+  defineBillingConfig: (c: unknown) => c,
+}));
+
 // Mock expo-updates (added for OTA update debugging)
 jest.mock('expo-updates', () => ({
   isEnabled: false,

--- a/apps/mobile/src/billing/mobileBillingUrls.ts
+++ b/apps/mobile/src/billing/mobileBillingUrls.ts
@@ -1,0 +1,19 @@
+/**
+ * Stripe return / portal URLs for the mobile dev client.
+ * Centralized so one {@link BillingProvider} can wrap the whole navigator.
+ */
+export function getMobileBillingProviderUrls(): {
+  checkoutSuccessUrl: string;
+  checkoutCancelUrl: string;
+  portalReturnUrl: string;
+} {
+  const base =
+    (typeof process !== 'undefined' &&
+      process.env?.['EXPO_PUBLIC_BILLING_DEMO_BASE_URL']) ||
+    'http://127.0.0.1:8081';
+  return {
+    checkoutSuccessUrl: `${base}/billing`,
+    checkoutCancelUrl: `${base}/billing/plans?checkout=cancel`,
+    portalReturnUrl: `${base}/billing`,
+  };
+}

--- a/apps/mobile/src/screens/BillingScreen.tsx
+++ b/apps/mobile/src/screens/BillingScreen.tsx
@@ -1,8 +1,4 @@
-import {
-  BillingProvider,
-  useRecordUsage,
-  useUsage,
-} from '@beakerstack/billing';
+import { useRecordUsage, useUsage } from '@beakerstack/billing';
 import {
   CustomerPortalLink,
   FeatureGate,
@@ -22,14 +18,8 @@ import {
 import { supabase } from '../lib/supabase';
 
 function readBillingScreenDemoMode(): boolean {
-  return process.env?.EXPO_PUBLIC_BILLING_DEMO_MODE === 'true';
+  return process.env?.['EXPO_PUBLIC_BILLING_DEMO_MODE'] === 'true';
 }
-
-/** Set EXPO_PUBLIC_BILLING_DEMO_BASE_URL to your dev machine URL for Stripe return URLs on device. */
-const billingBaseUrl =
-  (typeof process !== 'undefined' &&
-    process.env?.EXPO_PUBLIC_BILLING_DEMO_BASE_URL) ||
-  'http://127.0.0.1:8081';
 
 function MeteredBlock(): ReactElement {
   const { exceeded, refresh } = useUsage<
@@ -117,40 +107,32 @@ export default function BillingScreen(): ReactElement {
           For the full /billing experience (tabs, plans, invoices), use the web
           app. This screen reuses the billing package for dev testing.
         </Text>
-        <BillingProvider<typeof beakerstackBillingConfig>
-          supabase={supabase}
-          config={beakerstackBillingConfig}
-          checkoutSuccessUrl={`${billingBaseUrl}/billing`}
-          checkoutCancelUrl={`${billingBaseUrl}/billing`}
-          portalReturnUrl={`${billingBaseUrl}/billing`}
-        >
-          <DemoRpcButtons />
-          <View style={styles.section}>
-            <Text style={styles.h2}>Subscription</Text>
-            <SubscriptionStatus<typeof beakerstackBillingConfig> />
-            <CustomerPortalLink<typeof beakerstackBillingConfig>
-              style={{ marginTop: 8 }}
-            >
-              <Text style={styles.link}>Customer portal</Text>
-            </CustomerPortalLink>
-            <PricingTable<typeof beakerstackBillingConfig> highlightCurrent />
-          </View>
-          <MeteredBlock />
-          <View style={styles.section}>
-            <Text style={styles.h2}>Feature B (Max)</Text>
-            <FeatureGate<typeof beakerstackBillingConfig>
-              feature='feature_b'
-              fallback={
-                <UpgradePrompt<typeof beakerstackBillingConfig>
-                  targetTier='beakerstack_max'
-                  reason='Feature B requires Max.'
-                />
-              }
-            >
-              <Text style={styles.ok}>Feature B enabled</Text>
-            </FeatureGate>
-          </View>
-        </BillingProvider>
+        <DemoRpcButtons />
+        <View style={styles.section}>
+          <Text style={styles.h2}>Subscription</Text>
+          <SubscriptionStatus<typeof beakerstackBillingConfig> />
+          <CustomerPortalLink<typeof beakerstackBillingConfig>
+            style={{ marginTop: 8 }}
+          >
+            <Text style={styles.link}>Customer portal</Text>
+          </CustomerPortalLink>
+          <PricingTable<typeof beakerstackBillingConfig> highlightCurrent />
+        </View>
+        <MeteredBlock />
+        <View style={styles.section}>
+          <Text style={styles.h2}>Feature B (Max)</Text>
+          <FeatureGate<typeof beakerstackBillingConfig>
+            feature='feature_b'
+            fallback={
+              <UpgradePrompt<typeof beakerstackBillingConfig>
+                targetTier='beakerstack_max'
+                reason='Feature B requires Max.'
+              />
+            }
+          >
+            <Text style={styles.ok}>Feature B enabled</Text>
+          </FeatureGate>
+        </View>
       </ScrollView>
     </SafeAreaView>
   );

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -15,7 +15,6 @@ import {
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
-  BillingProvider,
   mapUnknownError,
   useBillingContext,
   useFeature,
@@ -42,11 +41,6 @@ function readBillingDashboardDemoMode(): boolean {
 function readDemoUseRealAi(): boolean {
   return process.env?.['EXPO_PUBLIC_DEMO_USE_REAL_AI'] === 'true';
 }
-
-const billingBaseUrl =
-  (typeof process !== 'undefined' &&
-    process.env?.['EXPO_PUBLIC_BILLING_DEMO_BASE_URL']) ||
-  'http://127.0.0.1:8081';
 
 type RootStackParamList = {
   Home: undefined;
@@ -612,15 +606,7 @@ export default function DashboardScreen({ navigation }: Props) {
   return (
     <SafeAreaView style={styles.container}>
       <AppHeader supabaseClient={supabase} />
-      <BillingProvider<typeof beakerstackBillingConfig>
-        supabase={supabase}
-        config={beakerstackBillingConfig}
-        checkoutSuccessUrl={`${billingBaseUrl}/billing`}
-        checkoutCancelUrl={`${billingBaseUrl}/billing/plans?checkout=cancel`}
-        portalReturnUrl={`${billingBaseUrl}/billing`}
-      >
-        <DashboardBody navigation={navigation} />
-      </BillingProvider>
+      <DashboardBody navigation={navigation} />
     </SafeAreaView>
   );
 }

--- a/packages/billing/src/BillingProvider.test.tsx
+++ b/packages/billing/src/BillingProvider.test.tsx
@@ -150,6 +150,32 @@ describe('BillingProvider', () => {
     expect(db.channel).toHaveBeenCalled();
   });
 
+  it('does not throw when window exists without location (React Native)', async () => {
+    const realWindow = globalThis.window;
+    const windowProxy = new Proxy(realWindow, {
+      get(target, prop, receiver) {
+        if (prop === 'location') return undefined;
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    vi.stubGlobal('window', windowProxy);
+
+    try {
+      auth.state.session = { user: { id: 'u-rn' } };
+      db.maybeSingle.mockResolvedValue({ data: null, error: null });
+      render(
+        <BillingProvider config={testBillingConfig} {...providerProps}>
+          <Reader />
+        </BillingProvider>
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('uid').textContent).toBe('u-rn');
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('rejects invalid config with the same schema BillingProvider uses', () => {
     expect(() =>
       productBillingConfigSchema.parse({

--- a/packages/billing/src/BillingProvider.tsx
+++ b/packages/billing/src/BillingProvider.tsx
@@ -202,7 +202,10 @@ export function BillingProvider<P extends ProductBillingConfig>({
   /** After Stripe Checkout, the row is written by `stripe-webhook` (async). Poll briefly so the UI updates even if Realtime lags or the user lands before the webhook finishes. */
   useEffect(() => {
     if (typeof window === 'undefined' || !userId) return;
-    const sp = new URLSearchParams(window.location.search);
+    // React Native / Hermes often defines `window` without `window.location`.
+    const search = window.location?.search ?? '';
+    if (!search) return;
+    const sp = new URLSearchParams(search);
     if (sp.get('checkout') !== 'success') return;
 
     let attempts = 0;

--- a/packages/billing/src/components/PricingTable.native.tsx
+++ b/packages/billing/src/components/PricingTable.native.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { usePlan } from '../hooks/usePlan.js';
 import { usePlanCatalog } from '../hooks/usePlanCatalog.js';
 import type { ProductBillingConfig } from '../schema.js';
@@ -28,19 +28,22 @@ export function PricingTable<P extends ProductBillingConfig>({
     );
   }
 
+  // Use plain Views (not FlatList): this component is often nested inside a
+  // parent ScrollView (e.g. mobile billing screen), and same-orientation
+  // VirtualizedList + ScrollView breaks windowing and triggers RN dev errors.
   return (
-    <FlatList
-      style={style}
-      data={plans}
-      keyExtractor={item => item.id}
-      renderItem={({ item: p }) => {
+    <View style={style}>
+      {plans.map(p => {
         const isCurrent =
           (highlightCurrent && currentPlan?.id === p.id) ||
           (highlightPlanId != null &&
             highlightPlanId !== '' &&
             p.id === highlightPlanId);
         return (
-          <View style={[styles.card, isCurrent && styles.cardHighlight]}>
+          <View
+            key={p.id}
+            style={[styles.card, isCurrent && styles.cardHighlight]}
+          >
             <Text style={styles.title}>{p.display_name}</Text>
             <Text>
               {(p.price_cents / 100).toFixed(2)} USD / {p.billing_period}
@@ -57,8 +60,8 @@ export function PricingTable<P extends ProductBillingConfig>({
             ) : null}
           </View>
         );
-      }}
-    />
+      })}
+    </View>
   );
 }
 


### PR DESCRIPTION
## Summary

- **BillingProvider (shared):** Avoid reading `window.location.search` when `window.location` is missing (Expo / Hermes), which was crashing the dashboard after sign-in.
- **Mobile app:** Hoist a single `BillingProvider` in `App.tsx` with centralized Stripe return URLs (`mobileBillingUrls.ts`), so Dashboard and Billing no longer each open the same Supabase Realtime channel (which caused `postgres_changes` errors after `subscribe()`).
- **PricingTable (native):** Render plan rows with `View` + `map` instead of `FlatList`, removing the "VirtualizedLists should never be nested inside plain ScrollViews" warning on the Billing screen.
- **Tests:** Regression test for the RN `window` case in `BillingProvider`, and a Jest mock for `@beakerstack/billing` in `App.test.tsx` so the app test bundle does not pull the full billing package graph.

## Test plan

- [x] `cd packages/billing && npm test`
- [x] `cd apps/mobile && npm test`
- [ ] Manual: iOS simulator — sign in, open Dashboard, open Billing — no `window.location` crash, no duplicate Realtime error, no VirtualizedList nesting warning.