### PR TITLE
fix(ci): fix git-cliff template remote PR links for template release

### DIFF
--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -77,6 +77,7 @@ jobs:
             --output RELEASE_NOTES.md
         env:
           GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create annotated tag
         run: |

--- a/cliff.toml
+++ b/cliff.toml
@@ -10,7 +10,7 @@ body = """
 {{ group }}
 {% for commit in commits %}
 - {{ commit.message | upper_first }}\
-{% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}]({{ commit.remote.link }})){% endif %}
+{% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}](https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/pull/{{ commit.remote.pr_number }})){% endif %}
 
 {% endfor %}
 {% endfor %}\n
@@ -33,3 +33,7 @@ commit_parsers = [
 filter_commits = true
 # Scope tag matching to CalVer template tags only — prevents anchoring to @beakerstack/* package tags
 tag_pattern = "^[0-9]{4}\\."
+
+[remote.github]
+owner = "Artificer-Innovations"
+repo = "BeakerStack"


### PR DESCRIPTION
commit.remote.link is not a git-cliff field; build PR URLs from remote.github. Enable GitHub remote config and pass GITHUB_TOKEN in Release Template workflow.

