### PR TITLE
feat(mobile): auto-redirect authenticated users from Home to Dashboard

### DIFF
--- a/apps/mobile/__tests__/screens/HomeScreen.test.tsx
+++ b/apps/mobile/__tests__/screens/HomeScreen.test.tsx
@@ -153,58 +153,73 @@ describe('HomeScreen', () => {
     );
   };
 
-  it('renders home screen with title and subtitle', () => {
+  // Signed-out tests use waitFor because auth.loading starts true (getSession is async)
+  // and the screen shows a spinner until loading resolves to unauthenticated.
+
+  it('renders home screen with title and subtitle', async () => {
     const { getAllByText, getByText } = renderWithAuth(
       <HomeScreen navigation={mockNavigation} />,
       false
     );
 
-    // Title appears in both header and main content
-    const titles = getAllByText(HOME_TITLE);
-    expect(titles.length).toBeGreaterThan(0);
-    // Check subtitle using the shared string constant
+    await waitFor(() => {
+      // Title appears in both header and main content
+      const titles = getAllByText(HOME_TITLE);
+      expect(titles.length).toBeGreaterThan(0);
+    });
     expect(getByText(HOME_SUBTITLE)).toBeTruthy();
   });
 
-  it('shows sign in button when not authenticated', () => {
+  it('shows sign in button when not authenticated', async () => {
     const { getAllByText } = renderWithAuth(
       <HomeScreen navigation={mockNavigation} />,
       false
     );
 
-    // Sign In appears in both header and main content
-    const signInButtons = getAllByText('Sign In');
-    expect(signInButtons.length).toBeGreaterThan(0);
+    await waitFor(() => {
+      // Sign In appears in both header and main content
+      const signInButtons = getAllByText('Sign In');
+      expect(signInButtons.length).toBeGreaterThan(0);
+    });
   });
 
-  it('shows sign up button when not authenticated', () => {
+  it('shows sign up button when not authenticated', async () => {
     const { getAllByText } = renderWithAuth(
       <HomeScreen navigation={mockNavigation} />,
       false
     );
 
-    // Sign Up appears in both header and main content
-    const signUpButtons = getAllByText('Sign Up');
-    expect(signUpButtons.length).toBeGreaterThan(0);
+    await waitFor(() => {
+      // Sign Up appears in both header and main content
+      const signUpButtons = getAllByText('Sign Up');
+      expect(signUpButtons.length).toBeGreaterThan(0);
+    });
   });
 
-  it('shows navigation header with sign in and sign up when not authenticated', () => {
+  it('shows navigation header with sign in and sign up when not authenticated', async () => {
     const { getAllByText } = renderWithAuth(
       <HomeScreen navigation={mockNavigation} />,
       false
     );
 
-    const signInLinks = getAllByText('Sign In');
-    const signUpLinks = getAllByText('Sign Up');
-    expect(signInLinks.length).toBeGreaterThan(0);
-    expect(signUpLinks.length).toBeGreaterThan(0);
+    await waitFor(() => {
+      const signInLinks = getAllByText('Sign In');
+      const signUpLinks = getAllByText('Sign Up');
+      expect(signInLinks.length).toBeGreaterThan(0);
+      expect(signUpLinks.length).toBeGreaterThan(0);
+    });
   });
 
-  it('navigates to Login and Signup from signed-out buttons', () => {
+  it('navigates to Login and Signup from signed-out buttons', async () => {
     const { getAllByText } = renderWithAuth(
       <HomeScreen navigation={mockNavigation} />,
       false
     );
+
+    // Wait for auth to resolve before interacting with buttons
+    await waitFor(() => {
+      expect(getAllByText('Sign In').length).toBeGreaterThan(0);
+    });
 
     const signIns = getAllByText('Sign In');
     fireEvent.press(signIns[signIns.length - 1]);

--- a/apps/mobile/__tests__/screens/HomeScreen.test.tsx
+++ b/apps/mobile/__tests__/screens/HomeScreen.test.tsx
@@ -66,7 +66,6 @@ import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { HOME_TITLE, HOME_SUBTITLE } from '@beakerstack/shared/utils/strings';
-import { BRANDING } from '@beakerstack/shared/config/branding';
 
 describe('HomeScreen', () => {
   let mockSupabaseClient: Partial<SupabaseClient>;
@@ -189,42 +188,6 @@ describe('HomeScreen', () => {
     expect(signUpButtons.length).toBeGreaterThan(0);
   });
 
-  it('shows dashboard link when authenticated', async () => {
-    const { getByText } = renderWithAuth(
-      <HomeScreen navigation={mockNavigation} />,
-      true
-    );
-
-    await waitFor(() => {
-      expect(getByText('Go To Dashboard')).toBeTruthy();
-    });
-  });
-
-  it('shows profile link when authenticated', async () => {
-    const { getByText } = renderWithAuth(
-      <HomeScreen navigation={mockNavigation} />,
-      true
-    );
-
-    await waitFor(() => {
-      expect(getByText('View Profile')).toBeTruthy();
-    });
-  });
-
-  it('shows navigation header with dashboard and profile links when authenticated', async () => {
-    const { getAllByText } = renderWithAuth(
-      <HomeScreen navigation={mockNavigation} />,
-      true
-    );
-
-    // The header should be visible with "Beaker Stack" text
-    // Dashboard and Profile are in the user menu dropdown, not directly visible
-    await waitFor(() => {
-      const beakerStackText = getAllByText(BRANDING.displayName);
-      expect(beakerStackText.length).toBeGreaterThan(0);
-    });
-  });
-
   it('shows navigation header with sign in and sign up when not authenticated', () => {
     const { getAllByText } = renderWithAuth(
       <HomeScreen navigation={mockNavigation} />,
@@ -235,56 +198,6 @@ describe('HomeScreen', () => {
     const signUpLinks = getAllByText('Sign Up');
     expect(signInLinks.length).toBeGreaterThan(0);
     expect(signUpLinks.length).toBeGreaterThan(0);
-  });
-
-  it('has dashboard button that can navigate', async () => {
-    const { getByText } = renderWithAuth(
-      <HomeScreen navigation={mockNavigation} />,
-      true
-    );
-
-    await waitFor(() => {
-      const button = getByText('Go To Dashboard');
-      expect(button).toBeTruthy();
-    });
-  });
-
-  it('has profile button that can navigate', async () => {
-    const { getByText } = renderWithAuth(
-      <HomeScreen navigation={mockNavigation} />,
-      true
-    );
-
-    await waitFor(() => {
-      const button = getByText('View Profile');
-      expect(button).toBeTruthy();
-    });
-  });
-
-  it('navigates to Dashboard when Go To Dashboard is pressed', async () => {
-    const { getByText } = renderWithAuth(
-      <HomeScreen navigation={mockNavigation} />,
-      true
-    );
-
-    await waitFor(() => {
-      expect(getByText('Go To Dashboard')).toBeTruthy();
-    });
-    fireEvent.press(getByText('Go To Dashboard'));
-    expect(mockNavigate).toHaveBeenCalledWith('Dashboard');
-  });
-
-  it('navigates to Profile when View Profile is pressed', async () => {
-    const { getByText } = renderWithAuth(
-      <HomeScreen navigation={mockNavigation} />,
-      true
-    );
-
-    await waitFor(() => {
-      expect(getByText('View Profile')).toBeTruthy();
-    });
-    fireEvent.press(getByText('View Profile'));
-    expect(mockNavigate).toHaveBeenCalledWith('Profile');
   });
 
   it('navigates to Login and Signup from signed-out buttons', () => {
@@ -300,5 +213,27 @@ describe('HomeScreen', () => {
     const signUps = getAllByText('Sign Up');
     fireEvent.press(signUps[signUps.length - 1]);
     expect(mockNavigate).toHaveBeenCalledWith('Signup');
+  });
+
+  it('resets navigation to Dashboard when authenticated', async () => {
+    renderWithAuth(<HomeScreen navigation={mockNavigation} />, true);
+
+    await waitFor(() => {
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: 'Dashboard' }],
+      });
+    });
+  });
+
+  it('shows redirecting indicator when authenticated', async () => {
+    const { getByText } = renderWithAuth(
+      <HomeScreen navigation={mockNavigation} />,
+      true
+    );
+
+    await waitFor(() => {
+      expect(getByText('Redirecting...')).toBeTruthy();
+    });
   });
 });

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   View,
   Text,
   StyleSheet,
   TouchableOpacity,
   SafeAreaView,
+  ActivityIndicator,
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { HOME_TITLE, HOME_SUBTITLE } from '@beakerstack/shared/utils/strings';
@@ -32,6 +33,26 @@ interface Props {
 export default function HomeScreen({ navigation }: Props) {
   const auth = useAuthContext();
 
+  useEffect(() => {
+    if (!auth.loading && auth.user) {
+      navigation.reset({
+        index: 0,
+        routes: [{ name: 'Dashboard' }],
+      });
+    }
+  }, [auth.loading, auth.user, navigation]);
+
+  if (auth.loading || auth.user) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size='large' color='#4F46E5' />
+        <Text style={styles.loadingText}>
+          {auth.loading ? 'Loading...' : 'Redirecting...'}
+        </Text>
+      </View>
+    );
+  }
+
   return (
     <SafeAreaView style={styles.container}>
       <AppHeader supabaseClient={supabase} />
@@ -44,46 +65,19 @@ export default function HomeScreen({ navigation }: Props) {
         </View>
 
         <View style={styles.buttonContainer}>
-          {auth.user ? (
-            // Signed in state
-            <>
-              <View style={styles.signedInContainer}>
-                <Text style={styles.signedInText}>Logged in as</Text>
-                <Text style={styles.signedInEmail}>{auth.user.email}</Text>
-              </View>
+          <TouchableOpacity
+            style={styles.primaryButton}
+            onPress={() => navigation.navigate('Login')}
+          >
+            <Text style={styles.primaryButtonText}>Sign In</Text>
+          </TouchableOpacity>
 
-              <TouchableOpacity
-                style={styles.primaryButton}
-                onPress={() => navigation.navigate('Dashboard')}
-              >
-                <Text style={styles.primaryButtonText}>Go To Dashboard</Text>
-              </TouchableOpacity>
-
-              <TouchableOpacity
-                style={styles.secondaryButton}
-                onPress={() => navigation.navigate('Profile')}
-              >
-                <Text style={styles.secondaryButtonText}>View Profile</Text>
-              </TouchableOpacity>
-            </>
-          ) : (
-            // Signed out state
-            <>
-              <TouchableOpacity
-                style={styles.primaryButton}
-                onPress={() => navigation.navigate('Login')}
-              >
-                <Text style={styles.primaryButtonText}>Sign In</Text>
-              </TouchableOpacity>
-
-              <TouchableOpacity
-                style={styles.secondaryButton}
-                onPress={() => navigation.navigate('Signup')}
-              >
-                <Text style={styles.secondaryButtonText}>Sign Up</Text>
-              </TouchableOpacity>
-            </>
-          )}
+          <TouchableOpacity
+            style={styles.secondaryButton}
+            onPress={() => navigation.navigate('Signup')}
+          >
+            <Text style={styles.secondaryButtonText}>Sign Up</Text>
+          </TouchableOpacity>
         </View>
       </View>
     </SafeAreaView>
@@ -123,26 +117,13 @@ const styles = StyleSheet.create({
     width: '100%',
     maxWidth: 300,
   },
-  signedInContainer: {
-    backgroundColor: '#d1fae5',
-    borderColor: '#6ee7b7',
-    borderWidth: 1,
-    borderRadius: 8,
-    padding: 12,
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
     alignItems: 'center',
-    marginBottom: 8,
+    backgroundColor: '#F9FAFB',
   },
-  signedInText: {
-    color: '#065f46',
-    fontSize: 14,
-    fontWeight: '500',
-  },
-  signedInEmail: {
-    color: '#065f46',
-    fontSize: 16,
-    fontWeight: '600',
-    marginTop: 4,
-  },
+  loadingText: { marginTop: 16, fontSize: 16, color: '#6B7280' },
   primaryButton: {
     backgroundColor: '#3b82f6',
     paddingVertical: 12,


### PR DESCRIPTION
## Summary

Closes #239.

Authenticated users landing on `HomeScreen` are now immediately redirected to `Dashboard` without seeing the redundant welcome hub — consistent with the behavior of `LoginScreen` and `SignupScreen`.

**Changes to `apps/mobile/src/screens/HomeScreen.tsx`:**
- Added `useEffect` that calls `navigation.reset({ index: 0, routes: [{ name: 'Dashboard' }] })` when `!auth.loading && auth.user` — same guard and call site as `LoginScreen`.
- Added early-return loading/redirecting UI (matching the `DashboardScreen` pattern): shows `ActivityIndicator` + "Loading..." while auth state resolves, then "Redirecting..." while the reset fires.
- Removed the signed-in branch (email banner, "Go To Dashboard", "View Profile" buttons) — those are now unreachable.
- Removed unused styles (`signedInContainer`, `signedInText`, `signedInEmail`); added `loadingContainer` / `loadingText`.
- Added `ActivityIndicator` to React Native imports; added `useEffect` to React import.

**Changes to `apps/mobile/__tests__/screens/HomeScreen.test.tsx`:**
- Removed 7 tests that asserted on the now-deleted signed-in UI (dashboard/profile buttons, header with auth).
- Added `resets navigation to Dashboard when authenticated` — asserts `navigation.reset` called with `{ index: 0, routes: [{ name: 'Dashboard' }] }`.
- Added `shows redirecting indicator when authenticated` — asserts "Redirecting..." text appears.
- Removed unused `BRANDING` import.

## Flows after this change

| Scenario | Result |
|----------|--------|
| Cold start with saved session | Brief loading spinner → reset to Dashboard |
| Signed out | Home with Sign In / Sign Up (unchanged) |
| Sign out → navigate to Home | Stays on Home, signed-out UI |
| Tap header logo while signed in | Navigate to Home → immediate redirect back to Dashboard |

## Test plan

- [ ] `cd apps/mobile && npm test -- --testPathPattern=HomeScreen` — all tests pass.
- [ ] Manual: launch app with an existing session → lands on Dashboard (no Home flash beyond spinner).
- [ ] Manual: sign out → Home renders with Sign In / Sign Up buttons only.
- [ ] Manual: sign in via Login screen → Dashboard (existing behavior unchanged).

