### PR TITLE
feat(web): render AnnotatedPrimitive tooltip as visible inline text

### DIFF
--- a/apps/web/src/components/dashboard/AnnotatedPrimitive.tsx
+++ b/apps/web/src/components/dashboard/AnnotatedPrimitive.tsx
@@ -25,8 +25,7 @@ export function AnnotatedPrimitive({
     <div className='relative rounded-xl border-2 border-dashed border-purple-300 dark:border-purple-700 hover:border-purple-400 dark:hover:border-purple-600 transition-colors p-5 pt-8'>
       <div
         className='absolute -top-3 left-4 flex items-center gap-1.5 rounded bg-slate-900 px-2.5 py-1 shadow-sm'
-        title={tooltip}
-        aria-label={tooltip ? `${tag} — ${tooltip}` : tag}
+        aria-label={tag}
       >
         <span
           className={`h-2 w-2 rounded-full shrink-0 ${dotColor[variant]}`}
@@ -36,6 +35,11 @@ export function AnnotatedPrimitive({
           {tag}
         </code>
       </div>
+      {tooltip && (
+        <p className='mt-1 mb-2 text-[11px] leading-4 text-slate-500 dark:text-slate-400'>
+          {tooltip}
+        </p>
+      )}
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary

Closes #219.

**Before:** The `tooltip` prop was only surfaced via a native HTML `title` attribute on the tag chip — invisible until hover, unreachable on touch/keyboard, and easy to miss on desktop demos.

**After:** Renders the tooltip as a visible `<p>` below the tag chip whenever the prop is present, matching the mobile `AnnotatedPrimitive` exactly.

## Change

Single file: `apps/web/src/components/dashboard/AnnotatedPrimitive.tsx`

- Add `{tooltip && <p className="mt-1 mb-2 text-[11px] leading-4 text-slate-500 dark:text-slate-400">{tooltip}</p>}` below the chip
- Remove `title={tooltip}` from the chip div (redundant now that text is in the DOM)
- Simplify `aria-label` on chip div to just `tag` (tooltip text is now a real DOM node)

Tailwind tokens used match mobile's `StyleSheet` values: 11px font, `#64748b` (slate-500) foreground, 16px line height.

## Test plan

- [ ] Web dashboard: each AnnotatedPrimitive section shows helper text below the tag chip without hovering
- [ ] Dark mode: tooltip text renders in slate-400
- [ ] No regression to dashed border, dot colors, or tag chip styling
- [ ] CI green
