### PR TITLE
fix(web): standardize public header — delegate PolicyPublicHeader to Nav (issue #215)

### DIFF
--- a/apps/web/src/components/PolicyPublicHeader.tsx
+++ b/apps/web/src/components/PolicyPublicHeader.tsx
@@ -1,23 +1,24 @@
 import { Nav } from './landing/sections/Nav';
 import { landingConfig } from '../config/landing';
+import { getPrPreviewAssetBasePath } from '../lib/prPreviewAssetBasePath';
 
 /**
  * Marketing header for public/policy pages. Delegates to {@link Nav} so sticky
  * scroll behavior, mobile menu, nav links (Features / Pricing / FAQ), and auth
  * CTAs are identical to the home page.
  *
- * Hash anchors are prefixed with '/' so they navigate home-then-scroll when
- * followed from a policy URL (e.g. /terms → /#features).
+ * Hash anchors are prefixed with the app base path so they work on PR preview
+ * deployments (e.g. /pr-123/#features) as well as production (/#features).
  */
-const publicNavConfig = {
-  ...landingConfig.nav,
-  links: landingConfig.nav.links.map(l => ({
-    ...l,
-    href: l.href.startsWith('#') ? `/${l.href}` : l.href,
-  })),
-  brand: landingConfig.brand,
-};
-
 export function PolicyPublicHeader() {
+  const basePath = getPrPreviewAssetBasePath();
+  const publicNavConfig = {
+    ...landingConfig.nav,
+    links: landingConfig.nav.links.map(l => ({
+      ...l,
+      href: l.href.startsWith('#') ? `${basePath}${l.href}` : l.href,
+    })),
+    brand: landingConfig.brand,
+  };
   return <Nav config={publicNavConfig} />;
 }

--- a/apps/web/src/components/PolicyPublicHeader.tsx
+++ b/apps/web/src/components/PolicyPublicHeader.tsx
@@ -1,63 +1,23 @@
-import { Link } from 'react-router-dom';
-import { BRANDING } from '@beakerstack/shared/config/branding';
-import { useMarketingAuthHint } from '../hooks/useMarketingAuthHint';
-import { getPrPreviewAssetBasePath } from '../lib/prPreviewAssetBasePath';
+import { Nav } from './landing/sections/Nav';
+import { landingConfig } from '../config/landing';
 
 /**
- * Policy/legal routes render outside {@link AuthenticatedApp}; this header mirrors
- * {@link AppHeader} chrome without AuthProvider, using the same localStorage hint as landing Nav.
+ * Marketing header for public/policy pages. Delegates to {@link Nav} so sticky
+ * scroll behavior, mobile menu, nav links (Features / Pricing / FAQ), and auth
+ * CTAs are identical to the home page.
+ *
+ * Hash anchors are prefixed with '/' so they navigate home-then-scroll when
+ * followed from a policy URL (e.g. /terms → /#features).
  */
+const publicNavConfig = {
+  ...landingConfig.nav,
+  links: landingConfig.nav.links.map(l => ({
+    ...l,
+    href: l.href.startsWith('#') ? `/${l.href}` : l.href,
+  })),
+  brand: landingConfig.brand,
+};
+
 export function PolicyPublicHeader() {
-  const marketingAuthHint = useMarketingAuthHint();
-  const basePath = getPrPreviewAssetBasePath();
-
-  return (
-    <div className='bg-white dark:bg-gray-900 shadow dark:shadow-gray-800 border-b border-transparent dark:border-gray-700'>
-      <div className='max-w-[1024px] mx-auto px-4 sm:px-6 lg:px-8'>
-        <div className='flex justify-between items-center h-16'>
-          <div className='flex items-center space-x-3'>
-            <Link to='/' className='flex items-center'>
-              <img
-                src={`${basePath}demo-flask-icon.svg`}
-                alt={BRANDING.displayName}
-                className='w-8 h-8'
-              />
-            </Link>
-            <Link
-              to='/'
-              className='text-xl font-semibold text-gray-900 dark:text-white hover:text-gray-700 dark:hover:text-gray-300'
-            >
-              {BRANDING.displayName}
-            </Link>
-          </div>
-
-          <div className='flex items-center space-x-4'>
-            {marketingAuthHint ? (
-              <Link
-                to='/dashboard'
-                className='bg-primary-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-primary-700'
-              >
-                Go to dashboard
-              </Link>
-            ) : (
-              <>
-                <Link
-                  to='/login'
-                  className='text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 px-3 py-2 rounded-md text-sm font-medium'
-                >
-                  Sign In
-                </Link>
-                <Link
-                  to='/signup'
-                  className='bg-primary-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-primary-700'
-                >
-                  Sign Up
-                </Link>
-              </>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+  return <Nav config={publicNavConfig} />;
 }

--- a/apps/web/src/components/__tests__/PolicyPublicHeader.test.tsx
+++ b/apps/web/src/components/__tests__/PolicyPublicHeader.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, act } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { PolicyPublicHeader } from '../PolicyPublicHeader';
 

--- a/apps/web/src/components/__tests__/PolicyPublicHeader.test.tsx
+++ b/apps/web/src/components/__tests__/PolicyPublicHeader.test.tsx
@@ -1,9 +1,17 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, act } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { PolicyPublicHeader } from '../PolicyPublicHeader';
 
 vi.stubEnv('VITE_SUPABASE_URL', 'http://localhost:54321');
+
+function renderHeader() {
+  return render(
+    <MemoryRouter>
+      <PolicyPublicHeader />
+    </MemoryRouter>
+  );
+}
 
 describe('PolicyPublicHeader', () => {
   beforeEach(() => {
@@ -11,20 +19,15 @@ describe('PolicyPublicHeader', () => {
     vi.clearAllMocks();
   });
 
-  it('shows Sign In and Sign Up when no session hint', () => {
-    render(
-      <MemoryRouter>
-        <PolicyPublicHeader />
-      </MemoryRouter>
-    );
-    expect(screen.getByRole('link', { name: 'Sign In' })).toHaveAttribute(
+  it('shows Sign in and Get started when no session hint', () => {
+    renderHeader();
+    expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute(
       'href',
       '/login'
     );
-    expect(screen.getByRole('link', { name: 'Sign Up' })).toHaveAttribute(
-      'href',
-      '/signup'
-    );
+    expect(
+      screen.getByRole('link', { name: 'Get started' })
+    ).toHaveAttribute('href', '/signup');
   });
 
   it('shows Go to dashboard when session hint is present', () => {
@@ -32,16 +35,50 @@ describe('PolicyPublicHeader', () => {
       'sb-localhost-auth-token',
       JSON.stringify({ access_token: 'jwt', refresh_token: 'r' })
     );
-    render(
-      <MemoryRouter>
-        <PolicyPublicHeader />
-      </MemoryRouter>
-    );
+    renderHeader();
     expect(
       screen.getByRole('link', { name: 'Go to dashboard' })
     ).toHaveAttribute('href', '/dashboard');
     expect(
-      screen.queryByRole('link', { name: 'Sign In' })
+      screen.queryByRole('link', { name: 'Sign in' })
     ).not.toBeInTheDocument();
+  });
+
+  it('renders Features, Pricing, and FAQ nav links with absolute anchors', () => {
+    renderHeader();
+    const mainNav = screen.getByRole('navigation', { name: 'Main' });
+    const links = mainNav.querySelectorAll('a');
+    const hrefs = Array.from(links).map(a => a.getAttribute('href'));
+    expect(hrefs).toContain('/#features');
+    expect(hrefs).toContain('/#pricing');
+    expect(hrefs).toContain('/#faq');
+  });
+
+  it('header is sticky and gains shadow class after scrolling past threshold', () => {
+    renderHeader();
+    const header = screen.getByRole('banner');
+    expect(header.className).toContain('sticky');
+    expect(header.className).not.toContain('shadow-sm');
+
+    act(() => {
+      Object.defineProperty(window, 'scrollY', {
+        value: 50,
+        writable: true,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(header.className).toContain('shadow-sm');
+  });
+
+  it('opens mobile menu showing nav links and Sign in', () => {
+    renderHeader();
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle menu' }));
+    const mobileNav = screen.getByRole('navigation', { name: 'Mobile' });
+    expect(mobileNav).toHaveTextContent('Features');
+    expect(mobileNav).toHaveTextContent('Pricing');
+    expect(mobileNav).toHaveTextContent('FAQ');
+    expect(mobileNav).toHaveTextContent('Sign in');
   });
 });

--- a/apps/web/src/pages/__tests__/PolicyPage.test.tsx
+++ b/apps/web/src/pages/__tests__/PolicyPage.test.tsx
@@ -50,9 +50,9 @@ describe('PolicyPage', () => {
     expect(screen.getByText('Refunds content.')).toBeInTheDocument();
   });
 
-  it('renders public policy header with Sign In link', () => {
+  it('renders public marketing header with Sign in link', () => {
     renderPolicy('terms');
-    expect(screen.getByRole('link', { name: 'Sign In' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute(
       'href',
       '/login'
     );


### PR DESCRIPTION
## Summary

- Rewrites `PolicyPublicHeader` as a thin wrapper around the landing `Nav` component
- Policy pages (`/terms`, `/privacy`, `/refunds`) now render the identical sticky-on-scroll header as the home page, including the mobile hamburger menu and Features / Pricing / FAQ nav links
- Hash anchors are prefixed with `/` (`/#features` etc.) so clicking them from a policy page navigates home-then-scrolls to the right section
- No changes to `Nav.tsx`, `PolicyPage.tsx`, or `landingConfig`

## What changed

| File | Change |
|---|---|
| `PolicyPublicHeader.tsx` | Replaced hand-rolled header with `<Nav config={publicNavConfig} />` |
| `PolicyPublicHeader.test.tsx` | Updated auth CTA labels to match Nav (`Sign In`→`Sign in`, `Sign Up`→`Get started`); added tests for nav links and sticky scroll |
| `PolicyPage.test.tsx` | Same auth CTA label fix |

## Test plan
- [ ] `/terms`, `/privacy`, `/refunds` — header is sticky, scrolling adds shadow border
- [ ] Features / Pricing / FAQ links appear and navigate to `/#features` etc.
- [ ] Auth CTAs match home page (Sign in / Get started, or Go to dashboard when logged in)
- [ ] Mobile menu opens and shows all nav links
- [ ] `vitest --run` passes

Closes #215