### PR TITLE
feat(mobile): web-parity billing dashboard and billing fixes

### DIFF
--- a/apps/mobile/__tests__/screens/DashboardScreen.test.tsx
+++ b/apps/mobile/__tests__/screens/DashboardScreen.test.tsx
@@ -301,19 +301,34 @@ describe('DashboardScreen', () => {
     );
 
     await waitFor(() => {
-      expect(getByText(/welcome to beakerstack/i)).toBeTruthy();
+      expect(getByText('Simulate AI summarize')).toBeTruthy();
+      expect(getByText('Boolean feature gates')).toBeTruthy();
     });
   });
 
-  it('navigates to Billing when polished billing link is pressed', async () => {
+  it('navigates to Billing when usage upgrade link is pressed', async () => {
+    const billing = jest.requireMock('@beakerstack/billing') as {
+      useUsage: jest.Mock;
+    };
+    billing.useUsage.mockImplementation(() => ({
+      used: 30,
+      limit: 30,
+      remaining: 0,
+      resetsAt: '',
+      exceeded: true,
+      loading: false,
+      error: null,
+      refresh: jest.fn().mockResolvedValue(undefined),
+    }));
+
     const { getByText } = renderWithProviders(
       <DashboardScreen navigation={mockNavigation} />
     );
 
     await waitFor(() => {
-      expect(getByText(/welcome to beakerstack/i)).toBeTruthy();
+      expect(getByText(/Upgrade to get more summaries/i)).toBeTruthy();
     });
-    fireEvent.press(getByText('View polished billing →'));
+    fireEvent.press(getByText(/Upgrade to get more summaries/i));
     expect(mockNavigate).toHaveBeenCalledWith('Billing');
   });
 
@@ -335,6 +350,7 @@ describe('DashboardScreen', () => {
       expect.objectContaining({
         p_product_id: 'beakerstack',
         p_quantity: 1,
+        p_idempotency_key: expect.any(String),
       })
     );
   });
@@ -359,7 +375,8 @@ describe('DashboardScreen', () => {
     );
 
     await waitFor(() => {
-      expect(getByText(/Limit reached — open Billing for plans/i)).toBeTruthy();
+      expect(getByText('Limit reached')).toBeTruthy();
+      expect(getByText(/Upgrade to get more summaries/i)).toBeTruthy();
     });
   });
 
@@ -399,12 +416,11 @@ describe('DashboardScreen', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Add collection')).toBeTruthy();
+      expect(getByText('+ New collection')).toBeTruthy();
     });
-    fireEvent.press(getByText('Add collection'));
+    fireEvent.press(getByText('+ New collection'));
 
     await waitFor(() => {
-      expect(getByText(/Collections:/)).toBeTruthy();
       expect(getByText(/1 of 2/)).toBeTruthy();
     });
   });
@@ -589,7 +605,7 @@ describe('DashboardScreen', () => {
     });
   });
 
-  it('shows Failed when addItem throws a non-Error from RPC', async () => {
+  it('shows Action failed when addItem rejects with a non-Error from RPC', async () => {
     const billing = jest.requireMock('@beakerstack/billing') as {
       useFeature: jest.Mock;
     };
@@ -643,12 +659,12 @@ describe('DashboardScreen', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Add item')).toBeTruthy();
+      expect(getByText('+ Add item')).toBeTruthy();
     });
-    fireEvent.press(getByText('Add item'));
+    fireEvent.press(getByText('+ Add item'));
 
     await waitFor(() => {
-      expect(getByText('Failed')).toBeTruthy();
+      expect(getByText('Action failed.')).toBeTruthy();
     });
   });
 
@@ -694,13 +710,13 @@ describe('DashboardScreen', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Delete')).toBeTruthy();
+      expect(getByText('Del')).toBeTruthy();
     });
-    fireEvent.press(getByText('Delete'));
+    fireEvent.press(getByText('Del'));
 
     await waitFor(() => {
       expect(
-        getByText(/No collections yet\. Tap Add collection to start\./)
+        getByText(/No collections yet\. Tap 'New collection' to start\./)
       ).toBeTruthy();
     });
   });
@@ -756,7 +772,7 @@ describe('DashboardScreen', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Limit')).toBeTruthy();
+      expect(getByText('Item limit reached')).toBeTruthy();
     });
   });
 });

--- a/apps/mobile/src/components/dashboard/AnnotatedPrimitive.tsx
+++ b/apps/mobile/src/components/dashboard/AnnotatedPrimitive.tsx
@@ -1,0 +1,92 @@
+import React, { type ReactNode } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+type TagVariant = 'usage' | 'gate' | 'feature';
+
+const dotColor: Record<TagVariant, string> = {
+  usage: '#fbbf24',
+  gate: '#60a5fa',
+  feature: '#4ade80',
+};
+
+interface AnnotatedPrimitiveProps {
+  tag: string;
+  variant: TagVariant;
+  tooltip?: string;
+  children: ReactNode;
+}
+
+export function AnnotatedPrimitive({
+  tag,
+  variant,
+  tooltip,
+  children,
+}: AnnotatedPrimitiveProps) {
+  const hint = tooltip ? `${tag} — ${tooltip}` : tag;
+  return (
+    <View style={styles.card} accessibilityHint={hint} accessibilityLabel={tag}>
+      <View style={styles.tagRow}>
+        <View
+          style={[styles.dot, { backgroundColor: dotColor[variant] }]}
+          accessibilityElementsHidden
+        />
+        <Text style={styles.tagText}>{tag}</Text>
+      </View>
+      {tooltip ? (
+        <Text style={styles.tooltip} accessibilityRole='text'>
+          {tooltip}
+        </Text>
+      ) : null}
+      <View style={styles.body}>{children}</View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    position: 'relative',
+    borderRadius: 12,
+    borderWidth: 2,
+    borderStyle: 'dashed',
+    borderColor: '#c4b5fd',
+    padding: 16,
+    paddingTop: 28,
+    marginBottom: 16,
+    backgroundColor: '#fff',
+  },
+  tagRow: {
+    position: 'absolute',
+    top: -10,
+    left: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    backgroundColor: '#0f172a',
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 6,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.12,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  tagText: {
+    fontFamily: 'monospace',
+    fontSize: 11,
+    color: '#e9d5ff',
+  },
+  tooltip: {
+    marginTop: 4,
+    marginBottom: 4,
+    fontSize: 11,
+    color: '#64748b',
+    lineHeight: 15,
+  },
+  body: { marginTop: 4 },
+});

