### PR TITLE
ci: register GitHub Deployments for production deploys

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  deployments: write
 
 concurrency:
   group: production-deploy
@@ -145,6 +146,49 @@ jobs:
             --domain "${DOMAIN}" \
             --environment prod \
             --region "${AWS_REGION_VALUE}"
+
+      - name: Create GitHub Deployment (production)
+        uses: actions/github-script@v7
+        env:
+          PRODUCTION_URL: ${{ format('https://{0}/', env.DOMAIN) }}
+        with:
+          script: |
+            const environmentUrl = process.env.PRODUCTION_URL;
+            const logUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: 'production',
+              auto_merge: false,
+              required_contexts: [],
+              description: 'Production deployment',
+            });
+            if (!deployment.data.id) {
+              core.warning(`createDeployment returned no id (HTTP ${deployment.status}): ${deployment.data.message ?? JSON.stringify(deployment.data)}`);
+              return;
+            }
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: 'success',
+              environment_url: environmentUrl,
+              log_url: logUrl,
+              description: 'Production deployed',
+            });
+
+      - name: Write Actions run summary
+        shell: bash
+        env:
+          PRODUCTION_URL: ${{ format('https://{0}/', env.DOMAIN) }}
+        run: |
+          set -euo pipefail
+          cat >> "${GITHUB_STEP_SUMMARY}" <<SUMMARY
+          ## Production Deployment
+
+          **Production URL:** ${PRODUCTION_URL}
+          SUMMARY
 
   deploy-mobile-production:
     if: vars.MOBILE_ENABLED != 'false'


### PR DESCRIPTION
## Summary

- Add `deployments: write` to the production deploy workflow so pushes to `main` can use the GitHub Deployments API.
- After a successful web deploy, create a `production` environment deployment with `environment_url` pointing at `https://{domain}/` and a link to the Actions run.
- Add an Actions run summary with the production URL (aligned with staging).

## Context

Staging already registers deployments on `develop`; production deploys ran successfully but never appeared in GitHub Environments / Deployments. This closes that gap.

## Test plan

- [ ] Merge to `develop`, then promote to `main` (or merge directly per release flow)
- [ ] Confirm **Deploy Production** succeeds on the next `main` push
- [ ] Verify **Settings → Environments** shows `production` with a new deployment
- [ ] Confirm deployment `environment_url` opens the live site