### PR TITLE
docs(pr-preview): fix stale SubdomainFolders → PRPathRouter in troubleshooting

### DIFF
--- a/docs/pr-preview-setup.md
+++ b/docs/pr-preview-setup.md
@@ -247,7 +247,7 @@ All scripts support `--dry-run` and write outputs to `GITHUB_OUTPUT` (CI) or
   Check CloudFront invalidation progress. Propagation can take up to 10 minutes.
 
 - **Unexpected production content**  
-  Ensure `SubdomainFolders` function deployed with latest code. Redeploy using
+  Ensure `PRPathRouter` function is deployed with the latest code (see `infra/aws/functions/PRPathRouter.js`). Redeploy using
   `bootstrap-aws-stack.sh`.
 
 - **Missing SSL certificate**  


### PR DESCRIPTION
Fixes #245

The troubleshooting section at line 250 referenced `SubdomainFolders`, which does not exist. The setup section (lines 77–83) and the actual implementation (`infra/aws/functions/PRPathRouter.js`) both use `PRPathRouter`. One-line correction to keep the runbook consistent.

```diff
-Ensure `SubdomainFolders` function deployed with latest code.
+Ensure `PRPathRouter` function is deployed with the latest code (see `infra/aws/functions/PRPathRouter.js`).
```

Grepped: zero remaining `SubdomainFolders` references in this file.