### PR TITLE
fix(ci): de-scope test-utils from npm; fix template release notes

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,7 +14,8 @@
     "web",
     "mobile-app",
     "@beakerstack/shared",
-    "@beakerstack/shared-tests"
+    "@beakerstack/shared-tests",
+    "@beakerstack/test-utils"
   ],
   "privatePackages": {
     "version": false,

--- a/.changeset/fiery-terms-wash.md
+++ b/.changeset/fiery-terms-wash.md
@@ -1,5 +1,0 @@
----
-'@beakerstack/test-utils': patch
----
-
-Initial release of test-utils package. Provides wait() and testId() helpers for use in BeakerStack-based test suites.

--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -40,16 +40,32 @@ jobs:
             echo "tag=${YEAR}.${PADDED_N}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Generate release notes
-        uses: orhun/git-cliff-action@v3
-        with:
-          config: cliff.toml
-          args: >-
-            --tag-pattern '^[0-9]{4}\.'
-            --tag ${{ steps.tag.outputs.tag }}
-            --latest
+      # orhun/git-cliff-action@v3 builds a Docker image on Debian buster; apt repos are EOL (404).
+      - name: Install git-cliff
         env:
-          OUTPUT: RELEASE_NOTES.md
+          GIT_CLIFF_VERSION: 2.13.1
+        run: |
+          arch=$(uname -m)
+          case "$arch" in
+            x86_64) arch_suffix=x86_64 ;;
+            aarch64) arch_suffix=aarch64 ;;
+            *) echo "unsupported arch: $arch"; exit 1 ;;
+          esac
+          curl -fsSL \
+            "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-${arch_suffix}-unknown-linux-gnu.tar.gz" \
+            | tar xz -C /tmp
+          sudo mv "/tmp/git-cliff-${GIT_CLIFF_VERSION}/git-cliff" /usr/local/bin/git-cliff
+          git-cliff --version
+
+      - name: Generate release notes
+        run: |
+          git-cliff \
+            --config cliff.toml \
+            --tag-pattern '^[0-9]{4}\.' \
+            --tag "${{ steps.tag.outputs.tag }}" \
+            --latest \
+            --output RELEASE_NOTES.md
+        env:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Create annotated tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build test-utils package
-        run: npm run build --workspace=@beakerstack/test-utils
-
-      - name: Test test-utils package
-        run: npm run test --workspace=@beakerstack/test-utils
-
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ When extracting reusable code into a new `@beakerstack/*` package:
 4. Add a changeset for the initial release.
 5. Follow the standard branch flow. The release workflow handles the first publish.
 
-See `packages/test-utils/` for a minimal working example.
+See `packages/test-utils/` for package layout (workspace-only scaffold; not published to npm).
 
 ## Documentation
 

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -1,14 +1,8 @@
 # @beakerstack/test-utils
 
-Testing utilities for [BeakerStack](https://github.com/Artificer-Innovations/BeakerStack)-based projects.
+Internal workspace scaffold for a publishable `@beakerstack/*` package layout. Not published to npm; use the workspace import from the monorepo root.
 
-## Installation
-
-```bash
-npm install --save-dev @beakerstack/test-utils
-```
-
-## Usage
+## Usage (monorepo)
 
 ```typescript
 import { wait, testId } from '@beakerstack/test-utils';

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@beakerstack/test-utils",
-  "version": "0.0.0",
+  "version": "0.0.1",
+  "private": true,
   "description": "Testing utilities for BeakerStack-based projects",
   "keywords": [
     "beakerstack",
@@ -37,9 +38,6 @@
     "README.md",
     "LICENSE"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts --clean",
     "clean": "rm -rf dist",


### PR DESCRIPTION
Make @beakerstack/test-utils workspace-only (private, changeset ignored). Replace git-cliff-action@v3 Docker build with git-cliff binary install.

## Description

<!-- Describe your changes here -->

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactoring
- [ ] Other (please describe)

## Merge Strategy Reminder

⚠️ **Important**: Please use the correct merge strategy when merging this PR:

- **If this PR targets `develop`**: Use **"Squash and merge"** ✅
- **If this PR targets `main`**: Use **"Create a merge commit"** ✅ (NOT squash merge)

Squash merging to `main` can cause conflicts when merging `develop` → `main` later.

## Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if needed)
- [ ] No new warnings generated
- [ ] Tests added/updated (if needed)
- [ ] All tests pass locally

## Testing

<!-- Describe how you tested your changes -->

## Related Issues

<!-- Link to related issues, if any -->
