### PR TITLE
chore: clarify npm-only package manager policy (closes #172)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+pnpm-lock.yaml
+yarn.lock
 
 # Runtime data
 pids

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ Issues: use [GitHub Issues](https://github.com/Artificer-Innovations/BeakerStack
 
 ## Workflow
 
+**Package manager:** This repo uses **npm** exclusively — `pnpm` and `yarn` are not supported. The `engines` field in `package.json` requires `npm >= 9.0.0` and all CI runs use `npm ci`. Both `pnpm-lock.yaml` and `yarn.lock` are listed in `.gitignore` to prevent accidental commits.
+
 1. Create a branch from `develop` (or the branch your team uses for integration).
 2. Make focused changes; match existing style, types, and test patterns.
 3. Run checks locally:


### PR DESCRIPTION
## Summary

Closes #172.

The repo uses npm exclusively throughout — `package.json` engines, all root and workspace scripts, and all CI workflows use npm. Two things were missing to make this unambiguous:

1. **`.gitignore`** — neither `pnpm-lock.yaml` nor `yarn.lock` were listed, so they could be accidentally committed. Added both after `pnpm-debug.log*`.
2. **`CONTRIBUTING.md`** — no explicit policy statement existed. Added a "Package manager" note at the top of the **Workflow** section (the first place a contributor reads before starting work), calling out npm-only, the `engines` field, and the gitignore entries.

### Files changed

| File | Change |
|------|--------|
| `.gitignore` | Add `pnpm-lock.yaml` and `yarn.lock` entries |
| `CONTRIBUTING.md` | Add package manager policy note at top of Workflow section |

### No changes needed

- CI workflows already use `npm ci` consistently — no change needed.
- `QUICKSTART.md` already shows `npm install` as the install step — no change needed.
- `package.json` `engines` already gates `npm >= 9.0.0` — no change needed.

## Test plan

- [ ] Verify `.gitignore` now blocks `pnpm-lock.yaml`: clone the repo, run `touch pnpm-lock.yaml`, confirm `git status` shows it as untracked/ignored.
- [ ] Confirm `CONTRIBUTING.md` renders the new note correctly on GitHub.