--- a/apps/mobile/src/components/dashboard/BooleanFeatureTiles.tsx
+++ b/apps/mobile/src/components/dashboard/BooleanFeatureTiles.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useFeature } from '@beakerstack/billing';
+import { beakerstackBillingConfig } from '../../billing/beakerstackBillingConfig';
+
+interface TileProps {
+  label: string;
+  plan: string;
+  enabled: boolean;
+  loading: boolean;
+  hookExpr: string;
+}
+
+function FeatureTile({ label, plan, enabled, loading, hookExpr }: TileProps) {
+  return (
+    <View style={[styles.tile, enabled ? styles.tileOn : styles.tileOff]}>
+      <View style={styles.tileHeader}>
+        <View>
+          <Text style={styles.tileLabel}>{label}</Text>
+          <Text style={styles.tilePlan}>{plan}</Text>
+        </View>
+        <View
+          style={[styles.iconWrap, enabled ? styles.iconOn : styles.iconOff]}
+        >
+          {loading ? (
+            <View style={styles.iconPlaceholder} />
+          ) : (
+            <Text style={[styles.iconText, enabled && styles.iconTextOn]}>
+              {enabled ? '✓' : '✕'}
+            </Text>
+          )}
+        </View>
+      </View>
+      <View style={styles.codeBox}>
+        <Text style={styles.codeText}>
+          {hookExpr} →{' '}
+          <Text style={enabled ? styles.codeValOn : styles.codeValOff}>
+            {loading ? '…' : String(enabled)}
+          </Text>
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+export function BooleanFeatureTiles() {
+  const featureA = useFeature<typeof beakerstackBillingConfig, 'feature_a'>(
+    'feature_a'
+  );
+  const featureB = useFeature<typeof beakerstackBillingConfig, 'feature_b'>(
+    'feature_b'
+  );
+
+  return (
+    <View>
+      <Text style={styles.sectionTitle}>Boolean feature gates</Text>
+      <View style={styles.row}>
+        <FeatureTile
+          label='Feature A'
+          plan='Requires Pro+'
+          enabled={featureA.enabled}
+          loading={featureA.loading}
+          hookExpr='useFeature("feature_a").enabled'
+        />
+        <FeatureTile
+          label='Feature B'
+          plan='Requires Max'
+          enabled={featureB.enabled}
+          loading={featureB.loading}
+          hookExpr='useFeature("feature_b").enabled'
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#111827',
+    marginBottom: 12,
+  },
+  row: { flexDirection: 'row', flexWrap: 'wrap', gap: 12 },
+  tile: {
+    flex: 1,
+    minWidth: 140,
+    borderRadius: 10,
+    borderWidth: 2,
+    padding: 14,
+  },
+  tileOn: {
+    borderColor: '#86efac',
+    backgroundColor: '#f0fdf4',
+  },
+  tileOff: {
+    borderColor: '#e5e7eb',
+    backgroundColor: '#f9fafb',
+  },
+  tileHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: 8,
+  },
+  tileLabel: { fontSize: 13, fontWeight: '600', color: '#111827' },
+  tilePlan: { marginTop: 2, fontSize: 11, color: '#6b7280' },
+  iconWrap: {
+    borderRadius: 999,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  iconOn: { backgroundColor: '#dcfce7' },
+  iconOff: { backgroundColor: '#e5e7eb' },
+  iconPlaceholder: { width: 14, height: 14 },
+  iconText: { fontSize: 12, fontWeight: '800', color: '#9ca3af' },
+  iconTextOn: { color: '#16a34a' },
+  codeBox: {
+    marginTop: 10,
+    backgroundColor: '#0f172a',
+    borderRadius: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  codeText: {
+    fontFamily: 'monospace',
+    fontSize: 11,
+    color: '#cbd5e1',
+  },
+  codeValOn: { color: '#4ade80' },
+  codeValOff: { color: '#64748b' },
+});

--- a/apps/mobile/src/components/dashboard/CollectionDetail.tsx
+++ b/apps/mobile/src/components/dashboard/CollectionDetail.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
-import type { SupabaseClient } from '@supabase/supabase-js';
 import {
   mapUnknownError,
   useBillingContext,
@@ -18,8 +17,6 @@ import { randomUuid } from '../../lib/randomUuid';
 import type { DemoCollectionRow } from '../../billing/useDemoCollections';
 import type { ActivityEntry } from './types';
 import { limLabel } from './utils';
-
-const supabaseRpc = supabase as unknown as SupabaseClient;
 
 interface Props {
   collection: DemoCollectionRow | undefined;
@@ -100,7 +97,7 @@ export function CollectionDetail({ collection, addItem, onActivity }: Props) {
       const key = summarizeKeys.get(itemIndex) ?? randomUuid();
       setSummarizeKeys(prev => new Map(prev).set(itemIndex, key));
       try {
-        const { error: rpcErr } = await supabaseRpc.rpc(
+        const { error: rpcErr } = await supabase.rpc(
           'billing_record_usage_event',
           {
             p_product_id: config.productId,

--- a/apps/mobile/src/components/dashboard/CollectionDetail.tsx
+++ b/apps/mobile/src/components/dashboard/CollectionDetail.tsx
@@ -1,0 +1,401 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  mapUnknownError,
+  useBillingContext,
+  useFeature,
+  useUsage,
+} from '@beakerstack/billing';
+import type { BillingError } from '@beakerstack/billing';
+import { supabase } from '../../lib/supabase';
+import {
+  beakerstackBillingConfig,
+  BEAKERSTACK_METER_AI_SUMMARIZE,
+} from '../../billing/beakerstackBillingConfig';
+import { nextFakeAiSummary } from '../../lib/fakeAi';
+import { randomUuid } from '../../lib/randomUuid';
+import type { DemoCollectionRow } from '../../billing/useDemoCollections';
+import type { ActivityEntry } from './types';
+import { limLabel } from './utils';
+
+const supabaseRpc = supabase as unknown as SupabaseClient;
+
+interface Props {
+  collection: DemoCollectionRow | undefined;
+  addItem: (collectionId: string) => Promise<void>;
+  onActivity?: (entry: Omit<ActivityEntry, 'id' | 'at'>) => void;
+}
+
+export function CollectionDetail({ collection, addItem, onActivity }: Props) {
+  const { config } = useBillingContext<typeof beakerstackBillingConfig>();
+  const { value: maxItemsRaw, loading: featLoading } = useFeature<
+    typeof beakerstackBillingConfig,
+    'items_per_container_max'
+  >('items_per_container_max');
+  const featureA = useFeature<typeof beakerstackBillingConfig, 'feature_a'>(
+    'feature_a'
+  );
+  const featureB = useFeature<typeof beakerstackBillingConfig, 'feature_b'>(
+    'feature_b'
+  );
+  const {
+    exceeded: usageExceeded,
+    loading: usageLoading,
+    refresh: refreshUsage,
+  } = useUsage<
+    typeof beakerstackBillingConfig,
+    typeof BEAKERSTACK_METER_AI_SUMMARIZE
+  >(BEAKERSTACK_METER_AI_SUMMARIZE);
+
+  const maxItems = typeof maxItemsRaw === 'number' ? maxItemsRaw : null;
+  const itemCount = collection?.item_count ?? 0;
+  const atItemCap =
+    maxItems !== null && maxItems !== -1 && itemCount >= maxItems;
+
+  const [summaries, setSummaries] = useState<Map<number, string>>(new Map());
+  const [summarizeBusy, setSummarizeBusy] = useState<Set<number>>(new Set());
+  const [summarizeErrors, setSummarizeErrors] = useState<
+    Map<number, BillingError>
+  >(new Map());
+  const [summarizeKeys, setSummarizeKeys] = useState<Map<number, string>>(
+    new Map()
+  );
+  const [addBusy, setAddBusy] = useState(false);
+  const [addErr, setAddErr] = useState<string | null>(null);
+  const [featureToast, setFeatureToast] = useState<string | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inFlightRef = useRef(0);
+
+  useEffect(() => {
+    setSummaries(new Map());
+    setSummarizeBusy(new Set());
+    setSummarizeErrors(new Map());
+    setSummarizeKeys(new Map());
+  }, [collection?.id]);
+
+  useEffect(
+    () => () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+    },
+    []
+  );
+
+  const showToast = useCallback((msg: string) => {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    setFeatureToast(msg);
+    toastTimer.current = setTimeout(() => setFeatureToast(null), 3000);
+  }, []);
+
+  const onSummarize = useCallback(
+    async (itemIndex: number) => {
+      if (!collection || usageExceeded || inFlightRef.current > 0) return;
+      inFlightRef.current += 1;
+      setSummarizeBusy(prev => new Set(prev).add(itemIndex));
+      setSummarizeErrors(prev => {
+        const next = new Map(prev);
+        next.delete(itemIndex);
+        return next;
+      });
+      const key = summarizeKeys.get(itemIndex) ?? randomUuid();
+      setSummarizeKeys(prev => new Map(prev).set(itemIndex, key));
+      try {
+        const { error: rpcErr } = await supabaseRpc.rpc(
+          'billing_record_usage_event',
+          {
+            p_product_id: config.productId,
+            p_event_type: BEAKERSTACK_METER_AI_SUMMARIZE,
+            p_quantity: 1,
+            p_metadata: {},
+            p_idempotency_key: key,
+          }
+        );
+        if (rpcErr) throw rpcErr;
+        await refreshUsage();
+        const text = nextFakeAiSummary();
+        setSummaries(prev => new Map(prev).set(itemIndex, text));
+        setSummarizeKeys(prev => {
+          const next = new Map(prev);
+          next.delete(itemIndex);
+          return next;
+        });
+        onActivity?.({
+          label: `Item ${itemIndex + 1} summarized`,
+          rpc: 'billing_record_usage_event',
+        });
+      } catch (e) {
+        setSummarizeErrors(prev =>
+          new Map(prev).set(itemIndex, mapUnknownError(e))
+        );
+      } finally {
+        inFlightRef.current -= 1;
+        setSummarizeBusy(prev => {
+          const next = new Set(prev);
+          next.delete(itemIndex);
+          return next;
+        });
+      }
+    },
+    [
+      collection,
+      usageExceeded,
+      config.productId,
+      refreshUsage,
+      onActivity,
+      summarizeKeys,
+    ]
+  );
+
+  const onAddItem = useCallback(async () => {
+    if (!collection || atItemCap) return;
+    setAddErr(null);
+    setAddBusy(true);
+    try {
+      await addItem(collection.id);
+      onActivity?.({ label: 'Item added', rpc: 'billing_demo_add_item' });
+    } catch (e) {
+      setAddErr(e instanceof Error ? e.message : 'Action failed.');
+    } finally {
+      setAddBusy(false);
+    }
+  }, [collection, atItemCap, addItem, onActivity]);
+
+  if (!collection) {
+    return (
+      <View style={styles.emptySelect}>
+        <Text style={styles.emptySelectText}>
+          Select a collection above to view its items.
+        </Text>
+      </View>
+    );
+  }
+
+  const itemRows = Array.from({ length: itemCount }, (_, i) => i);
+  const anySummarizeBusy = summarizeBusy.size > 0;
+
+  return (
+    <View>
+      <View style={styles.headerRow}>
+        <View>
+          <Text style={styles.sectionTitle}>Items</Text>
+          <Text style={styles.sub}>
+            {featLoading
+              ? '…'
+              : `${itemCount} of ${limLabel(maxItems)} in this collection`}
+          </Text>
+        </View>
+        <View style={styles.featureBtns}>
+          <Pressable
+            style={[
+              styles.featBtn,
+              featureA.enabled ? styles.featBtnAOn : styles.featBtnOff,
+            ]}
+            disabled={featureA.loading}
+            onPress={() => {
+              if (featureA.enabled) {
+                showToast('Feature A action triggered');
+              } else {
+                showToast(
+                  'Feature A requires Pro or higher. Upgrade at /billing.'
+                );
+              }
+            }}
+          >
+            <Text
+              style={[
+                styles.featBtnText,
+                !featureA.enabled && styles.featBtnTextOff,
+              ]}
+            >
+              Feature A
+            </Text>
+          </Pressable>
+          <Pressable
+            style={[
+              styles.featBtn,
+              featureB.enabled ? styles.featBtnBOn : styles.featBtnOff,
+            ]}
+            disabled={featureB.loading}
+            onPress={() => {
+              if (featureB.enabled) {
+                showToast('Feature B action triggered');
+              } else {
+                showToast('Feature B requires Max plan. Upgrade at /billing.');
+              }
+            }}
+          >
+            <Text
+              style={[
+                styles.featBtnText,
+                !featureB.enabled && styles.featBtnTextOff,
+              ]}
+            >
+              Feature B
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+
+      {featureToast ? (
+        <View style={styles.toast} accessibilityLiveRegion='polite'>
+          <Text style={styles.toastText}>{featureToast}</Text>
+        </View>
+      ) : null}
+
+      {addErr ? (
+        <Text style={styles.err} accessibilityRole='alert'>
+          {addErr}
+        </Text>
+      ) : null}
+
+      {itemRows.length === 0 ? (
+        <Text style={styles.emptyItems}>No items yet. Add one below.</Text>
+      ) : (
+        <View style={styles.itemList}>
+          {itemRows.map(i => {
+            const isBusy = summarizeBusy.has(i);
+            const summary = summaries.get(i);
+            const err = summarizeErrors.get(i);
+            const summarizeDisabled =
+              anySummarizeBusy || usageExceeded || usageLoading;
+            return (
+              <View key={i} style={styles.itemCard}>
+                <View style={styles.itemRow}>
+                  <Text style={styles.itemLabel}>Item {i + 1}</Text>
+                  <Pressable
+                    style={[
+                      styles.summarizeBtn,
+                      summarizeDisabled &&
+                        !isBusy &&
+                        styles.summarizeBtnDisabled,
+                    ]}
+                    disabled={summarizeDisabled && !isBusy}
+                    onPress={() => void onSummarize(i)}
+                    accessibilityLabel={
+                      usageExceeded
+                        ? 'AI summarize limit reached'
+                        : anySummarizeBusy && !isBusy
+                          ? 'Another item is being summarized'
+                          : 'Summarize'
+                    }
+                  >
+                    <Text style={styles.summarizeBtnText}>
+                      {isBusy
+                        ? '…'
+                        : usageExceeded
+                          ? 'Limit reached'
+                          : 'Summarize'}
+                    </Text>
+                  </Pressable>
+                </View>
+                {err ? (
+                  <Text style={styles.itemErr} accessibilityRole='alert'>
+                    {err.message}
+                  </Text>
+                ) : null}
+                {summary ? (
+                  <Text style={styles.summaryText}>{summary}</Text>
+                ) : null}
+              </View>
+            );
+          })}
+        </View>
+      )}
+
+      <Pressable
+        style={[
+          styles.addItemBtn,
+          (atItemCap || featLoading || addBusy) && styles.btnDisabled,
+        ]}
+        disabled={atItemCap || featLoading || addBusy}
+        onPress={() => void onAddItem()}
+      >
+        <Text style={styles.addItemBtnText}>
+          {addBusy ? '…' : atItemCap ? 'Item limit reached' : '+ Add item'}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  emptySelect: { paddingVertical: 24, alignItems: 'center' },
+  emptySelectText: { fontSize: 13, color: '#6b7280' },
+  headerRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    gap: 10,
+    marginBottom: 12,
+  },
+  sectionTitle: { fontSize: 14, fontWeight: '600', color: '#111827' },
+  sub: { marginTop: 2, fontSize: 11, color: '#6b7280' },
+  featureBtns: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  featBtn: {
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  featBtnAOn: { backgroundColor: '#e0e7ff' },
+  featBtnBOn: { backgroundColor: '#f3e8ff' },
+  featBtnOff: { backgroundColor: '#f3f4f6' },
+  featBtnText: { fontSize: 11, fontWeight: '700', color: '#4338ca' },
+  featBtnTextOff: { color: '#9ca3af' },
+  toast: {
+    marginBottom: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#c7d2fe',
+    backgroundColor: '#eef2ff',
+    padding: 10,
+  },
+  toastText: { fontSize: 13, color: '#3730a3' },
+  err: { marginBottom: 10, fontSize: 13, color: '#dc2626' },
+  emptyItems: { fontSize: 13, color: '#6b7280', paddingVertical: 8 },
+  itemList: { gap: 8, marginBottom: 10 },
+  itemCard: {
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#e5e7eb',
+    backgroundColor: '#f9fafb',
+    padding: 12,
+  },
+  itemRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 8,
+  },
+  itemLabel: { fontSize: 13, fontWeight: '600', color: '#1f2937' },
+  summarizeBtn: {
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    backgroundColor: '#fff',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+  },
+  summarizeBtnDisabled: { opacity: 0.5 },
+  summarizeBtnText: { fontSize: 11, fontWeight: '600', color: '#374151' },
+  itemErr: { marginTop: 6, fontSize: 11, color: '#dc2626' },
+  summaryText: {
+    marginTop: 8,
+    fontSize: 11,
+    color: '#4b5563',
+    lineHeight: 16,
+  },
+  addItemBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderStyle: 'dashed',
+    borderColor: '#d1d5db',
+    borderRadius: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+  },
+  addItemBtnText: { fontSize: 13, fontWeight: '500', color: '#6b7280' },
+  btnDisabled: { opacity: 0.5 },
+});

--- a/apps/mobile/src/components/dashboard/CollectionsGrid.tsx
+++ b/apps/mobile/src/components/dashboard/CollectionsGrid.tsx
@@ -1,0 +1,237 @@
+import React, { useCallback, useState } from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { useFeature } from '@beakerstack/billing';
+import { beakerstackBillingConfig } from '../../billing/beakerstackBillingConfig';
+import type { DemoCollectionRow } from '../../billing/useDemoCollections';
+import type { ActivityEntry } from './types';
+import { limLabel } from './utils';
+
+interface Props {
+  collections: DemoCollectionRow[];
+  loading: boolean;
+  error: string | null;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  addCollection: () => Promise<void>;
+  deleteCollection: (id: string) => Promise<void>;
+  onActivity?: (entry: Omit<ActivityEntry, 'id' | 'at'>) => void;
+}
+
+export function CollectionsGrid({
+  collections,
+  loading,
+  error,
+  selectedId,
+  onSelect,
+  addCollection,
+  deleteCollection,
+  onActivity,
+}: Props) {
+  const { value: maxCollectionsRaw, loading: featLoading } = useFeature<
+    typeof beakerstackBillingConfig,
+    'containers_per_account_max'
+  >('containers_per_account_max');
+
+  const maxCollections =
+    typeof maxCollectionsRaw === 'number' ? maxCollectionsRaw : null;
+  const atCap =
+    maxCollections !== null &&
+    maxCollections !== -1 &&
+    collections.length >= maxCollections;
+
+  const [busy, setBusy] = useState<string | null>(null);
+  const [actionErr, setActionErr] = useState<string | null>(null);
+
+  const wrap = useCallback(async (key: string, fn: () => Promise<void>) => {
+    setActionErr(null);
+    setBusy(key);
+    try {
+      await fn();
+    } catch (e) {
+      setActionErr(e instanceof Error ? e.message : 'Action failed.');
+    } finally {
+      setBusy(null);
+    }
+  }, []);
+
+  const handleAdd = () =>
+    void wrap('add', async () => {
+      await addCollection();
+      onActivity?.({
+        label: 'Collection added',
+        rpc: 'billing_demo_add_collection',
+      });
+    });
+
+  const handleDelete = (id: string) =>
+    void wrap(`del:${id}`, async () => {
+      await deleteCollection(id);
+      onActivity?.({
+        label: 'Collection deleted',
+        rpc: 'billing_demo_delete_collection',
+      });
+    });
+
+  return (
+    <View>
+      <View style={styles.headerRow}>
+        <View>
+          <Text style={styles.sectionTitle}>Collections</Text>
+          <Text style={styles.sub}>
+            {loading || featLoading
+              ? '…'
+              : `${collections.length} of ${limLabel(maxCollections)}`}
+          </Text>
+        </View>
+        <Pressable
+          style={[
+            styles.addBtn,
+            (atCap || loading || featLoading || busy === 'add') &&
+              styles.btnDisabled,
+          ]}
+          disabled={atCap || loading || featLoading || busy === 'add'}
+          onPress={handleAdd}
+          accessibilityLabel={
+            atCap ? 'Collection limit reached for your plan' : 'New collection'
+          }
+        >
+          <Text style={styles.addBtnText}>
+            {busy === 'add'
+              ? '…'
+              : atCap
+                ? 'Limit reached'
+                : '+ New collection'}
+          </Text>
+        </Pressable>
+      </View>
+
+      {error ? (
+        <Text style={styles.warn} accessibilityRole='alert'>
+          {error}{' '}
+          <Text style={styles.warnMuted}>
+            (Requires demo billing RPCs and{' '}
+            <Text style={styles.mono}>demo_billing_mode</Text> in the database.)
+          </Text>
+        </Text>
+      ) : null}
+
+      {actionErr ? (
+        <Text style={styles.err} accessibilityRole='alert'>
+          {actionErr}
+        </Text>
+      ) : null}
+
+      {!loading && collections.length === 0 ? (
+        <Text style={styles.empty}>
+          No collections yet. Tap &apos;New collection&apos; to start.
+        </Text>
+      ) : (
+        <View style={styles.grid}>
+          {collections.map(col => {
+            const isSelected = col.id === selectedId;
+            const delKey = `del:${col.id}`;
+            return (
+              <Pressable
+                key={col.id}
+                style={[styles.card, isSelected && styles.cardSelected]}
+                onPress={() => onSelect(col.id)}
+                accessibilityRole='button'
+                accessibilityState={{ selected: isSelected }}
+              >
+                <Pressable
+                  style={styles.deleteBtn}
+                  accessibilityLabel='Delete collection'
+                  disabled={busy === delKey}
+                  onPress={() => handleDelete(col.id)}
+                >
+                  <Text style={styles.deleteBtnText}>Del</Text>
+                </Pressable>
+                <Text style={styles.monoId} numberOfLines={1}>
+                  {col.id.slice(0, 8)}…
+                </Text>
+                <Text style={styles.cardTitle}>Collection</Text>
+                <Text style={styles.cardMeta}>
+                  {col.item_count} item{col.item_count !== 1 ? 's' : ''}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 10,
+    marginBottom: 12,
+  },
+  sectionTitle: { fontSize: 14, fontWeight: '600', color: '#111827' },
+  sub: { marginTop: 2, fontSize: 11, color: '#6b7280' },
+  addBtn: {
+    backgroundColor: '#4f46e5',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  addBtnText: { fontSize: 13, fontWeight: '700', color: '#fff' },
+  btnDisabled: { opacity: 0.5 },
+  warn: {
+    marginBottom: 10,
+    fontSize: 13,
+    color: '#92400e',
+  },
+  warnMuted: { color: '#4b5563', fontSize: 12 },
+  mono: { fontFamily: 'monospace', fontSize: 11 },
+  err: { marginBottom: 10, fontSize: 13, color: '#dc2626' },
+  empty: { fontSize: 13, color: '#6b7280' },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+  card: {
+    width: '47%',
+    minWidth: 140,
+    flexGrow: 1,
+    borderRadius: 10,
+    borderWidth: 2,
+    borderColor: '#e5e7eb',
+    backgroundColor: '#fff',
+    padding: 12,
+    paddingTop: 36,
+  },
+  cardSelected: {
+    borderColor: '#6366f1',
+    shadowColor: '#6366f1',
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  deleteBtn: {
+    position: 'absolute',
+    top: 6,
+    right: 6,
+    padding: 6,
+    zIndex: 1,
+  },
+  deleteBtnText: { fontSize: 14, color: '#9ca3af' },
+  monoId: {
+    fontFamily: 'monospace',
+    fontSize: 11,
+    color: '#9ca3af',
+  },
+  cardTitle: {
+    marginTop: 4,
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#111827',
+  },
+  cardMeta: { marginTop: 2, fontSize: 11, color: '#6b7280' },
+});

--- a/apps/mobile/src/components/dashboard/FeatureGateCard.tsx
+++ b/apps/mobile/src/components/dashboard/FeatureGateCard.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { usePlan } from '@beakerstack/billing';
+import { FeatureGate } from '@beakerstack/billing/native';
+import { beakerstackBillingConfig } from '../../billing/beakerstackBillingConfig';
+
+interface Props {
+  onNavigateBilling: () => void;
+}
+
+export function FeatureGateCard({ onNavigateBilling }: Props) {
+  const { loading: planLoading } = usePlan<typeof beakerstackBillingConfig>();
+
+  return (
+    <View>
+      <Text style={styles.heading}>
+        Feature A <Text style={styles.headingMuted}>(Pro+)</Text>
+      </Text>
+      {planLoading ? (
+        <Text style={styles.muted}>…</Text>
+      ) : (
+        <FeatureGate<typeof beakerstackBillingConfig>
+          feature='feature_a'
+          fallback={
+            <View style={styles.fallbackBox}>
+              <View style={styles.lockCircle}>
+                <Text style={styles.lockGlyph}>🔒</Text>
+              </View>
+              <View style={styles.fallbackTextWrap}>
+                <Text style={styles.fallbackTitle}>
+                  Feature A is locked on your current plan
+                </Text>
+                <Text style={styles.fallbackBody}>
+                  Upgrade to Pro or Max to unlock Feature A.{' '}
+                  <Text style={styles.monoSm}>
+                    useFeature(&quot;feature_a&quot;).enabled
+                  </Text>{' '}
+                  returns <Text style={styles.monoSm}>false</Text> on your plan
+                  — <Text style={styles.monoSm}>FeatureGate</Text> renders this
+                  fallback.
+                </Text>
+                <Pressable
+                  style={styles.upgradeBtn}
+                  onPress={onNavigateBilling}
+                >
+                  <Text style={styles.upgradeBtnText}>Upgrade →</Text>
+                </Pressable>
+              </View>
+            </View>
+          }
+        >
+          <View style={styles.successBox}>
+            <Text style={styles.checkGlyph}>✓</Text>
+            <View>
+              <Text style={styles.successTitle}>Feature A is active</Text>
+              <Text style={styles.successSub}>
+                <Text style={styles.monoSm}>
+                  useFeature(&quot;feature_a&quot;).enabled
+                </Text>
+                {' → '}
+                <Text style={styles.monoSm}>true</Text> ·{' '}
+                <Text style={styles.monoSm}>FeatureGate</Text> renders children
+              </Text>
+            </View>
+          </View>
+        </FeatureGate>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  heading: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#111827',
+    marginBottom: 10,
+  },
+  headingMuted: { fontWeight: '400', color: '#6b7280' },
+  muted: { fontSize: 13, color: '#6b7280' },
+  fallbackBox: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#e9d5ff',
+    backgroundColor: '#faf5ff',
+    padding: 14,
+  },
+  lockCircle: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: '#f3e8ff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  lockGlyph: { fontSize: 16 },
+  fallbackTextWrap: { flex: 1, minWidth: 0 },
+  fallbackTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#111827',
+  },
+  fallbackBody: {
+    marginTop: 4,
+    fontSize: 12,
+    color: '#4b5563',
+    lineHeight: 18,
+  },
+  monoSm: { fontFamily: 'monospace', fontSize: 11, color: '#374151' },
+  upgradeBtn: {
+    alignSelf: 'flex-start',
+    marginTop: 10,
+    backgroundColor: '#9333ea',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  upgradeBtnText: { fontSize: 13, fontWeight: '700', color: '#fff' },
+  successBox: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#bbf7d0',
+    backgroundColor: '#f0fdf4',
+    padding: 14,
+  },
+  checkGlyph: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#16a34a',
+    marginTop: -2,
+  },
+  successTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#166534',
+  },
+  successSub: {
+    marginTop: 4,
+    fontSize: 11,
+    color: '#15803d',
+    lineHeight: 16,
+  },
+});

--- a/apps/mobile/src/components/dashboard/UsageStrip.tsx
+++ b/apps/mobile/src/components/dashboard/UsageStrip.tsx
@@ -1,0 +1,254 @@
+import React, { useCallback, useState } from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  mapUnknownError,
+  useBillingContext,
+  useUsage,
+} from '@beakerstack/billing';
+import type { BillingError } from '@beakerstack/billing';
+import { supabase } from '../../lib/supabase';
+import {
+  beakerstackBillingConfig,
+  BEAKERSTACK_METER_AI_SUMMARIZE,
+} from '../../billing/beakerstackBillingConfig';
+import { nextFakeAiSummary } from '../../lib/fakeAi';
+import { randomUuid } from '../../lib/randomUuid';
+import type { ActivityEntry } from './types';
+
+const supabaseRpc = supabase as unknown as SupabaseClient;
+
+function readDemoUseRealAi(): boolean {
+  return process.env?.['EXPO_PUBLIC_DEMO_USE_REAL_AI'] === 'true';
+}
+
+interface Props {
+  onActivity?: (entry: Omit<ActivityEntry, 'id' | 'at'>) => void;
+  onNavigateBilling: () => void;
+}
+
+export function UsageStrip({ onActivity, onNavigateBilling }: Props) {
+  const { config } = useBillingContext<typeof beakerstackBillingConfig>();
+  const {
+    used,
+    limit,
+    resetsAt,
+    exceeded,
+    loading,
+    error: usageError,
+    refresh,
+  } = useUsage<
+    typeof beakerstackBillingConfig,
+    typeof BEAKERSTACK_METER_AI_SUMMARIZE
+  >(BEAKERSTACK_METER_AI_SUMMARIZE);
+
+  const [results, setResults] = useState<
+    { id: string; text: string; at: number }[]
+  >([]);
+  const [pending, setPending] = useState(false);
+  const [recordError, setRecordError] = useState<BillingError | null>(null);
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+
+  const resolveSummaryText = useCallback(async (): Promise<string> => {
+    if (readDemoUseRealAi()) {
+      try {
+        const { data, error: fnErr } = await supabase.functions.invoke(
+          'demo-ai-summarize',
+          {
+            body: {
+              prompt: 'Write a short lorem-style summary (3-5 lines).',
+            },
+          }
+        );
+        if (!fnErr) {
+          const t = (data as { text?: string } | null)?.text;
+          if (typeof t === 'string' && t.trim()) return t.trim();
+        }
+      } catch {
+        /* edge function unavailable — use fake fallback */
+      }
+    }
+    return nextFakeAiSummary();
+  }, []);
+
+  const onSimulate = useCallback(async () => {
+    if (exceeded || pending) return;
+    const summaryText = await resolveSummaryText();
+    const key = pendingKey ?? randomUuid();
+    if (!pendingKey) setPendingKey(key);
+    setPending(true);
+    setRecordError(null);
+    try {
+      const { error: rpcErr } = await supabaseRpc.rpc(
+        'billing_record_usage_event',
+        {
+          p_product_id: config.productId,
+          p_event_type: BEAKERSTACK_METER_AI_SUMMARIZE,
+          p_quantity: 1,
+          p_metadata: {},
+          p_idempotency_key: key,
+        }
+      );
+      if (rpcErr) throw rpcErr;
+      await refresh();
+      setResults(prev =>
+        [
+          {
+            id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+            at: Date.now(),
+            text: summaryText,
+          },
+          ...prev,
+        ].slice(0, 3)
+      );
+      setPendingKey(null);
+      onActivity?.({
+        label: 'AI summarize recorded',
+        rpc: 'billing_record_usage_event',
+      });
+    } catch (e) {
+      setRecordError(mapUnknownError(e));
+    } finally {
+      setPending(false);
+    }
+  }, [
+    exceeded,
+    pending,
+    pendingKey,
+    config.productId,
+    refresh,
+    resolveSummaryText,
+    onActivity,
+  ]);
+
+  const lim = limit === null ? '∞' : String(limit);
+  const pct =
+    limit != null && limit > 0 ? Math.min(100, (used / limit) * 100) : 0;
+  const capLine =
+    limit === null
+      ? `${used} used this period · unlimited`
+      : `${used} of ${lim} used · resets ${
+          resetsAt ? new Date(resetsAt).toLocaleDateString() : '—'
+        }`;
+
+  const displayError = recordError ?? usageError;
+
+  return (
+    <View>
+      <View style={styles.titleRow}>
+        <Text style={styles.sectionTitle}>AI Summaries</Text>
+        {exceeded ? (
+          <View style={styles.limitBadge}>
+            <Text style={styles.limitBadgeText}>Limit reached</Text>
+          </View>
+        ) : null}
+      </View>
+
+      {limit != null ? (
+        <View style={styles.barTrack}>
+          <View style={[styles.barFill, { width: `${pct}%` }]} />
+        </View>
+      ) : null}
+      <Text style={styles.capLine}>{loading ? '…' : capLine}</Text>
+
+      <View style={styles.actions}>
+        {exceeded ? (
+          <Pressable onPress={onNavigateBilling}>
+            <Text style={styles.link}>Upgrade to get more summaries →</Text>
+          </Pressable>
+        ) : (
+          <Pressable
+            style={[styles.btnPrimary, pending && styles.btnDisabled]}
+            disabled={pending}
+            onPress={() => void onSimulate()}
+          >
+            <Text style={styles.btnPrimaryText}>
+              {pending ? '…' : 'Simulate AI summarize'}
+            </Text>
+          </Pressable>
+        )}
+      </View>
+
+      {displayError ? (
+        <Text style={styles.err} accessibilityRole='alert'>
+          {displayError.message}
+        </Text>
+      ) : null}
+
+      {results.length > 0 ? (
+        <View style={styles.results}>
+          {results.map(r => (
+            <View key={r.id} style={styles.resultItem}>
+              <Text style={styles.resultTs}>
+                {new Date(r.at).toLocaleTimeString()}
+              </Text>
+              <Text style={styles.resultBody}>{r.text}</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  titleRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 10,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#111827',
+  },
+  limitBadge: {
+    backgroundColor: '#fee2e2',
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 999,
+  },
+  limitBadgeText: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#b91c1c',
+  },
+  barTrack: {
+    height: 8,
+    width: '100%',
+    borderRadius: 4,
+    backgroundColor: '#e5e7eb',
+    overflow: 'hidden',
+  },
+  barFill: {
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#4f46e5',
+  },
+  capLine: {
+    marginTop: 6,
+    fontSize: 13,
+    color: '#6b7280',
+  },
+  actions: { marginTop: 14, flexDirection: 'row', flexWrap: 'wrap', gap: 10 },
+  btnPrimary: {
+    backgroundColor: '#4f46e5',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 8,
+  },
+  btnPrimaryText: { color: '#fff', fontWeight: '600', fontSize: 14 },
+  btnDisabled: { opacity: 0.5 },
+  link: { fontSize: 14, fontWeight: '600', color: '#4f46e5' },
+  err: { marginTop: 8, fontSize: 13, color: '#dc2626' },
+  results: { marginTop: 14, gap: 8 },
+  resultItem: {
+    borderRadius: 8,
+    backgroundColor: '#f9fafb',
+    padding: 12,
+  },
+  resultTs: { fontSize: 11, color: '#9ca3af', marginBottom: 4 },
+  resultBody: { fontSize: 13, color: '#374151' },
+});

--- a/apps/mobile/src/components/dashboard/UsageStrip.tsx
+++ b/apps/mobile/src/components/dashboard/UsageStrip.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
-import type { SupabaseClient } from '@supabase/supabase-js';
 import {
   mapUnknownError,
   useBillingContext,
@@ -15,8 +14,6 @@ import {
 import { nextFakeAiSummary } from '../../lib/fakeAi';
 import { randomUuid } from '../../lib/randomUuid';
 import type { ActivityEntry } from './types';
-
-const supabaseRpc = supabase as unknown as SupabaseClient;
 
 function readDemoUseRealAi(): boolean {
   return process.env?.['EXPO_PUBLIC_DEMO_USE_REAL_AI'] === 'true';
@@ -48,6 +45,7 @@ export function UsageStrip({ onActivity, onNavigateBilling }: Props) {
   const [pending, setPending] = useState(false);
   const [recordError, setRecordError] = useState<BillingError | null>(null);
   const [pendingKey, setPendingKey] = useState<string | null>(null);
+  const simulateInFlightRef = useRef(false);
 
   const resolveSummaryText = useCallback(async (): Promise<string> => {
     if (readDemoUseRealAi()) {
@@ -72,14 +70,15 @@ export function UsageStrip({ onActivity, onNavigateBilling }: Props) {
   }, []);
 
   const onSimulate = useCallback(async () => {
-    if (exceeded || pending) return;
-    const summaryText = await resolveSummaryText();
+    if (exceeded || pending || simulateInFlightRef.current) return;
+    simulateInFlightRef.current = true;
     const key = pendingKey ?? randomUuid();
     if (!pendingKey) setPendingKey(key);
     setPending(true);
     setRecordError(null);
     try {
-      const { error: rpcErr } = await supabaseRpc.rpc(
+      const summaryText = await resolveSummaryText();
+      const { error: rpcErr } = await supabase.rpc(
         'billing_record_usage_event',
         {
           p_product_id: config.productId,
@@ -109,6 +108,7 @@ export function UsageStrip({ onActivity, onNavigateBilling }: Props) {
     } catch (e) {
       setRecordError(mapUnknownError(e));
     } finally {
+      simulateInFlightRef.current = false;
       setPending(false);
     }
   }, [

--- a/apps/mobile/src/components/dashboard/index.ts
+++ b/apps/mobile/src/components/dashboard/index.ts
@@ -1,0 +1,8 @@
+export type { ActivityEntry } from './types';
+export { limLabel } from './utils';
+export { AnnotatedPrimitive } from './AnnotatedPrimitive';
+export { UsageStrip } from './UsageStrip';
+export { FeatureGateCard } from './FeatureGateCard';
+export { CollectionsGrid } from './CollectionsGrid';
+export { CollectionDetail } from './CollectionDetail';
+export { BooleanFeatureTiles } from './BooleanFeatureTiles';

--- a/apps/mobile/src/components/dashboard/types.ts
+++ b/apps/mobile/src/components/dashboard/types.ts
@@ -1,0 +1,6 @@
+export interface ActivityEntry {
+  id: string;
+  at: Date;
+  label: string;
+  rpc: string;
+}

--- a/apps/mobile/src/components/dashboard/utils.ts
+++ b/apps/mobile/src/components/dashboard/utils.ts
@@ -1,0 +1,5 @@
+export function limLabel(v: number | null): string {
+  if (v === null) return '…';
+  if (v === -1) return '∞';
+  return String(v);
+}

--- a/apps/mobile/src/lib/randomUuid.ts
+++ b/apps/mobile/src/lib/randomUuid.ts
@@ -1,0 +1,26 @@
+import 'react-native-get-random-values';
+
+/**
+ * UUID for idempotency keys and activity log ids. Uses `crypto.randomUUID`
+ * when available; RN often exposes `crypto` without `randomUUID`, so we fall
+ * back to a high-entropy string (getRandomValues is polyfilled by the import).
+ */
+export function randomUuid(): string {
+  const c = typeof globalThis !== 'undefined' ? globalThis.crypto : undefined;
+  if (c && typeof c.randomUUID === 'function') {
+    return c.randomUUID();
+  }
+  const bytes = new Uint8Array(16);
+  if (typeof c?.getRandomValues === 'function') {
+    c.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < 16; i += 1) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  // RFC 4122 variant — good enough for client idempotency keys
+  const b6 = bytes[6] ?? 0;
+  const b8 = bytes[8] ?? 0;
+  bytes[6] = (b6 & 0x0f) | 0x40;
+  bytes[8] = (b8 & 0x3f) | 0x80;
+  const hex = [...bytes].map(b => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -14,15 +14,7 @@ import {
   Pressable,
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import {
-  mapUnknownError,
-  useBillingContext,
-  useFeature,
-  usePlan,
-  useUsage,
-} from '@beakerstack/billing';
-import type { BillingError } from '@beakerstack/billing';
-import { FeatureGate } from '@beakerstack/billing/native';
+import { useBillingContext, usePlan, useUsage } from '@beakerstack/billing';
 import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
 import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.native';
 import { supabase } from '../lib/supabase';
@@ -31,15 +23,17 @@ import {
   BEAKERSTACK_METER_AI_SUMMARIZE,
 } from '../billing/beakerstackBillingConfig';
 import { useDemoCollections } from '../billing/useDemoCollections';
-import { nextFakeAiSummary } from '../lib/fakeAi';
+import {
+  AnnotatedPrimitive,
+  BooleanFeatureTiles,
+  CollectionDetail,
+  CollectionsGrid,
+  FeatureGateCard,
+  UsageStrip,
+} from '../components/dashboard';
 
-// Read at call time (not module init) so tests and dev toggles can change process.env without reload.
 function readBillingDashboardDemoMode(): boolean {
   return process.env?.['EXPO_PUBLIC_BILLING_DEMO_MODE'] === 'true';
-}
-
-function readDemoUseRealAi(): boolean {
-  return process.env?.['EXPO_PUBLIC_DEMO_USE_REAL_AI'] === 'true';
 }
 
 type RootStackParamList = {
@@ -58,356 +52,6 @@ type DashboardScreenNavigationProp = NativeStackNavigationProp<
 
 interface Props {
   navigation: DashboardScreenNavigationProp;
-}
-
-type SummaryEntry = { id: string; at: number; text: string };
-
-function limLabel(v: number | null): string {
-  if (v === null) return '…';
-  if (v === -1) return '∞';
-  return String(v);
-}
-
-function SectionCard(props: {
-  title: string;
-  demonstrates: string;
-  description: string;
-  codeRef: string;
-  demoMode?: boolean;
-  children: React.ReactNode;
-}): ReactElement {
-  return (
-    <View style={[styles.card, props.demoMode && styles.cardDemo]}>
-      {props.demoMode && (
-        <View style={styles.badge}>
-          <Text style={styles.badgeText}>Demo mode only</Text>
-        </View>
-      )}
-      <Text style={styles.cardTitle}>{props.title}</Text>
-      <Text style={styles.demonstratesLabel}>
-        DEMONSTRATES:{' '}
-        <Text style={styles.demonstratesMono}>{props.demonstrates}</Text>
-      </Text>
-      <Text style={styles.cardDesc}>{props.description}</Text>
-      <View style={styles.cardBody}>{props.children}</View>
-      <Text style={styles.codeLine}>// {props.codeRef}</Text>
-    </View>
-  );
-}
-
-function MeteredBlock(): ReactElement {
-  const { config } = useBillingContext<typeof beakerstackBillingConfig>();
-  const {
-    used,
-    limit,
-    resetsAt,
-    exceeded,
-    loading,
-    error: usageError,
-    refresh,
-  } = useUsage<
-    typeof beakerstackBillingConfig,
-    typeof BEAKERSTACK_METER_AI_SUMMARIZE
-  >(BEAKERSTACK_METER_AI_SUMMARIZE);
-  const [results, setResults] = useState<SummaryEntry[]>([]);
-  const [pending, setPending] = useState(false);
-  const [recordError, setRecordError] = useState<BillingError | null>(null);
-
-  const resolveSummaryText = useCallback(async (): Promise<string> => {
-    if (readDemoUseRealAi()) {
-      try {
-        const { data, error: fnErr } = await supabase.functions.invoke(
-          'demo-ai-summarize',
-          {
-            body: {
-              prompt: 'Write a short lorem-style summary (3-5 lines).',
-            },
-          }
-        );
-        if (!fnErr) {
-          const t = (data as { text?: string } | null)?.text;
-          if (typeof t === 'string' && t.trim()) return t.trim();
-        }
-      } catch {
-        /* optional demo-ai edge unavailable */
-      }
-    }
-    return nextFakeAiSummary();
-  }, []);
-
-  const pushResult = useCallback((text: string) => {
-    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-    setResults(prev => {
-      const next: SummaryEntry[] = [{ id, at: Date.now(), text }, ...prev];
-      return next.slice(0, 3);
-    });
-  }, []);
-
-  const onSimulate = useCallback(async () => {
-    if (exceeded || pending) return;
-    const summaryText = await resolveSummaryText();
-    setPending(true);
-    setRecordError(null);
-    try {
-      const { error: rpcErr } = await supabase.rpc(
-        'billing_record_usage_event',
-        {
-          p_product_id: config.productId,
-          p_event_type: BEAKERSTACK_METER_AI_SUMMARIZE,
-          p_quantity: 1,
-          p_metadata: {},
-        }
-      );
-      if (rpcErr) throw rpcErr;
-      await refresh();
-      pushResult(summaryText);
-    } catch (e) {
-      setRecordError(mapUnknownError(e));
-    } finally {
-      setPending(false);
-    }
-  }, [
-    exceeded,
-    pending,
-    config.productId,
-    refresh,
-    resolveSummaryText,
-    pushResult,
-  ]);
-
-  const lim = limit === null ? '∞' : String(limit);
-  const capLine =
-    limit === null
-      ? `${used} used this period · unlimited`
-      : `${used} of ${lim} used · resets ${
-          resetsAt ? new Date(resetsAt).toLocaleDateString() : '—'
-        }`;
-  const pct =
-    limit != null && limit > 0 ? Math.min(100, (used / limit) * 100) : 0;
-  const displayError = recordError ?? usageError;
-
-  return (
-    <View>
-      <View testID='usage-indicator-expanded'>
-        {limit != null && (
-          <View style={styles.usageBarTrack}>
-            <View style={[styles.usageBarFill, { width: `${pct}%` }]} />
-          </View>
-        )}
-        <Text style={styles.usageCapLine}>{loading ? '…' : capLine}</Text>
-      </View>
-      <View style={styles.row}>
-        {exceeded ? (
-          <Text style={styles.muted}>
-            Limit reached — open Billing for plans.
-          </Text>
-        ) : (
-          <Pressable
-            style={[styles.btnPrimary, pending && styles.btnDisabled]}
-            disabled={pending}
-            onPress={() => void onSimulate()}
-          >
-            <Text style={styles.btnPrimaryText}>
-              {pending ? '…' : 'Simulate AI summarize'}
-            </Text>
-          </Pressable>
-        )}
-      </View>
-      {displayError ? (
-        <Text style={styles.errText}>{displayError.message}</Text>
-      ) : null}
-      <View style={styles.resultBox}>
-        {results.length === 0 ? (
-          <Text style={styles.muted}>
-            Tap &apos;Simulate AI summarize&apos; to generate a result.
-          </Text>
-        ) : (
-          results.map(e => (
-            <View key={e.id} style={styles.resultItem}>
-              <Text style={styles.resultTs}>
-                {new Date(e.at).toLocaleString()}
-              </Text>
-              <Text style={styles.resultBody}>{e.text}</Text>
-            </View>
-          ))
-        )}
-      </View>
-    </View>
-  );
-}
-
-function NumericCapsBlock(): ReactElement {
-  const {
-    collections,
-    loading,
-    error,
-    addCollection,
-    deleteCollection,
-    addItem,
-  } = useDemoCollections();
-  const { value: maxCollectionsRaw, loading: l1 } = useFeature<
-    typeof beakerstackBillingConfig,
-    'containers_per_account_max'
-  >('containers_per_account_max');
-  const { value: maxItemsRaw, loading: l2 } = useFeature<
-    typeof beakerstackBillingConfig,
-    'items_per_container_max'
-  >('items_per_container_max');
-  const maxCollections =
-    typeof maxCollectionsRaw === 'number' ? maxCollectionsRaw : null;
-  const maxItemsPer = typeof maxItemsRaw === 'number' ? maxItemsRaw : null;
-  const count = collections.length;
-  const atCollectionCap =
-    maxCollections !== null && maxCollections !== -1 && count >= maxCollections;
-  const [busy, setBusy] = useState<string | null>(null);
-  const [actionErr, setActionErr] = useState<string | null>(null);
-  const wrap = useCallback(async (key: string, fn: () => Promise<void>) => {
-    setActionErr(null);
-    setBusy(key);
-    try {
-      await fn();
-    } catch (e) {
-      setActionErr(e instanceof Error ? e.message : 'Failed');
-    } finally {
-      setBusy(null);
-    }
-  }, []);
-  const featLoading = l1 || l2;
-
-  return (
-    <View>
-      {error ? (
-        <Text style={styles.warnText}>
-          {error} (needs demo_billing_mode in DB)
-        </Text>
-      ) : null}
-      <View style={styles.rowBetween}>
-        <Text style={styles.bodyText}>
-          Collections:{' '}
-          {loading || featLoading
-            ? '…'
-            : `${count} of ${limLabel(maxCollections)}`}
-        </Text>
-        <Pressable
-          style={[
-            styles.btnPrimary,
-            (atCollectionCap || busy === 'add') && styles.btnDisabled,
-          ]}
-          disabled={atCollectionCap || loading || featLoading || busy === 'add'}
-          onPress={() => void wrap('add', addCollection)}
-        >
-          <Text style={styles.btnPrimaryText}>
-            {busy === 'add'
-              ? '…'
-              : atCollectionCap
-                ? 'Limit reached'
-                : 'Add collection'}
-          </Text>
-        </Pressable>
-      </View>
-      {actionErr ? <Text style={styles.errText}>{actionErr}</Text> : null}
-      {!loading && collections.length === 0 ? (
-        <Text style={styles.muted}>
-          No collections yet. Tap Add collection to start.
-        </Text>
-      ) : (
-        collections.map(row => {
-          const itemCap =
-            maxItemsPer !== null &&
-            maxItemsPer !== -1 &&
-            row.item_count >= maxItemsPer;
-          return (
-            <View key={row.id} style={styles.collectionCard}>
-              <Text style={styles.monoSm}>{row.id.slice(0, 8)}…</Text>
-              <Text style={styles.bodyText}>
-                Items: {row.item_count} of {limLabel(maxItemsPer)}
-              </Text>
-              <View style={styles.row}>
-                <Pressable
-                  style={styles.btnSecondary}
-                  disabled={itemCap || busy === `i-${row.id}`}
-                  onPress={() =>
-                    void wrap(`i-${row.id}`, () => addItem(row.id))
-                  }
-                >
-                  <Text style={styles.btnSecondaryText}>
-                    {itemCap
-                      ? 'Limit'
-                      : busy === `i-${row.id}`
-                        ? '…'
-                        : 'Add item'}
-                  </Text>
-                </Pressable>
-                <Pressable
-                  style={styles.btnDanger}
-                  onPress={() =>
-                    void wrap(`d-${row.id}`, () => deleteCollection(row.id))
-                  }
-                >
-                  <Text style={styles.btnDangerText}>Delete</Text>
-                </Pressable>
-              </View>
-            </View>
-          );
-        })
-      )}
-    </View>
-  );
-}
-
-function BooleanGatesBlock(): ReactElement {
-  const { loading: planLoading } = usePlan<typeof beakerstackBillingConfig>();
-  const a = useFeature<typeof beakerstackBillingConfig, 'feature_a'>(
-    'feature_a'
-  );
-  const b = useFeature<typeof beakerstackBillingConfig, 'feature_b'>(
-    'feature_b'
-  );
-  return (
-    <View>
-      <Text style={styles.subH}>Feature A (requires Pro)</Text>
-      {planLoading ? (
-        <Text style={styles.muted}>…</Text>
-      ) : (
-        <FeatureGate<typeof beakerstackBillingConfig>
-          feature='feature_a'
-          fallback={
-            <Text style={styles.bodyText}>
-              Feature A requires Pro. See Billing for plans.
-            </Text>
-          }
-        >
-          <Text style={styles.okText}>
-            ✓ Feature A is enabled for your plan.
-          </Text>
-        </FeatureGate>
-      )}
-      <Text style={[styles.subH, { marginTop: 12 }]}>
-        Feature B (requires Max)
-      </Text>
-      {planLoading ? (
-        <Text style={styles.muted}>…</Text>
-      ) : (
-        <FeatureGate<typeof beakerstackBillingConfig>
-          feature='feature_b'
-          fallback={
-            <Text style={styles.bodyText}>
-              Feature B requires Max. See Billing for plans.
-            </Text>
-          }
-        >
-          <Text style={styles.okText}>
-            ✓ Feature B is enabled for your plan.
-          </Text>
-        </FeatureGate>
-      )}
-      <Text style={[styles.bodyText, { marginTop: 12 }]}>
-        useFeature(&quot;feature_a&quot;) →{' '}
-        {a.loading ? '…' : String(a.enabled)} · feature_b →{' '}
-        {b.loading ? '…' : String(b.enabled)}
-      </Text>
-    </View>
-  );
 }
 
 const PLANS = [
@@ -445,77 +89,89 @@ function DemoControlsBlock(): ReactElement | null {
   }, []);
 
   return (
-    <SectionCard
-      title='Demo controls'
-      demonstrates='billing_demo_simulate_upgrade, billing_demo_reset_usage'
-      description='App-layer only. Not part of @beakerstack/billing. Remove in production.'
-      codeRef='supabase.rpc("billing_demo_simulate_upgrade", …)'
-      demoMode
-    >
-      <Text style={styles.bodyText}>
-        Current plan: {planLoading ? '…' : (plan?.display_name ?? '—')}
+    <View style={[styles.demoCard, styles.cardDemo]}>
+      <View style={styles.badge}>
+        <Text style={styles.badgeText}>Demo mode only</Text>
+      </View>
+      <Text style={styles.demoTitle}>Demo controls</Text>
+      <Text style={styles.demonstratesLabel}>
+        DEMONSTRATES:{' '}
+        <Text style={styles.demonstratesMono}>
+          billing_demo_simulate_upgrade, billing_demo_reset_usage
+        </Text>
       </Text>
-      <View style={styles.btnRow}>
-        {PLANS.map(p => (
-          <Pressable
-            key={p.id}
-            style={[
-              styles.btnSecondary,
-              (plan?.id === p.id || pending != null) && styles.btnDisabled,
-            ]}
-            disabled={plan?.id === p.id || pending != null}
-            onPress={() =>
-              void run(`p-${p.id}`, async () => {
+      <Text style={styles.demoDesc}>
+        App-layer only. Not part of @beakerstack/billing. Remove in production.
+      </Text>
+      <View style={styles.demoBody}>
+        <Text style={styles.bodyText}>
+          Current plan: {planLoading ? '…' : (plan?.display_name ?? '—')}
+        </Text>
+        <View style={styles.btnRow}>
+          {PLANS.map(p => (
+            <Pressable
+              key={p.id}
+              style={[
+                styles.btnSecondary,
+                (plan?.id === p.id || pending != null) && styles.btnDisabled,
+              ]}
+              disabled={plan?.id === p.id || pending != null}
+              onPress={() =>
+                void run(`p-${p.id}`, async () => {
+                  const { error: e } = await supabase.rpc(
+                    'billing_demo_simulate_upgrade',
+                    {
+                      p_product_id: beakerstackBillingConfig.productId,
+                      p_plan_id: p.id,
+                    }
+                  );
+                  if (e) throw e;
+                  await refreshSubscription();
+                })
+              }
+            >
+              <Text style={styles.btnSecondaryText}>
+                {pending === `p-${p.id}` ? '…' : `To ${p.label}`}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+        <Pressable
+          style={[
+            styles.btnSecondary,
+            { marginTop: 8 },
+            pending != null && styles.btnDisabled,
+          ]}
+          disabled={pending != null}
+          onPress={() =>
+            void run('reset', async () => {
+              for (const m of METERS) {
                 const { error: e } = await supabase.rpc(
-                  'billing_demo_simulate_upgrade',
+                  'billing_demo_reset_usage',
                   {
                     p_product_id: beakerstackBillingConfig.productId,
-                    p_plan_id: p.id,
+                    p_event_type: m,
                   }
                 );
                 if (e) throw e;
-                await refreshSubscription();
-              })
-            }
-          >
-            <Text style={styles.btnSecondaryText}>
-              {pending === `p-${p.id}` ? '…' : `To ${p.label}`}
-            </Text>
-          </Pressable>
-        ))}
-      </View>
-      <Pressable
-        style={[
-          styles.btnSecondary,
-          { marginTop: 8 },
-          pending != null && styles.btnDisabled,
-        ]}
-        disabled={pending != null}
-        onPress={() =>
-          void run('reset', async () => {
-            for (const m of METERS) {
-              const { error: e } = await supabase.rpc(
-                'billing_demo_reset_usage',
-                {
-                  p_product_id: beakerstackBillingConfig.productId,
-                  p_event_type: m,
-                }
-              );
-              if (e) throw e;
-            }
-            await refreshUsage();
-          })
-        }
-      >
-        <Text style={styles.btnSecondaryText}>
-          {pending === 'reset' ? '…' : 'Reset all usage counters'}
+              }
+              await refreshUsage();
+            })
+          }
+        >
+          <Text style={styles.btnSecondaryText}>
+            {pending === 'reset' ? '…' : 'Reset all usage counters'}
+          </Text>
+        </Pressable>
+        {msg ? <Text style={styles.muted}>{msg}</Text> : null}
+        <Text style={styles.tinyLegal}>
+          These actions bypass Stripe. Do not deploy to production.
         </Text>
-      </Pressable>
-      {msg ? <Text style={styles.muted}>{msg}</Text> : null}
-      <Text style={styles.tinyLegal}>
-        These actions bypass Stripe. Do not deploy to production.
+      </View>
+      <Text style={styles.codeLine}>
+        // supabase.rpc(&quot;billing_demo_simulate_upgrade&quot;, …)
       </Text>
-    </SectionCard>
+    </View>
   );
 }
 
@@ -524,51 +180,94 @@ function DashboardBody({
 }: {
   navigation: DashboardScreenNavigationProp;
 }): ReactElement {
+  const [selectedCollectionId, setSelectedCollectionId] = useState<
+    string | null
+  >(null);
+
+  const {
+    collections,
+    loading: collectionsLoading,
+    error: collectionsError,
+    addCollection,
+    deleteCollection,
+    addItem,
+  } = useDemoCollections();
+
+  useEffect(() => {
+    if (collections.length === 0) {
+      setSelectedCollectionId(null);
+      return;
+    }
+    if (selectedCollectionId === null) {
+      setSelectedCollectionId(collections[0].id);
+      return;
+    }
+    if (!collections.find(c => c.id === selectedCollectionId)) {
+      setSelectedCollectionId(collections[0].id);
+    }
+  }, [collections, selectedCollectionId]);
+
+  const selectedCollection = collections.find(
+    c => c.id === selectedCollectionId
+  );
+
+  const onNavigateBilling = useCallback(() => {
+    navigation.navigate('Billing');
+  }, [navigation]);
+
   return (
     <ScrollView
       style={styles.scrollView}
-      contentContainerStyle={styles.content}
+      contentContainerStyle={styles.scrollContent}
+      keyboardShouldPersistTaps='handled'
     >
-      <Text style={styles.h1}>Welcome to BeakerStack</Text>
-      <Text style={styles.lede}>
-        This dashboard is a sandbox for @beakerstack/billing. For polished
-        billing UI, use the web app.
-      </Text>
-      <Pressable
-        onPress={() => navigation.navigate('Billing')}
-        style={styles.navLink}
+      <AnnotatedPrimitive
+        tag='useUsage("ai_summarize")'
+        variant='usage'
+        tooltip='Meter reads from useUsage; the Simulate button records usage via billing_record_usage_event.'
       >
-        <Text style={styles.navLinkText}>View polished billing →</Text>
-      </Pressable>
+        <UsageStrip onNavigateBilling={onNavigateBilling} />
+      </AnnotatedPrimitive>
 
-      <View style={styles.spacer} />
-
-      <SectionCard
-        title='Metered usage'
-        demonstrates='useUsage, billing_record_usage_event, refresh()'
-        description='AI summarize is metered. Free 30/mo, Pro 500, Max unlimited.'
-        codeRef='await refresh() after RPC'
+      <AnnotatedPrimitive
+        tag='FeatureGate + useFeature("feature_a")'
+        variant='gate'
+        tooltip='When useFeature("feature_a").enabled is false, FeatureGate renders the fallback; when true, children render.'
       >
-        <MeteredBlock />
-      </SectionCard>
+        <FeatureGateCard onNavigateBilling={onNavigateBilling} />
+      </AnnotatedPrimitive>
 
-      <SectionCard
-        title='Numeric feature caps'
-        demonstrates='useFeature (numeric), container caps'
-        description='Free: 2 collections × 3 items. Pro: unlimited × 25. Max: unlimited both.'
-        codeRef='useFeature("containers_per_account_max")'
+      <AnnotatedPrimitive
+        tag='useFeature("containers_per_account_max")'
+        variant='feature'
+        tooltip='Numeric cap from useFeature; New collection enforces containers_per_account_max.'
       >
-        <NumericCapsBlock />
-      </SectionCard>
+        <CollectionsGrid
+          collections={collections}
+          loading={collectionsLoading}
+          error={collectionsError}
+          selectedId={selectedCollectionId}
+          onSelect={setSelectedCollectionId}
+          addCollection={addCollection}
+          deleteCollection={deleteCollection}
+        />
+      </AnnotatedPrimitive>
 
-      <SectionCard
-        title='Boolean feature gates'
-        demonstrates='FeatureGate, useFeature (boolean)'
-        description='Feature A at Pro+, Feature B at Max only.'
-        codeRef='FeatureGate feature="feature_a"'
+      <AnnotatedPrimitive
+        tag='useFeature("items_per_container_max")'
+        variant='feature'
+        tooltip='Per-collection item cap from useFeature; add-item enforces items_per_container_max.'
       >
-        <BooleanGatesBlock />
-      </SectionCard>
+        <CollectionDetail collection={selectedCollection} addItem={addItem} />
+      </AnnotatedPrimitive>
+
+      <AnnotatedPrimitive
+        tag='useFeature("feature_a") · useFeature("feature_b")'
+        variant='feature'
+        tooltip='Boolean features reflect plan config; enabled/disabled state changes with the active plan.'
+      >
+        <BooleanFeatureTiles />
+      </AnnotatedPrimitive>
 
       <DemoControlsBlock />
     </ScrollView>
@@ -614,23 +313,32 @@ export default function DashboardScreen({ navigation }: Props) {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#f9fafb' },
   scrollView: { flex: 1 },
-  content: { padding: 20, paddingBottom: 40 },
-  h1: { fontSize: 22, fontWeight: '700', color: '#111827' },
-  lede: { marginTop: 8, fontSize: 14, color: '#4b5563', lineHeight: 20 },
-  navLink: { marginTop: 12, alignSelf: 'flex-start' },
-  navLinkText: { color: '#4f46e5', fontWeight: '600' },
-  spacer: { height: 20 },
-  card: {
+  scrollContent: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 24,
+    maxWidth: 1024,
+    width: '100%',
+    alignSelf: 'center',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F9FAFB',
+  },
+  loadingText: { marginTop: 16, fontSize: 16, color: '#6B7280' },
+  demoCard: {
     backgroundColor: '#fff',
     borderRadius: 12,
     borderWidth: 1,
     borderColor: '#e5e7eb',
     padding: 16,
-    marginBottom: 20,
+    marginBottom: 8,
   },
-  cardDemo: { borderStyle: 'dashed' as const, borderColor: '#d1d5db' },
+  cardDemo: { borderStyle: 'dashed', borderColor: '#d1d5db' },
   badge: {
-    position: 'absolute' as const,
+    position: 'absolute',
     right: 12,
     top: 10,
     backgroundColor: '#fef3c7',
@@ -639,7 +347,7 @@ const styles = StyleSheet.create({
     borderRadius: 4,
   },
   badgeText: { fontSize: 10, fontWeight: '600', color: '#92400e' },
-  cardTitle: {
+  demoTitle: {
     fontSize: 18,
     fontWeight: '600',
     color: '#111827',
@@ -650,57 +358,14 @@ const styles = StyleSheet.create({
     fontSize: 10,
     fontWeight: '600',
     color: '#6b7280',
-    textTransform: 'uppercase' as const,
+    textTransform: 'uppercase',
     letterSpacing: 0.5,
   },
   demonstratesMono: { fontFamily: 'monospace', fontSize: 12, color: '#374151' },
-  cardDesc: { marginTop: 6, fontSize: 14, color: '#4b5563' },
-  cardBody: { marginTop: 12 },
-  codeLine: {
-    marginTop: 12,
-    fontSize: 11,
-    fontFamily: 'monospace',
-    color: '#6b7280',
-  },
-  usageBarTrack: {
-    height: 8,
-    backgroundColor: '#e5e7eb',
-    borderRadius: 4,
-    overflow: 'hidden',
-  },
-  usageBarFill: {
-    height: 8,
-    backgroundColor: '#4f46e5',
-    borderRadius: 4,
-  },
-  usageCapLine: {
-    marginTop: 8,
-    fontSize: 13,
-    color: '#4b5563',
-  },
-  row: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    alignItems: 'center',
-    gap: 8,
-    marginTop: 8,
-  },
-  rowBetween: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: 8,
-    marginTop: 4,
-  },
-  btnPrimary: {
-    backgroundColor: '#4f46e5',
-    paddingHorizontal: 16,
-    paddingVertical: 10,
-    borderRadius: 8,
-  },
-  btnPrimaryText: { color: '#fff', fontWeight: '600' },
-  btnDisabled: { opacity: 0.5 },
+  demoDesc: { marginTop: 6, fontSize: 14, color: '#4b5563' },
+  demoBody: { marginTop: 12 },
+  bodyText: { fontSize: 14, color: '#374151' },
+  btnRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 8 },
   btnSecondary: {
     borderWidth: 1,
     borderColor: '#d1d5db',
@@ -710,45 +375,13 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
   },
   btnSecondaryText: { color: '#374151', fontSize: 12, fontWeight: '500' },
-  btnDanger: { marginLeft: 8, padding: 6 },
-  btnDangerText: { color: '#b91c1c', fontSize: 12, fontWeight: '600' },
-  btnRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 8 },
+  btnDisabled: { opacity: 0.5 },
   muted: { color: '#6b7280', fontSize: 13, marginTop: 4 },
-  errText: { color: '#b91c1c', fontSize: 13, marginTop: 4 },
-  warnText: { color: '#b45309', fontSize: 12, marginBottom: 6 },
-  bodyText: { fontSize: 14, color: '#374151' },
-  subH: { fontSize: 14, fontWeight: '600', color: '#111827' },
-  okText: { fontSize: 14, color: '#15803d' },
-  resultBox: {
-    marginTop: 12,
-    borderWidth: 1,
-    borderColor: '#e5e7eb',
-    backgroundColor: '#f9fafb',
-    borderRadius: 8,
-    padding: 10,
-  },
-  resultItem: {
-    marginBottom: 10,
-    borderBottomWidth: 1,
-    borderBottomColor: '#e5e7eb',
-  },
-  resultTs: { fontSize: 11, color: '#6b7280' },
-  resultBody: { fontSize: 13, color: '#1f2937', marginTop: 2 },
-  collectionCard: {
-    marginTop: 10,
-    padding: 10,
-    backgroundColor: '#f9fafb',
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: '#e5e7eb',
-  },
-  monoSm: { fontFamily: 'monospace', fontSize: 11, color: '#6b7280' },
   tinyLegal: { fontSize: 10, color: '#6b7280', marginTop: 8 },
-  loadingContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F9FAFB',
+  codeLine: {
+    marginTop: 12,
+    fontSize: 11,
+    fontFamily: 'monospace',
+    color: '#6b7280',
   },
-  loadingText: { marginTop: 16, fontSize: 16, color: '#6B7280' },
 });

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -63,7 +63,7 @@ const PLANS = [
 const METERS = [BEAKERSTACK_METER_AI_SUMMARIZE] as const;
 
 function DemoControlsBlock(): ReactElement | null {
-  if (!readBillingDashboardDemoMode()) return null;
+  const demoMode = readBillingDashboardDemoMode();
   const { data: plan, loading: planLoading } =
     usePlan<typeof beakerstackBillingConfig>();
   const { refreshSubscription } =
@@ -87,6 +87,8 @@ function DemoControlsBlock(): ReactElement | null {
       setPending(null);
     }
   }, []);
+
+  if (!demoMode) return null;
 
   return (
     <View style={[styles.demoCard, styles.cardDemo]}>

--- a/packages/billing/src/errors.test.ts
+++ b/packages/billing/src/errors.test.ts
@@ -60,6 +60,18 @@ describe('mapUnknownError', () => {
     expect(e.message).toContain('function does not exist');
   });
 
+  it('maps undefined without throwing (JSON.stringify(undefined) is not a string)', () => {
+    const e = mapUnknownError(undefined);
+    expect(e.kind).toBe('unknown');
+    expect(typeof e.message).toBe('string');
+    expect(() => e.message.toLowerCase()).not.toThrow();
+  });
+
+  it('maps symbols and functions to a string message', () => {
+    expect(typeof mapUnknownError(Symbol('x')).message).toBe('string');
+    expect(typeof mapUnknownError(() => {}).message).toBe('string');
+  });
+
   it('passes through BillingError', () => {
     const inner = billingError('stripe', 'bad');
     const e = mapUnknownError(inner);

--- a/packages/billing/src/errors.test.ts
+++ b/packages/billing/src/errors.test.ts
@@ -40,6 +40,26 @@ describe('mapUnknownError', () => {
     expect(e.message).toBe('timeout');
   });
 
+  it('extracts message from PostgREST-style error objects', () => {
+    const e = mapUnknownError({
+      code: 'P0001',
+      message: 'Usage limit exceeded for this meter',
+      details: null,
+      hint: null,
+    });
+    expect(e.kind).toBe('unknown');
+    expect(e.message).toBe('Usage limit exceeded for this meter');
+  });
+
+  it('falls back to code and details when message is missing', () => {
+    const e = mapUnknownError({
+      code: '42883',
+      details: 'function does not exist',
+    });
+    expect(e.message).toContain('42883');
+    expect(e.message).toContain('function does not exist');
+  });
+
   it('passes through BillingError', () => {
     const inner = billingError('stripe', 'bad');
     const e = mapUnknownError(inner);

--- a/packages/billing/src/errors.ts
+++ b/packages/billing/src/errors.ts
@@ -43,8 +43,15 @@ function messageFromUnknown(err: unknown): string {
     }
   }
   if (typeof err === 'string') return err;
+  if (typeof err === 'bigint') return err.toString();
   try {
-    return JSON.stringify(err);
+    const j = JSON.stringify(err);
+    if (typeof j === 'string') return j;
+  } catch {
+    /* e.g. cyclic structure, or stringify rejects the value */
+  }
+  try {
+    return String(err);
   } catch {
     return 'Unknown error';
   }

--- a/packages/billing/src/errors.ts
+++ b/packages/billing/src/errors.ts
@@ -20,6 +20,36 @@ export function billingError(
   return { kind, message, cause };
 }
 
+function messageFromUnknown(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err && typeof err === 'object') {
+    const o = err as Record<string, unknown>;
+    if (typeof o['message'] === 'string' && o['message'].trim())
+      return o['message'];
+    if (
+      typeof o['error_description'] === 'string' &&
+      o['error_description'].trim()
+    ) {
+      return o['error_description'];
+    }
+    if (typeof o['msg'] === 'string' && o['msg'].trim()) return o['msg'];
+    if (typeof o['code'] === 'string') {
+      const parts = [o['code']];
+      if (typeof o['details'] === 'string' && o['details'].trim())
+        parts.push(o['details']);
+      if (typeof o['hint'] === 'string' && o['hint'].trim())
+        parts.push(o['hint']);
+      return parts.join(' · ');
+    }
+  }
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return 'Unknown error';
+  }
+}
+
 export function mapUnknownError(err: unknown): BillingError {
   if (
     err &&
@@ -29,7 +59,7 @@ export function mapUnknownError(err: unknown): BillingError {
   ) {
     return err as BillingError;
   }
-  const msg = err instanceof Error ? err.message : String(err);
+  const msg = messageFromUnknown(err);
   const lower = msg.toLowerCase();
   if (
     lower.includes('jwt') ||


### PR DESCRIPTION
## Summary
- Restructures the mobile dashboard into the same billing demo flow as the web app: annotated sections for metered usage (`UsageStrip`), Feature A gate, collections grid with selection, collection detail (items + summarize + idempotency), and boolean feature tiles, plus env-gated demo plan controls.
- Adds `randomUuid()` for React Native environments where `crypto.randomUUID` is missing so usage RPCs and idempotency keys work on device.
- Improves `@beakerstack/billing` `mapUnknownError` to read PostgREST-style `{ message, code, details }` objects instead of showing `[object Object]`.
- Includes the prior **fix mobile build** work on this branch (Expo/App wiring, mobile billing URLs, `BillingProvider` / native pricing tweaks, and related tests) so the branch merges cleanly with current mobile billing behavior.

## Test plan
- [ ] `cd apps/mobile && npm test` (at least `DashboardScreen` tests)
- [ ] `cd packages/billing && npx vitest run src/errors.test.ts`
- [ ] Smoke: sign in on iOS/Android sim, open Dashboard, simulate AI summarize against local Supabase with migrations applied (`supabase migration up` or `db reset`)
- [ ] Confirm Billing screen still opens plan/checkout URLs as expected after mobile billing URL changes