### PR TITLE
fix(mobile): replace back link with AppHeader in BillingLayout

### DIFF
--- a/apps/mobile/__tests__/screens/billing/BillingScreens.test.tsx
+++ b/apps/mobile/__tests__/screens/billing/BillingScreens.test.tsx
@@ -118,6 +118,14 @@ jest.mock('@beakerstack/billing/native', () => {
   };
 });
 
+jest.mock('@beakerstack/shared/components/navigation/AppHeader.native', () => ({
+  AppHeader: () => null,
+}));
+
+jest.mock('../../../src/lib/supabase', () => ({
+  supabase: {},
+}));
+
 function renderWithNav(ui: React.ReactElement) {
   return render(<NavigationContainer>{ui}</NavigationContainer>);
 }

--- a/apps/mobile/src/screens/billing/BillingLayout.tsx
+++ b/apps/mobile/src/screens/billing/BillingLayout.tsx
@@ -1,7 +1,7 @@
 import React, { type ReactNode } from 'react';
-import { Pressable, ScrollView, Text } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
+import { SafeAreaView, ScrollView } from 'react-native';
+import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.native';
+import { supabase } from '../../lib/supabase';
 import { BillingTabBar } from './BillingTabBar';
 import { billingStyles } from './styles';
 
@@ -10,25 +10,10 @@ export function BillingLayout({
 }: {
   children: ReactNode;
 }): React.ReactElement {
-  const navigation = useNavigation();
   return (
-    <SafeAreaView style={billingStyles.safe} edges={['top', 'bottom']}>
+    <SafeAreaView style={billingStyles.safe}>
+      <AppHeader supabaseClient={supabase} />
       <ScrollView contentContainerStyle={billingStyles.scrollContent}>
-        <Pressable
-          accessibilityRole='button'
-          accessibilityLabel='Go back'
-          onPress={() => {
-            const parent = navigation.getParent();
-            if (parent?.canGoBack()) {
-              parent.goBack();
-            } else {
-              navigation.goBack();
-            }
-          }}
-        >
-          <Text style={billingStyles.backLink}>← Back</Text>
-        </Pressable>
-        <Text style={billingStyles.h1}>Billing</Text>
         <BillingTabBar />
         {children}
       </ScrollView>

--- a/apps/mobile/src/screens/billing/styles.ts
+++ b/apps/mobile/src/screens/billing/styles.ts
@@ -22,13 +22,6 @@ export const billingColors = {
 export const billingStyles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: billingColors.pageBg },
   scrollContent: { padding: 16, paddingBottom: 40 },
-  h1: {
-    fontSize: 22,
-    fontWeight: '700',
-    color: billingColors.textPrimary,
-    marginBottom: 4,
-  },
-  backLink: { color: billingColors.indigo, fontSize: 15, marginBottom: 8 },
   card: {
     backgroundColor: billingColors.cardBg,
     borderRadius: 12,


### PR DESCRIPTION
Fixes #234.

Billing screens were showing a custom `← Back` Pressable and a plain `Billing` heading instead of the standard `AppHeader`. This made billing feel like a pushed sub-flow rather than a top-level authenticated screen, inconsistent with Dashboard and Profile.

## Changes

- `BillingLayout.tsx` — remove `Pressable` back link and `Text` h1 heading; add `<AppHeader supabaseClient={supabase} />` above the `ScrollView`, matching the Dashboard/Profile pattern exactly. Switch `SafeAreaView` to the `react-native` import (same as Dashboard/Profile; `react-native-safe-area-context` with `edges` is no longer needed when `AppHeader` handles the top inset). Remove now-unused `useNavigation` import.
- `styles.ts` — remove unused `h1` and `backLink` style rules.
- `BillingScreens.test.tsx` — add `AppHeader.native` and `supabase` mocks so the test renders cleanly with the updated layout.