### PR TITLE
fix(seed): remove feature_c from beakerstack_max in both seed files

### DIFF
--- a/apps/mobile/supabase/seed.sql
+++ b/apps/mobile/supabase/seed.sql
@@ -58,7 +58,7 @@ VALUES
     NULL,
     NULL,
     NULL,
-    '{"containers_per_account_max": -1, "items_per_container_max": -1, "feature_a": true, "feature_b": true, "feature_c": true}'::jsonb,
+    '{"containers_per_account_max": -1, "items_per_container_max": -1, "feature_a": true, "feature_b": true}'::jsonb,
     '{"ai_summarize": -1}'::jsonb,
     5,
     true,

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -60,7 +60,7 @@ VALUES
     NULL,
     NULL,
     NULL,
-    '{"containers_per_account_max": -1, "items_per_container_max": -1, "feature_a": true, "feature_b": true, "feature_c": true}'::jsonb,
+    '{"containers_per_account_max": -1, "items_per_container_max": -1, "feature_a": true, "feature_b": true}'::jsonb,
     '{"ai_summarize": -1}'::jsonb,
     5,
     true,


### PR DESCRIPTION
Fixes #244.

`beakerstack_max` in both seed files included `"feature_c": true`, which is not defined in `beakerstackBillingConfig` on web or mobile. Removed from both:

- `supabase/seed.sql` (line 63)
- `apps/mobile/supabase/seed.sql` (line 61)

Target features JSON for `beakerstack_max`:
```json
{"containers_per_account_max": -1, "items_per_container_max": -1, "feature_a": true, "feature_b": true}
```

No other changes — `feature_c` has no UI, presentation rows, or tests, so nothing else to clean up.