### PR TITLE
fix(billing): Free tier shows US$0 instead of $0

### DIFF
--- a/apps/web/src/components/billing/PlanCard.web.tsx
+++ b/apps/web/src/components/billing/PlanCard.web.tsx
@@ -126,7 +126,12 @@ export function PlanCard({
 
 /** Display price: monthly uses DB cents; annual uses yearly amount from billing-sync (Stripe). */
 export function listPriceForPlan(plan: Plan, cadence: 'monthly' | 'annual') {
-  if (plan.price_cents === 0) return 'US$0';
+  if (plan.price_cents === 0)
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      maximumFractionDigits: 0,
+    }).format(0);
   if (cadence === 'monthly') {
     return (
       new Intl.NumberFormat('en-US', {

--- a/apps/web/src/components/billing/__tests__/PlanCard.web.test.tsx
+++ b/apps/web/src/components/billing/__tests__/PlanCard.web.test.tsx
@@ -37,7 +37,7 @@ const proPlan: Plan = {
 describe('listPriceForPlan', () => {
   it('formats free and paid cadence copy', () => {
     const free: Plan = { ...proPlan, id: 'beakerstack_free', price_cents: 0 };
-    expect(listPriceForPlan(free, 'monthly')).toBe('US$0');
+    expect(listPriceForPlan(free, 'monthly')).toBe('$0');
     expect(listPriceForPlan(proPlan, 'monthly')).toMatch(/19/);
     expect(listPriceForPlan(proPlan, 'annual')).toMatch(/year/);
   });

--- a/apps/web/src/components/landing/sections/PricingSection.tsx
+++ b/apps/web/src/components/landing/sections/PricingSection.tsx
@@ -46,11 +46,9 @@ function StaticPricingTable() {
             }).format(cents / 100);
 
           const priceHeadline =
-            plan.price_cents === 0
-              ? 'US$0'
-              : isAnnual && annualCents != null
-                ? fmt(annualCents)
-                : fmt(plan.price_cents);
+            isAnnual && annualCents != null
+              ? fmt(annualCents)
+              : fmt(plan.price_cents);
 
           const priceSubline =
             plan.price_cents === 0

--- a/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
+++ b/apps/web/src/components/landing/sections/__tests__/PricingSection.test.tsx
@@ -36,14 +36,17 @@ vi.mock('../../../../billing/staticPlanAdapter', () => ({
 vi.mock('../../../billing/PlanCard.web', () => ({
   PlanCard: ({
     plan,
+    priceHeadline,
     primary,
   }: {
     plan: { id: string; display_name: string };
+    priceHeadline: string;
     primary: { label: string; onClick: () => void };
   }) => (
     <button
       type='button'
       data-testid={`plan-card-${plan.id}`}
+      data-price-headline={priceHeadline}
       onClick={primary.onClick}
     >
       {plan.display_name}
@@ -109,6 +112,14 @@ describe('PricingSection', () => {
     expect(screen.getByTestId('plan-card-free')).toHaveTextContent('Free');
     expect(screen.getByTestId('plan-card-pro')).toHaveTextContent('Pro');
     expect(screen.getByTestId('plan-card-team')).toHaveTextContent('Team');
+  });
+
+  it('passes $0 as priceHeadline for the Free plan (not US$0)', () => {
+    renderSection();
+    expect(screen.getByTestId('plan-card-free')).toHaveAttribute(
+      'data-price-headline',
+      '$0'
+    );
   });
 
   it('navigates to signup with encoded plan id', async () => {

--- a/apps/web/src/pages/billing/BillingPlansPage.tsx
+++ b/apps/web/src/pages/billing/BillingPlansPage.tsx
@@ -305,14 +305,11 @@ export default function BillingPlansPage() {
                 : cadence === 'annual'
                   ? annualListCentsFromSync(p.id, p.price_cents)
                   : p.price_cents;
-            const head =
-              p.price_cents === 0
-                ? 'US$0'
-                : new Intl.NumberFormat('en-US', {
-                    style: 'currency',
-                    currency: 'USD',
-                    maximumFractionDigits: 0,
-                  }).format(displayCents / 100);
+            const head = new Intl.NumberFormat('en-US', {
+              style: 'currency',
+              currency: 'USD',
+              maximumFractionDigits: 0,
+            }).format(displayCents / 100);
             const sub =
               p.price_cents === 0
                 ? 'Free forever'

--- a/apps/web/src/pages/billing/__tests__/BillingPlansPage.test.tsx
+++ b/apps/web/src/pages/billing/__tests__/BillingPlansPage.test.tsx
@@ -246,6 +246,16 @@ describe('BillingPlansPage', () => {
     expect(screen.getByRole('heading', { name: 'Pro' })).toBeInTheDocument();
   });
 
+  it('renders $0 price headline for the Free plan card (not US$0)', () => {
+    plansState.current = plansState.freePlan;
+    plansState.subscription = null;
+    renderPage();
+    const freeCard = document.getElementById('plan-card-beakerstack_free');
+    expect(freeCard).not.toBeNull();
+    expect(within(freeCard as HTMLElement).getByText('$0')).toBeInTheDocument();
+    expect(within(freeCard as HTMLElement).queryByText('US$0')).not.toBeInTheDocument();
+  });
+
   it('shows Free as current plan when subscription is null', () => {
     plansState.current = plansState.freePlan;
     plansState.subscription = null;


### PR DESCRIPTION
Fixes #233

## Plan

Triage: fast — formatting inconsistency, no logic change.

## Changes

- **`PlanCard.web.tsx`** — `listPriceForPlan`: replace `return 'US$0'` with `Intl.NumberFormat(...).format(0)`, matching the formatter used for paid tiers
- **`BillingPlansPage.tsx`** — remove the `price_cents === 0 ? 'US$0'` ternary in `head`; `displayCents` is already `0` for free plans so the formatter produces `$0` directly
- **`PricingSection.tsx`** — remove the `price_cents === 0 ? 'US$0'` ternary in `priceHeadline`; `fmt(plan.price_cents)` evaluates to `'$0'` when `price_cents` is `0`
- **`PlanCard.web.test.tsx`** — update the free-tier assertion from `'US$0'` to `'$0'`
- **`BillingPlansPage.test.tsx`** — add test asserting the Free plan card renders `$0` (not `US$0`)
- **`PricingSection.test.tsx`** — expose `priceHeadline` in the `PlanCard` mock via `data-price-headline`; add test asserting `$0` for the Free plan

`Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(0)` → `'$0'` in all major JS engines.