### PR TITLE
fix: clean up GitHub deployments and environment on PR teardown

### DIFF
--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -742,3 +742,89 @@ jobs:
             --region "${AWS_REGION_VALUE}" \
             --supabase-db-url "${SUPABASE_PREVIEW_DB_URL}"
 
+      - name: Clean up GitHub Deployment and environment
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          script: |
+            // Fork PRs cannot write to Deployments API — skip cleanly.
+            const headRepo = context.payload.pull_request.head.repo?.full_name;
+            const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
+            if (!headRepo || headRepo !== baseRepo) {
+              core.info(`Skipping: fork PR (${headRepo ?? 'deleted repo'}) — Deployments API write not available.`);
+              return;
+            }
+
+            const environment = `pr-${process.env.PR_NUMBER}-preview`;
+
+            // List all deployments for this environment (up to 100).
+            let deployments = [];
+            try {
+              const { data } = await github.rest.repos.listDeployments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                environment,
+                per_page: 100,
+              });
+              deployments = data;
+            } catch (err) {
+              if (err.status === 404) {
+                core.info(`No deployments found for ${environment} — nothing to clean up.`);
+                return;
+              }
+              throw err;
+            }
+
+            if (deployments.length === 0) {
+              core.info(`No deployments for ${environment} — nothing to clean up.`);
+            }
+
+            for (const dep of deployments) {
+              // GitHub requires inactive status before a deployment can be deleted.
+              try {
+                await github.rest.repos.createDeploymentStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  deployment_id: dep.id,
+                  state: 'inactive',
+                });
+              } catch (err) {
+                if (err.status === 404) {
+                  core.info(`Deployment ${dep.id} already gone — skipping inactive status.`);
+                } else {
+                  core.warning(`Could not mark deployment ${dep.id} inactive: ${err.message}`);
+                }
+              }
+              try {
+                await github.rest.repos.deleteDeployment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  deployment_id: dep.id,
+                });
+                core.info(`Deleted deployment ${dep.id}.`);
+              } catch (err) {
+                if (err.status === 404) {
+                  core.info(`Deployment ${dep.id} already deleted.`);
+                } else {
+                  core.warning(`Could not delete deployment ${dep.id}: ${err.message}`);
+                }
+              }
+            }
+
+            // Delete the GitHub environment so it no longer appears in the Environments list.
+            try {
+              await github.rest.repos.deleteAnEnvironment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                environment_name: environment,
+              });
+              core.info(`Deleted environment ${environment}.`);
+            } catch (err) {
+              if (err.status === 404) {
+                core.info(`Environment ${environment} already gone — nothing to delete.`);
+              } else {
+                core.warning(`Could not delete environment ${environment}: ${err.message}`);
+              }
+            }
+

--- a/docs/pr-preview-setup.md
+++ b/docs/pr-preview-setup.md
@@ -158,6 +158,11 @@ Triggered when a PR is `closed` (merged or abandoned).
    - Deletes S3 prefix `pr-<number>/` from deploy bucket.
    - Creates CloudFront invalidation for `/pr-<number>/*` on deploy distribution.
    - Drops Supabase schema `preview_pr_<number>` (if DB URL provided).
+3. Cleans up GitHub metadata via the Deployments API:
+   - Marks all deployments for `pr-<number>-preview` as `inactive`.
+   - Deletes each deployment record.
+   - Deletes the `pr-<number>-preview` environment so it no longer appears in the repository Environments / Deployments views.
+   - Skipped for fork PRs; 404s are treated as non-fatal so teardown never fails over stale or already-removed GitHub metadata.
 
 ## Helper Scripts
 


### PR DESCRIPTION
## Summary

Closes #235.

When a PR preview is torn down (PR closed), the workflow now also removes the associated GitHub deployment records and environment via the Deployments API — so the stale `pr-N-preview` entry no longer lingers in the repository's Environments / Deployments views after the preview URL and infrastructure are gone.

**Changes:**

- `.github/workflows/pr-preview-environment.yml` — adds a `Clean up GitHub Deployment and environment` step at the end of the `teardown-preview` job (using `actions/github-script@v7`, matching the style of the existing deploy step):
  1. Skips fork PRs (same guard as the deploy step — fork workflows cannot write to the Deployments API).
  2. Lists all deployments for environment `pr-{N}-preview` (`per_page: 100`).
  3. For each: posts `inactive` status (required by GitHub before deletion), then deletes the deployment record.
  4. Deletes the environment itself so it disappears from the Environments tab.
  5. Treats 404s and empty deployment lists as non-fatal — teardown will never fail because GitHub metadata was already removed or the PR was closed before ever deploying.

- `docs/pr-preview-setup.md` — updates the Teardown section under Workflow Behaviour to document the new step 3.

## Test plan

- [ ] Merge or close a PR that has at least one active preview deployment; confirm `teardown-preview` completes without error and the `pr-N-preview` environment no longer appears under **Settings → Environments** or on the PR Deployments tab.
- [ ] Close a PR that was never deployed (no deployments exist); confirm the step logs "nothing to clean up" and the job still succeeds.
- [ ] Verify the fork-PR guard: a PR from a fork should log "Skipping" and the step should exit cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)