### PR TITLE
docs: setup prep checklist and full/brief wizard guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ If the hook blocks your commit, fix the reported errors and re-commit. Do not us
 
 - Prefer small PRs over large mixed ones.
 - If you change `scripts/lib/setup-manifest.mjs`, run `npm run docs:actions-secrets` and commit updates to `docs/reference/github-actions-secrets.md`.
+- If you add or change setup wizard prompts in `scripts/setup-full.mjs` or `scripts/lib/setup-manual-instructions.mjs`, update `docs/setup-prep-checklist.md`.
 - Do not commit `.env*` files or real secrets.
 
 ## Branch flow and releases

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -170,6 +170,8 @@ Work through these when you are ready; they are intentionally dense. For **promp
 - [ ] Firebase / Google Cloud OAuth clients; `google-services.json` where required.
 - [ ] Supabase Auth Google provider + redirect URLs: [docs/supabase-preview-setup.md](docs/supabase-preview-setup.md), [docs/supabase-staging-production-setup.md](docs/supabase-staging-production-setup.md).
 
-**Deep dives:** [docs/pr-preview-setup.md](docs/pr-preview-setup.md), [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md), [docs/README.md](docs/README.md).
+**Optional — signed-cookie preview access:** after the AWS stack, run [docs/preview-access-control.md](docs/preview-access-control.md) (`setup-signed-cookies.sh`); not part of `setup:full`.
+
+**Deep dives:** [docs/pr-preview-setup.md](docs/pr-preview-setup.md), [docs/preview-access-control.md](docs/preview-access-control.md), [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md), [docs/README.md](docs/README.md).
 
 Do not commit `.env*` files; sensitive paths are listed in [.cursorignore](.cursorignore).

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -65,7 +65,7 @@ You should see a banner and a prompt similar to:
 ========================================================================
 
 [setup] …
-Setup: (1) Local — … [default]  (2) Full cloud — … (read README + QUICKSTART first)  (q) Quit:
+Setup: (1) Local — … [default]  (2) Full cloud — … (read docs/setup-prep-checklist.md first)  (q) Quit:
 ```
 
 Choose **(1) Local** (press Enter for the default). That path wires dependencies, copies `env.example` toward `.env.local`, starts **Supabase in Docker**, and runs type generation when the script completes.
@@ -105,7 +105,11 @@ At minimum for deploy workflows you will need **`SUPABASE_ACCESS_TOKEN`** and **
 
 **Lighthouse CI** scores are posted as GitHub status checks on each PR preview if `LHCI_GITHUB_APP_TOKEN` is set (install the [Lighthouse CI GitHub App](https://github.com/apps/lighthouse-ci) to get the token). The step is skipped automatically when the preview is signed-cookie gated — Lighthouse cannot authenticate headlessly. See [docs/lighthouse-ci.md](docs/lighthouse-ci.md) for details.
 
-### 6.2 Full interactive bootstrap
+### 6.2 Before full cloud setup (read first)
+
+**[docs/setup-prep-checklist.md](docs/setup-prep-checklist.md)** lists every wizard prompt, what to gather in advance, which values are **one-time** (database passwords, some tokens), and what remains **manual after** the wizard (Stripe, OAuth, Lighthouse). Skim it before option **(2)** or `npm run setup:full`.
+
+### 6.3 Full interactive bootstrap
 
 ```bash
 npm run setup:full
@@ -113,14 +117,16 @@ npm run setup:full
 
 Options (see also `npm run setup:full -- --help`):
 
-| Flag                 | Meaning                                     |
-| -------------------- | ------------------------------------------- |
-| `--dry-run`          | No file writes; log-only GitHub sync        |
-| `--from=PHASE`       | Resume at a phase (see table below)         |
-| `--skip-rename`      | Skip template rename                        |
-| `--skip-github`      | Do not push secrets with `gh`               |
-| `--skip-mobile`      | Skip Expo/EAS/Google setup (web-only repos) |
-| `--aws-profile=NAME` | Pass through to AWS bootstrap script        |
+| Flag                  | Meaning                                                                                                                          |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `--dry-run`           | No file writes; log-only GitHub sync                                                                                             |
+| `--from=PHASE`        | Resume at a phase (see table below)                                                                                              |
+| `--skip-rename`       | Skip template rename                                                                                                             |
+| `--skip-github`       | Do not push secrets with `gh`                                                                                                    |
+| `--skip-mobile`       | Skip Expo/EAS/Google setup (web-only repos)                                                                                      |
+| `--aws-profile=NAME`  | Pass through to AWS bootstrap script                                                                                             |
+| `--guide=full\|brief` | Intro banner: **full** (default) prints GitHub/Supabase/AWS/Expo checklist in the terminal; **brief** links to the prep doc only |
+| `--brief-guide`       | Same as `--guide=brief`                                                                                                          |
 
 **Phase names** for `--from=` (order matters; later phases assume earlier work or merged `.env*` files):
 
@@ -135,9 +141,9 @@ Options (see also `npm run setup:full -- --help`):
 | `write`    | Merge collected values into `.env.cloud.generated.local` / `.env.local` |
 | `github`   | Optional `gh secret set` / `variable set` from manifest                 |
 
-### 6.3 Full-cloud checklist (accounts and DNS)
+### 6.4 Full-cloud checklist (accounts and DNS)
 
-Work through these when you are ready; they are intentionally dense.
+Work through these when you are ready; they are intentionally dense. For **prompt-by-prompt** detail, use [docs/setup-prep-checklist.md](docs/setup-prep-checklist.md).
 
 **GitHub**
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -103,6 +103,8 @@ Commit any updates to `docs/reference/github-actions-secrets.md` when you change
 
 At minimum for deploy workflows you will need **`SUPABASE_ACCESS_TOKEN`** and **AWS access keys** (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, plus optional `AWS_SESSION_TOKEN`), plus the Supabase URL/keys and project refs for each tier—see the generated table. **`EXPO_TOKEN`**, `EXPO_PROJECT_ID`, `EXPO_ACCOUNT`, and all `GOOGLE_SERVICES_*` entries are mobile-only; set `MOBILE_ENABLED=false` (GitHub variable) to skip them for web-only repos.
 
+Before the **github** phase of `npm run setup:full`, see [docs/setup-prep-checklist.md § github](docs/setup-prep-checklist.md#github) (gh auth, what may still be missing if you skipped earlier steps).
+
 **Lighthouse CI** scores are posted as GitHub status checks on each PR preview if `LHCI_GITHUB_APP_TOKEN` is set (install the [Lighthouse CI GitHub App](https://github.com/apps/lighthouse-ci) to get the token). The step is skipped automatically when the preview is signed-cookie gated — Lighthouse cannot authenticate headlessly. See [docs/lighthouse-ci.md](docs/lighthouse-ci.md) for details.
 
 ### 6.2 Before full cloud setup (read first)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ npm install
 npm run setup
 ```
 
-The setup wizard handles Docker Supabase, `.env.local`, and type generation. Full cloud + CI checklist: [QUICKSTART.md](QUICKSTART.md).
+The setup wizard handles Docker Supabase, `.env.local`, and type generation. Full cloud + CI: read [docs/setup-prep-checklist.md](docs/setup-prep-checklist.md) before `npm run setup:full`, then [QUICKSTART.md](QUICKSTART.md).
 
 **Node 18+** (`>=18` in `package.json`); **Node 20** matches CI. Docker Desktop + Supabase CLI for local work.
 

--- a/docs/MOBILE_BUILD_TESTING.md
+++ b/docs/MOBILE_BUILD_TESTING.md
@@ -36,9 +36,63 @@ You must use a **Development Build** (also called a "custom dev client") which:
 - Still supports OTA updates via EAS Updates
 - Can be installed on simulators, emulators, or physical devices
 
+## Before the Expo wizard phase
+
+If you use `npm run setup:full` with mobile enabled, the **expo** phase:
+
+1. Logs you into EAS (`eas login`) if needed.
+2. Links **apps/mobile** to your Expo project (**link existing UUID** or **`eas init` new**).
+3. Asks for an **access token** for GitHub Actions (`EXPO_TOKEN`).
+
+### Checklist (before you answer Yes to the expo phase)
+
+| #   | Requirement             | Details                                                                                                                                                                                                                                                                                                          |
+| --- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Expo account**        | https://expo.dev — personal or org; `eas whoami` works after login.                                                                                                                                                                                                                                              |
+| 2   | **EAS project**         | Existing **Project ID** (UUID) to link, or plan to create one with `eas init`. Do not keep the template BeakerStack project id. **Note:** `eas init` often prints “Cannot automatically write to dynamic config” for `app.config.js` — that is expected; the setup wizard patches `extra.eas.projectId` for you. |
+| 3   | **Access token for CI** | Create at [expo.dev → Access tokens](https://expo.dev/settings/access-tokens) at the end of the phase; saved as **`EXPO_TOKEN`** on GitHub.                                                                                                                                                                      |
+| 4   | **Web-only fork?**      | Use `--skip-mobile` to skip expo + google phases entirely.                                                                                                                                                                                                                                                       |
+
+Outputs written locally: `apps/mobile/.eas/project.json`, `app.config.js` (`extra.eas.projectId`), and setup accumulator keys **`EXPO_PROJECT_ID`**, **`EXPO_ACCOUNT`**, **`EXPO_TOKEN`**.
+
+### Rotating `EXPO_TOKEN`
+
+1. Create a new access token at [expo.dev/settings/access-tokens](https://expo.dev/settings/access-tokens).
+2. Update GitHub secret **`EXPO_TOKEN`** (Settings → Secrets and variables → Actions), or run `npm run setup:full -- --from=github` and paste when prompted.
+3. Revoke the old token in the Expo dashboard after a successful mobile deploy workflow.
+4. If you store the token in EAS project secrets for cloud builds, update those entries too.
+
+## Before the Google wizard phase
+
+The **google** phase in `npm run setup:full` is **optional**. It imports a Firebase **`google-services.json`** file into **`GOOGLE_SERVICES_*`** keys for GitHub Actions (mobile CI). It does **not** configure Supabase web OAuth — that is [OAUTH.md](OAUTH.md).
+
+### When you need this
+
+| Need it now                                                                 | Can skip for now                                   |
+| --------------------------------------------------------------------------- | -------------------------------------------------- |
+| Native **Google Sign-In on Android** in EAS builds / PR preview mobile      | Web-only product, or no Google login on mobile yet |
+| PR preview workflow runs **mobile** deploy with `GOOGLE_SERVICES_*` secrets | You skipped **expo** and will add mobile CI later  |
+
+### Checklist
+
+1. **Firebase project** at [console.firebase.google.com](https://console.firebase.google.com) (or use an existing GCP project).
+2. **Android app** registered with package name matching `android.package` in `apps/mobile/app.config.js` (template default: `com.anonymous.beakerstack`).
+3. **Download** `google-services.json`: Firebase → Project settings → Your apps → your Android app → download.
+4. At the wizard prompt, paste the **file path** (e.g. `~/Downloads/google-services.json`).
+
+The wizard extracts keys such as `GOOGLE_SERVICES_WEB_CLIENT_ID`, `GOOGLE_SERVICES_ANDROID_CLIENT_ID`, `GOOGLE_SERVICES_IOS_CLIENT_ID`, and `GOOGLE_SERVICES_API_KEY` for the **github** sync phase.
+
+### Not the same as Supabase Google OAuth
+
+|                  | **google-services.json** (this phase) | **Supabase Google provider** ([OAUTH.md](OAUTH.md))                   |
+| ---------------- | ------------------------------------- | --------------------------------------------------------------------- |
+| Purpose          | Native mobile Google Sign-In (EAS)    | Web (and server) OAuth via Supabase Auth                              |
+| Where configured | Firebase Android app + this file      | Google Cloud OAuth client + Supabase dashboard / `config.toml`        |
+| Env / secrets    | `GOOGLE_SERVICES_*`                   | `SUPABASE_AUTH_EXTERNAL_GOOGLE_*` (local), Supabase dashboard (cloud) |
+
 ## Prerequisites
 
-1. **Expo Account Access**: You need access to the `artificer-innovations-llc` organization on Expo
+1. **Expo Account Access**: You need access to your Expo account (or org) that owns the EAS project linked in setup
 2. **Development Build** installed on your device/simulator (see below)
 3. **Physical Device or Simulator/Emulator**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,16 +4,17 @@ Start on the repo root **[README.md](../README.md)** and **[QUICKSTART.md](../QU
 
 ## Setup and infrastructure
 
-| Document                                                                     | Purpose                                                                                      |
-| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| [QUICKSTART.md](../QUICKSTART.md)                                            | First run: local hello-world vs full cloud + CI checklist                                    |
-| [pr-preview-setup.md](pr-preview-setup.md)                                   | AWS PR previews, DNS, CloudFormation                                                         |
-| [supabase-staging-production-setup.md](supabase-staging-production-setup.md) | Remote staging/production Supabase projects                                                  |
-| [supabase-preview-setup.md](supabase-preview-setup.md)                       | Shared PR preview database and redirects                                                     |
-| [stripe-billing-setup.md](stripe-billing-setup.md)                           | Stripe + Supabase Edge billing (keys, webhooks, sync, local vs hosted)                       |
-| [reference/github-actions-secrets.md](reference/github-actions-secrets.md)   | Actions secret/variable names (regenerate with `npm run docs:actions-secrets`)               |
-| [project-label-bridge.md](project-label-bridge.md)                           | **Optional:** label-driven org GitHub Project updates (`npm run setup:project-label-bridge`) |
-| [branch-protection-setup.md](branch-protection-setup.md)                     | Branch rules                                                                                 |
+| Document                                                                     | Purpose                                                                                       |
+| ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [QUICKSTART.md](../QUICKSTART.md)                                            | First run: local hello-world vs full cloud + CI checklist                                     |
+| [setup-prep-checklist.md](setup-prep-checklist.md)                           | **Before `setup:full`:** wizard prompts, values to gather, one-time secrets, post-wizard work |
+| [pr-preview-setup.md](pr-preview-setup.md)                                   | AWS PR previews, DNS, CloudFormation                                                          |
+| [supabase-staging-production-setup.md](supabase-staging-production-setup.md) | Remote staging/production Supabase projects                                                   |
+| [supabase-preview-setup.md](supabase-preview-setup.md)                       | Shared PR preview database and redirects                                                      |
+| [stripe-billing-setup.md](stripe-billing-setup.md)                           | Stripe + Supabase Edge billing (keys, webhooks, sync, local vs hosted)                        |
+| [reference/github-actions-secrets.md](reference/github-actions-secrets.md)   | Actions secret/variable names (regenerate with `npm run docs:actions-secrets`)                |
+| [project-label-bridge.md](project-label-bridge.md)                           | **Optional:** label-driven org GitHub Project updates (`npm run setup:project-label-bridge`)  |
+| [branch-protection-setup.md](branch-protection-setup.md)                     | Branch rules                                                                                  |
 
 ## OAuth
 

--- a/docs/pr-preview-setup.md
+++ b/docs/pr-preview-setup.md
@@ -43,6 +43,28 @@ locally ensure the following are available:
 - `jq` (JSON parsing in scripts)
 - Optional: set `SUPABASE_MAX_RETRIES` (default `3`) to raise retry attempts when Supabase CLI operations are flaky.
 
+## Before the AWS wizard phase
+
+If you use `npm run setup:full`, the **aws** phase runs `scripts/pr-preview/bootstrap-aws-stack.sh`. Have the following **before** you answer **Yes** to that phase (the wizard prints the same checklist and waits for Enter).
+
+### Checklist
+
+| #   | Requirement                           | Details                                                                                                                                                                                                                              |
+| --- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | **Apex domain in Route 53**           | Public hosted zone for your apex (e.g. `example.com`). If DNS is elsewhere, NS records must delegate to this zone.                                                                                                                   |
+| 2   | **ACM certificate (TLS)**             | In **us-east-1**, status **Issued**, covering **apex** and **\*.apex** (DNS validation in Route 53). Required for CloudFront — not optional.                                                                                         |
+| 3   | **AWS CLI credentials (local)**       | `aws sts get-caller-identity` succeeds on the machine running setup (`aws configure` access keys or `aws sso login`). IAM permissions for CloudFormation, S3, CloudFront, Route 53, ACM (read).                                      |
+| 4   | **GitHub deploy credentials (later)** | Separate **IAM access key + secret** for CI (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) — collected in the setup **github** phase or added manually. Not the same as “CLI works on my laptop” unless you reuse the same IAM user. |
+
+The wizard will ask for your **apex domain** and can auto-detect the hosted zone ID and certificate ARN when they already exist in the account.
+
+### Rotating AWS deploy credentials
+
+1. Create a new IAM access key for the deploy user (or replace SSO role policy as your org requires).
+2. Update GitHub secrets **`AWS_ACCESS_KEY_ID`** and **`AWS_SECRET_ACCESS_KEY`** (and **`AWS_SESSION_TOKEN`** if temporary).
+3. Disable/delete the old access key after a successful deploy workflow run.
+4. Re-run `npm run setup:full -- --from=github` if you use the wizard to sync secrets.
+
 ## Infrastructure Provisioning
 
 1. **Wildcard Certificate**
@@ -290,7 +312,7 @@ Re-run jobs using GitHub Actions UI after addressing configuration issues.
 ## Maintenance & Extension
 
 - **Cache policy tuning:** adjust `deploy-web.sh` cache headers for hashed assets.
-- **Secrets rotation:** rotate AWS, Supabase, Expo credentials periodically.
+- **Secrets rotation:** rotate AWS, Supabase, Expo credentials periodically — AWS deploy keys: [Rotating AWS deploy credentials](#rotating-aws-deploy-credentials).
 - **Cleanup retention:** schedule periodic runs of `teardown.sh` for stale PRs.
 - **Monitoring:** enable AWS S3/CloudFront access logs (already configured) and
   integrate with monitoring stack if desired.

--- a/docs/setup-prep-checklist.md
+++ b/docs/setup-prep-checklist.md
@@ -1,0 +1,213 @@
+# Setup prep checklist
+
+Read this **before** you run the full cloud wizard (`npm run setup` → option **2**, or `npm run setup:full`). It maps what the setup script will ask for to what you should have ready—especially values you **cannot look up later** (database passwords, some webhook secrets, newly created tokens).
+
+For a short account checklist, see [QUICKSTART.md §6.4](../QUICKSTART.md#64-full-cloud-checklist-accounts-and-dns). For GitHub Actions secret **names** only, see [reference/github-actions-secrets.md](reference/github-actions-secrets.md) (`npm run docs:actions-secrets` regenerates that table from `scripts/lib/setup-manifest.mjs`).
+
+The wizard prints the same GitHub / Supabase / AWS / Expo prerequisites in the terminal by default (`--guide=full`). Use `--guide=brief` or `--brief-guide` if you already read this doc and want a shorter banner.
+
+**Do not commit** filled-in copies of this checklist or any `.env*` files with real secrets.
+
+---
+
+## Track A — Local setup (default)
+
+`npm run setup` → **(1) Local** runs [`scripts/setup-local.sh`](../scripts/setup-local.sh). It does **not** ask interactive questions.
+
+### Prerequisites
+
+| Item                                         | Notes                                           |
+| -------------------------------------------- | ----------------------------------------------- |
+| Node.js **20** recommended (`>=18` required) | Matches CI                                      |
+| **npm** `>=9`                                | `npm install` at repo root                      |
+| **Docker Desktop** (or Docker Engine)        | For `supabase start`                            |
+| **Supabase CLI**                             | [Install](https://supabase.com/docs/guides/cli) |
+
+### After the script
+
+1. If `.env.local` was created from [env.example](../env.example), replace placeholder Supabase keys with output from `supabase status` (URL, anon key, service role key).
+2. Run `npm run dev:all` — web at http://localhost:5173.
+
+Stripe, OAuth, AWS, and remote Supabase tiers are **not** part of local setup; see [Track B](#track-b--full-cloud--ci) and [Post-wizard work](#post-wizard-not-in-setup-full).
+
+---
+
+## Track B — Full cloud + CI
+
+**Time:** often **1–3 hours** of focused work (excluding DNS propagation).
+
+**Commands:** `npm run setup` → **(2)**, or `npm run setup:full` directly.
+
+**Phases (in order):** `prereqs` → `identity` → `supabase` → `aws` → `expo` → `google` → `write` → `github`
+
+Each phase (except `prereqs` and `write`) can be skipped with **(N)**; skipped phases print manual steps in the terminal. Resume with `--from=PHASE` (see [QUICKSTART.md §6.2](../QUICKSTART.md#62-full-interactive-bootstrap)).
+
+### Decisions to make before you start
+
+| Decision                        | When asked                                                       | Effect                                                                                                                                  |
+| ------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Enable mobile (Expo / EAS)?** | Start of full setup (`Enable mobile … [Y/n]`) or `--skip-mobile` | **No** → skips `expo` and `google` phases; set `MOBILE_ENABLED=false` for CI                                                            |
+| **Rebrand template?**           | `identity` phase or `--skip-rename`                              | Runs `npm run rename` (display name + optional legal org string)                                                                        |
+| **Supabase: create vs select**  | Per tier: `preview`, `staging`, `production`                     | Create → you set or accept a **DB password** (one-time if you do not save it)                                                           |
+| **AWS PR-preview stack**        | `aws` phase                                                      | Needs apex domain, Route53 zone, ACM cert in **us-east-1**; may prompt for destructive bucket teardown if a prior deploy left conflicts |
+| **Sync secrets to GitHub?**     | `github` phase or `--skip-github`                                | Needs `gh auth login` and repo admin                                                                                                    |
+
+### Global prompts (every phase)
+
+| Prompt                                               | Purpose                                  |
+| ---------------------------------------------------- | ---------------------------------------- |
+| `Press Enter after you have reviewed the checklist…` | Acknowledge prereqs (first run only)     |
+| `Run "<phase>" now? (Y)es / (N)o skip / (Q)uit`      | Skip phase → manual instructions printed |
+
+---
+
+### Phase reference
+
+#### `prereqs`
+
+| You will be asked    | Have ready                                                 | Written to | One-time? |
+| -------------------- | ---------------------------------------------------------- | ---------- | --------- |
+| (none — checks only) | Node, npm; optional `supabase`, `aws`, `gh` CLIs installed | —          | —         |
+
+#### `identity` (optional)
+
+| You will be asked                                    | Have ready                                                  | Written to                      | One-time? |
+| ---------------------------------------------------- | ----------------------------------------------------------- | ------------------------------- | --------- |
+| `New display name:`                                  | Product name for rebrand                                    | Many files via `npm run rename` | —         |
+| `Also replace legal organization string? (y/N)`      | Whether to change legal name in `package.json` author, etc. | Same                            | —         |
+| `New legal organization name:`                       | If yes above                                                | Same                            | —         |
+| Rename may ask: stop local Supabase / proceed / quit | If `supabase start` is running in this clone                | —                               | —         |
+
+See [renaming.md](renaming.md). Tip: `npm run rename -- --dry-run` first.
+
+#### `supabase`
+
+| You will be asked                                                      | Have ready                                                                                                                                            | Written to                               | One-time?                                              |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------ |
+| Supabase PAT (paste / retry / skip) if CLI not logged in               | [Dashboard access token](https://supabase.com/dashboard/account/tokens) or `supabase login` in **Terminal.app** (IDE terminals sometimes break login) | `SUPABASE_ACCESS_TOKEN`                  | Token can be rotated; save for CI                      |
+| `Choose org index [0]:`                                                | Know which Supabase org owns your projects                                                                                                            | —                                        | —                                                      |
+| `Default region for new projects [us-east-1]:`                         | Region if creating projects                                                                                                                           | —                                        | —                                                      |
+| Per tier (`staging`, `production`, `preview`): `(c)reate or (s)elect?` | Whether to create new projects or pick existing                                                                                                       | —                                        | —                                                      |
+| `[tier] project name slug […]:`                                        | Slug if creating (default from app config)                                                                                                            | Project name in Supabase                 | —                                                      |
+| `[tier] Database password` (masked)                                    | Strong password or blank for random                                                                                                                   | `*_SUPABASE_DB_PASSWORD`, GitHub secrets | **Yes** — Supabase does not show the DB password again |
+| `[tier] Project index`                                                 | If selecting existing                                                                                                                                 | URLs, anon keys, refs in acc             | —                                                      |
+| GitHub: paste token for Actions                                        | Same PAT as above                                                                                                                                     | `SUPABASE_ACCESS_TOKEN` secret           | —                                                      |
+
+**Env keys (examples):** `STAGING_*`, `PRODUCTION_*`, `PREVIEW_*`, `PR_TESTING_*`, `SUPABASE_PREVIEW_*` → `.env.cloud.generated.local` / `.env.local`
+
+**Deep dive:** [supabase-staging-production-setup.md](supabase-staging-production-setup.md), [supabase-preview-setup.md](supabase-preview-setup.md)
+
+#### `aws`
+
+| You will be asked                                            | Have ready                                                                | Written to                   | One-time?      |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------- | ---------------------------- | -------------- |
+| AWS login fix: SSO / configure / re-check / skip             | IAM user or SSO profile with CloudFormation, S3, CloudFront, Route53, ACM | `AWS_*` for CI               | Keys rotatable |
+| `APEX domain (e.g. example.com):`                            | Your production apex                                                      | `PR_PREVIEW_DOMAIN`          | —              |
+| Route53 hosted zone (discovered or manual)                   | Public zone for apex in this AWS account                                  | `PR_PREVIEW_HOSTED_ZONE_ID`  | —              |
+| ACM certificate ARN **us-east-1** (apex + `*.apex`)          | Issued, DNS-validated cert                                                | `PR_PREVIEW_CERTIFICATE_ARN` | —              |
+| `CloudFormation stack name […]:`                             | Unique stack name                                                         | `PR_PREVIEW_STACK_NAME`      | —              |
+| `AWS region [us-east-1]:`                                    | Region for stack                                                          | `PR_PREVIEW_AWS_REGION`      | —              |
+| `Preview URL prefix [pr-]:`                                  | Path prefix for PR URLs                                                   | `PR_PREVIEW_PREFIX`          | —              |
+| Preflight: delete FAILED change sets?                        | —                                                                         | —                            | —              |
+| Conflict: skip / continue / **destructive bucket teardown**  | Understand risk to S3 buckets named `<apex>-prod`, `-staging`, `-deploy`  | —                            | Destructive    |
+| `ACKNOWLEDGE CLOUDFRONT RISK` / `PERMANENTLY DELETE BUCKETS` | Only if destructive path                                                  | —                            | —              |
+| `(D)eploy or (R)efresh outputs`                              | Existing healthy stack                                                    | `.env.aws.generated.local`   | —              |
+
+**Deep dive:** [pr-preview-setup.md](pr-preview-setup.md)
+
+#### `expo` (skipped if mobile disabled)
+
+| You will be asked                             | Have ready                                                     | Written to                                         | One-time?                                     |
+| --------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------- | --------------------------------------------- |
+| `Run eas-cli login now? (Y/n/q)`              | Expo account                                                   | Session local to machine                           | —                                             |
+| Link UUID / new project / skip                | Existing EAS project UUID or run `eas init`                    | `EXPO_PROJECT_ID`, `apps/mobile/.eas/project.json` | —                                             |
+| `Existing EAS project UUID` or read from init | UUID from [expo.dev](https://expo.dev)                         | `EXPO_PROJECT_ID`                                  | —                                             |
+| `EXPO_TOKEN` (paste, file, or env)            | [Access token](https://expo.dev/settings/access-tokens) for CI | GitHub `EXPO_TOKEN`                                | **Save when created** — treat like a password |
+
+#### `google` (skipped if mobile disabled)
+
+| You will be asked              | Have ready                        | Written to                   | One-time?                 |
+| ------------------------------ | --------------------------------- | ---------------------------- | ------------------------- |
+| `Path to google-services.json` | File from Firebase / Google Cloud | `GOOGLE_SERVICES_*` env keys | File can be re-downloaded |
+
+#### `write`
+
+| You will be asked | Have ready | Written to                                 | One-time? |
+| ----------------- | ---------- | ------------------------------------------ | --------- |
+| (automatic merge) | —          | `.env.cloud.generated.local`, `.env.local` | —         |
+
+#### `github`
+
+| You will be asked                             | Have ready                                     | Written to                                                                   | One-time?                             |
+| --------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------- |
+| `Run gh auth login now? (Y/n/q)`              | GitHub admin on **your** fork                  | `gh` session                                                                 | —                                     |
+| Enter missing CI values / path to dotenv file | Any keys still empty after earlier phases      | GitHub secrets & variables per [manifest](../scripts/lib/setup-manifest.mjs) | Masked for secrets                    |
+| Per missing manifest entry                    | Stripe keys, signing keys, etc. if not set yet | `gh secret set` / `gh variable set`                                          | Webhook secrets: **save at creation** |
+
+Full name list: [reference/github-actions-secrets.md](reference/github-actions-secrets.md).
+
+---
+
+## Post-wizard (not in setup-full)
+
+The wizard does **not** walk through these end-to-end. Plan time after `setup:full` completes.
+
+| Topic                    | Why separate                                                                                 | Doc                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| **Stripe billing**       | Keys may only appear during GitHub “missing CI” prompts; webhooks need per-project endpoints | [stripe-billing-setup.md](stripe-billing-setup.md)             |
+| **Google / Apple OAuth** | Supabase Auth providers + redirect URLs per environment                                      | [OAUTH.md](OAUTH.md)                                           |
+| **Lighthouse CI**        | Optional PR status checks                                                                    | [lighthouse-ci.md](lighthouse-ci.md) — `LHCI_GITHUB_APP_TOKEN` |
+| **Branch protection**    | Rules on `develop` / `main`                                                                  | [branch-protection-setup.md](branch-protection-setup.md)       |
+| **Project label bridge** | Optional org Project automation                                                              | [project-label-bridge.md](project-label-bridge.md)             |
+
+---
+
+## My values (copy locally — do not commit)
+
+Duplicate this block into a password manager or a **gitignored** note. Leave blanks until you generate each value.
+
+```text
+# Identity
+NEW_DISPLAY_NAME=
+NEW_LEGAL_NAME=
+
+# Supabase
+SUPABASE_ACCESS_TOKEN=
+SUPABASE_ORG_INDEX=
+SUPABASE_REGION=us-east-1
+PREVIEW_DB_PASSWORD=
+STAGING_DB_PASSWORD=
+PRODUCTION_DB_PASSWORD=
+
+# AWS
+APEX_DOMAIN=
+ROUTE53_HOSTED_ZONE_ID=
+ACM_CERTIFICATE_ARN_us-east-1=
+CF_STACK_NAME=
+AWS_REGION=us-east-1
+PR_PREVIEW_PREFIX=pr-
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+# Expo (if mobile enabled)
+EXPO_ACCOUNT=
+EXPO_PROJECT_ID=
+EXPO_TOKEN=
+
+# Google mobile (if applicable)
+GOOGLE_SERVICES_JSON_PATH=
+
+# Stripe (post-wizard)
+STAGING_STRIPE_SECRET_KEY=
+STAGING_STRIPE_WEBHOOK_SECRET=
+PRODUCTION_STRIPE_SECRET_KEY=
+PRODUCTION_STRIPE_WEBHOOK_SECRET=
+PREVIEW_STRIPE_SECRET_KEY=
+PREVIEW_STRIPE_WEBHOOK_SECRET=
+```
+
+---
+
+## Maintenance
+
+If you add or change prompts in `scripts/setup-full.mjs` or phase text in `scripts/lib/setup-manual-instructions.mjs`, update this file in the same PR. If you change `scripts/lib/setup-manifest.mjs`, run `npm run docs:actions-secrets` and commit [reference/github-actions-secrets.md](reference/github-actions-secrets.md).

--- a/docs/setup-prep-checklist.md
+++ b/docs/setup-prep-checklist.md
@@ -95,7 +95,7 @@ Do not commit filled-in values or `.env*` files with secrets.
 - `Choose org index [0]:`
 - `Default region for new projects [us-east-1]:`
 - Each tier: `(c)reate or (s)elect?` → slug and **database password** (masked), or project index
-- PAT again for GitHub Actions
+- After all tiers: **personal access token** for GitHub — **Press Enter** opens [account tokens](https://supabase.com/dashboard/account/tokens); create **personal access token** (`sbp_…`), expiry **90 days–1 year** (not project API keys); rotate later per [supabase-staging-production-setup.md § Rotating](supabase-staging-production-setup.md#rotating-supabase_access_token)
 
 **Saved as:** `STAGING_*`, `PRODUCTION_*`, `PREVIEW_*`, `PR_TESTING_*`, `SUPABASE_PREVIEW_*` → `.env.cloud.generated.local` / `.env.local`; `SUPABASE_ACCESS_TOKEN` on GitHub.
 
@@ -105,45 +105,67 @@ Do not commit filled-in values or `.env*` files with secrets.
 
 ### aws
 
-**Have ready:**
+**Have ready (before you answer Yes to the aws phase — wizard shows checklist + Enter):**
 
-- AWS credentials (IAM or SSO) for CloudFormation, S3, CloudFront, Route53, ACM
-- **Apex domain** (e.g. `example.com`)
-- Route 53 **public** hosted zone for that apex
-- ACM cert in **us-east-1** covering apex + `*.apex` (DNS validated)
-- Stack name, region, preview URL prefix (defaults are fine)
+1. **Route 53** — public hosted zone for your **apex** domain (NS delegated to Route 53 if registered elsewhere).
+2. **ACM (us-east-1 only)** — certificate **Issued** for **apex + \*.apex**, DNS-validated in Route 53 (required for CloudFront).
+3. **AWS CLI on this machine** — `aws sts get-caller-identity` works (`aws configure` keys or SSO); IAM can run CloudFormation, S3, CloudFront, Route 53.
+4. **CI keys (later)** — separate IAM **access key ID + secret** for GitHub Actions (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in **github** phase).
 
 **You will be asked:**
 
+- **Press Enter** when the checklist above is done
 - Fix AWS login if `sts get-caller-identity` fails
 - `APEX domain` → confirm or enter hosted zone ID + ACM ARN (auto-discovered when possible)
 - `CloudFormation stack name`, `AWS region`, `Preview URL prefix`
-- On conflicts: skip / continue / **destructive** bucket teardown (`ACKNOWLEDGE CLOUDFRONT RISK`, `PERMANENTLY DELETE BUCKETS`)
+- On conflicts: skip / continue / **destructive** bucket teardown
 - Existing stack: deploy or refresh outputs
 
 **Saved as:** `PR_PREVIEW_*` → `.env.aws.generated.local` + GitHub variables.
 
-**More:** [pr-preview-setup.md](pr-preview-setup.md)
+**More:** [pr-preview-setup.md § Before the AWS wizard phase](pr-preview-setup.md#before-the-aws-wizard-phase)
 
 ---
 
 ### expo (mobile only)
 
-**Have ready:** Expo account; optional existing EAS project UUID; [EXPO_TOKEN](https://expo.dev/settings/access-tokens) for CI (**save when created**).
+**Have ready (before Yes — wizard shows checklist + Enter):**
 
-**You will be asked:** `eas login`? → link UUID / `eas init` / skip → paste `EXPO_TOKEN`.
+1. **Expo account** — [expo.dev](https://expo.dev); use Terminal.app if `eas login` fails in the IDE.
+2. **EAS project** — existing **Project ID** (UUID) to **[l]ink**, or plan **[n]ew** `eas init`; template BeakerStack project id must be replaced.
+3. **Access token for CI** — create at [expo.dev/settings/access-tokens](https://expo.dev/settings/access-tokens) when prompted (**save when created**).
+
+**You will be asked:**
+
+- **Press Enter** when ready
+- `eas login`? (if `eas whoami` failed)
+- `[l] Link` / `[n] New` / `[s] Skip` / `[q] Quit` for EAS project
+- **Press Enter** → browser → paste **EXPO_TOKEN** (automation access token, not password)
 
 **Saved as:** `EXPO_PROJECT_ID`, `EXPO_TOKEN`, `EXPO_ACCOUNT` → env + GitHub.
 
+**More:** [MOBILE_BUILD_TESTING.md § Before the Expo wizard phase](MOBILE_BUILD_TESTING.md#before-the-expo-wizard-phase)
+
 ---
 
-### google (mobile only)
+### google (mobile only, optional)
 
-**Have ready:** path to `google-services.json` (Firebase / Google Cloud).
+**Have ready (before Yes — wizard shows checklist + Enter):**
 
-**You will be asked:** `Path to google-services.json`.
+1. **Optional** — skip entirely if you have no native mobile Google Sign-In yet.
+2. **Firebase** Android app with package name matching `apps/mobile` (`com.anonymous.beakerstack` unless renamed).
+3. **`google-services.json`** downloaded (Firebase → Project settings → Your apps → Android).
 
-**Saved as:** `GOOGLE_SERVICES_*` env keys.
+**You will be asked:**
+
+- **Press Enter** to continue (or skip with blank at path prompt)
+- `Path to google-services.json` — absolute or relative path; **Enter** = skip
+
+**Saved as:** `GOOGLE_SERVICES_*` → GitHub secrets in **github** phase.
+
+**Not this phase:** Supabase web Google OAuth → [OAUTH.md](OAUTH.md).
+
+**More:** [MOBILE_BUILD_TESTING.md § Before the Google wizard phase](MOBILE_BUILD_TESTING.md#before-the-google-wizard-phase)
 
 ---
 
@@ -157,19 +179,25 @@ Do not commit filled-in values or `.env*` files with secrets.
 
 ### github
 
-**Have ready:**
+**Have ready (before Yes — wizard shows checklist + Enter):**
 
-- `gh auth login` with permission to set Actions secrets on **your** repo
-- Any values still missing after earlier phases (Stripe, optional CloudFront signing keys, etc.)
-- Optional: dotenv file path to bulk-fill secrets
+1. **Your fork, not upstream** — clone the repo you own (`git remote -v` → your `owner/name`). The wizard runs `gh secret set` / `gh variable set` on **`gh repo view`** for this directory. If you cloned `Artificer-Innovations/BeakerStack` directly, you would be asked to type the repo name to confirm before touching the public template. Prefer **N** / `--skip-github` on upstream clones; sync on your fork instead.
+2. **[GitHub CLI](https://cli.github.com)** installed; `gh auth login`; **admin** on **your** fork (manage Actions secrets).
+3. **Values from earlier phases** in `.env.local` / `.env.cloud.generated.local` / `.env.aws.generated.local` (wizard merges them). Anything you skipped (AWS, Supabase, expo, google, Stripe) may be prompted now.
+4. **Web-only after skipping mobile?** Plan to set **`MOBILE_ENABLED=false`** when asked, or re-run with `--skip-mobile`.
+5. Optional: a **.env file** with remaining keys to paste in bulk.
 
 **You will be asked:**
 
-- `gh auth login`?
-- Enter missing CI values or path to a dotenv file
-- Per missing manifest key (masked when secret)
+- **Press Enter** when ready (or **N** to skip entire phase / use `--skip-github`)
+- **Target repo summary** + confirm (type full `owner/repo` if upstream template; otherwise Y/n)
+- `gh auth login`? if not authenticated
+- Enter missing CI values? → path to dotenv file → per-key prompts (secrets masked)
+- Then `gh secret set` / `gh variable set` for each resolved value (names only logged)
 
-**Saved as:** GitHub secrets/variables — see [reference/github-actions-secrets.md](reference/github-actions-secrets.md).
+**Saved as:** GitHub repository **secrets** and **variables** — full list: [reference/github-actions-secrets.md](reference/github-actions-secrets.md).
+
+**Still manual after sync:** Stripe webhooks per env, OAuth in Supabase — not pushed by this phase alone.
 
 ---
 

--- a/docs/setup-prep-checklist.md
+++ b/docs/setup-prep-checklist.md
@@ -1,180 +1,222 @@
 # Setup prep checklist
 
-Read this **before** you run the full cloud wizard (`npm run setup` → option **2**, or `npm run setup:full`). It maps what the setup script will ask for to what you should have ready—especially values you **cannot look up later** (database passwords, some webhook secrets, newly created tokens).
+Use this **before** `npm run setup:full` (or menu option **2**). Each phase below lists **have ready** then **you will be asked**.
 
-For a short account checklist, see [QUICKSTART.md §6.4](../QUICKSTART.md#64-full-cloud-checklist-accounts-and-dns). For GitHub Actions secret **names** only, see [reference/github-actions-secrets.md](reference/github-actions-secrets.md) (`npm run docs:actions-secrets` regenerates that table from `scripts/lib/setup-manifest.mjs`).
+| Also useful                             | Link                                                                         |
+| --------------------------------------- | ---------------------------------------------------------------------------- |
+| Account checklist (short)               | [QUICKSTART §6.4](../QUICKSTART.md#64-full-cloud-checklist-accounts-and-dns) |
+| GitHub secret **names**                 | [reference/github-actions-secrets.md](reference/github-actions-secrets.md)   |
+| Terminal banner (same topics, optional) | `npm run setup:full -- --guide=full`                                         |
 
-The wizard prints the same GitHub / Supabase / AWS / Expo prerequisites in the terminal by default (`--guide=full`). Use `--guide=brief` or `--brief-guide` if you already read this doc and want a shorter banner.
-
-**Do not commit** filled-in copies of this checklist or any `.env*` files with real secrets.
-
----
-
-## Track A — Local setup (default)
-
-`npm run setup` → **(1) Local** runs [`scripts/setup-local.sh`](../scripts/setup-local.sh). It does **not** ask interactive questions.
-
-### Prerequisites
-
-| Item                                         | Notes                                           |
-| -------------------------------------------- | ----------------------------------------------- |
-| Node.js **20** recommended (`>=18` required) | Matches CI                                      |
-| **npm** `>=9`                                | `npm install` at repo root                      |
-| **Docker Desktop** (or Docker Engine)        | For `supabase start`                            |
-| **Supabase CLI**                             | [Install](https://supabase.com/docs/guides/cli) |
-
-### After the script
-
-1. If `.env.local` was created from [env.example](../env.example), replace placeholder Supabase keys with output from `supabase status` (URL, anon key, service role key).
-2. Run `npm run dev:all` — web at http://localhost:5173.
-
-Stripe, OAuth, AWS, and remote Supabase tiers are **not** part of local setup; see [Track B](#track-b--full-cloud--ci) and [Post-wizard work](#post-wizard-not-in-setup-full).
+Do not commit filled-in values or `.env*` files with secrets.
 
 ---
 
-## Track B — Full cloud + CI
+## Pick a path
 
-**Time:** often **1–3 hours** of focused work (excluding DNS propagation).
-
-**Commands:** `npm run setup` → **(2)**, or `npm run setup:full` directly.
-
-**Phases (in order):** `prereqs` → `identity` → `supabase` → `aws` → `expo` → `google` → `write` → `github`
-
-Each phase (except `prereqs` and `write`) can be skipped with **(N)**; skipped phases print manual steps in the terminal. Resume with `--from=PHASE` (see [QUICKSTART.md §6.2](../QUICKSTART.md#62-full-interactive-bootstrap)).
-
-### Decisions to make before you start
-
-| Decision                        | When asked                                                       | Effect                                                                                                                                  |
-| ------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| **Enable mobile (Expo / EAS)?** | Start of full setup (`Enable mobile … [Y/n]`) or `--skip-mobile` | **No** → skips `expo` and `google` phases; set `MOBILE_ENABLED=false` for CI                                                            |
-| **Rebrand template?**           | `identity` phase or `--skip-rename`                              | Runs `npm run rename` (display name + optional legal org string)                                                                        |
-| **Supabase: create vs select**  | Per tier: `preview`, `staging`, `production`                     | Create → you set or accept a **DB password** (one-time if you do not save it)                                                           |
-| **AWS PR-preview stack**        | `aws` phase                                                      | Needs apex domain, Route53 zone, ACM cert in **us-east-1**; may prompt for destructive bucket teardown if a prior deploy left conflicts |
-| **Sync secrets to GitHub?**     | `github` phase or `--skip-github`                                | Needs `gh auth login` and repo admin                                                                                                    |
-
-### Global prompts (every phase)
-
-| Prompt                                               | Purpose                                  |
-| ---------------------------------------------------- | ---------------------------------------- |
-| `Press Enter after you have reviewed the checklist…` | Acknowledge prereqs (first run only)     |
-| `Run "<phase>" now? (Y)es / (N)o skip / (Q)uit`      | Skip phase → manual instructions printed |
+| Path                | Command                   | This doc                                                                |
+| ------------------- | ------------------------- | ----------------------------------------------------------------------- |
+| **Local** (default) | `npm run setup` → **(1)** | [Track A](#track-a--local) only                                         |
+| **Full cloud + CI** | `npm run setup:full`      | [Track B](#track-b--full-cloud) + [After the wizard](#after-the-wizard) |
 
 ---
 
-### Phase reference
+## Track A — Local
 
-#### `prereqs`
+**No wizard questions.** Needs Node 20 (or ≥18), npm, Docker, Supabase CLI → `npm install` → `npm run setup` → **(1)**.
 
-| You will be asked    | Have ready                                                 | Written to | One-time? |
-| -------------------- | ---------------------------------------------------------- | ---------- | --------- |
-| (none — checks only) | Node, npm; optional `supabase`, `aws`, `gh` CLIs installed | —          | —         |
-
-#### `identity` (optional)
-
-| You will be asked                                    | Have ready                                                  | Written to                      | One-time? |
-| ---------------------------------------------------- | ----------------------------------------------------------- | ------------------------------- | --------- |
-| `New display name:`                                  | Product name for rebrand                                    | Many files via `npm run rename` | —         |
-| `Also replace legal organization string? (y/N)`      | Whether to change legal name in `package.json` author, etc. | Same                            | —         |
-| `New legal organization name:`                       | If yes above                                                | Same                            | —         |
-| Rename may ask: stop local Supabase / proceed / quit | If `supabase start` is running in this clone                | —                               | —         |
-
-See [renaming.md](renaming.md). Tip: `npm run rename -- --dry-run` first.
-
-#### `supabase`
-
-| You will be asked                                                      | Have ready                                                                                                                                            | Written to                               | One-time?                                              |
-| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------ |
-| Supabase PAT (paste / retry / skip) if CLI not logged in               | [Dashboard access token](https://supabase.com/dashboard/account/tokens) or `supabase login` in **Terminal.app** (IDE terminals sometimes break login) | `SUPABASE_ACCESS_TOKEN`                  | Token can be rotated; save for CI                      |
-| `Choose org index [0]:`                                                | Know which Supabase org owns your projects                                                                                                            | —                                        | —                                                      |
-| `Default region for new projects [us-east-1]:`                         | Region if creating projects                                                                                                                           | —                                        | —                                                      |
-| Per tier (`staging`, `production`, `preview`): `(c)reate or (s)elect?` | Whether to create new projects or pick existing                                                                                                       | —                                        | —                                                      |
-| `[tier] project name slug […]:`                                        | Slug if creating (default from app config)                                                                                                            | Project name in Supabase                 | —                                                      |
-| `[tier] Database password` (masked)                                    | Strong password or blank for random                                                                                                                   | `*_SUPABASE_DB_PASSWORD`, GitHub secrets | **Yes** — Supabase does not show the DB password again |
-| `[tier] Project index`                                                 | If selecting existing                                                                                                                                 | URLs, anon keys, refs in acc             | —                                                      |
-| GitHub: paste token for Actions                                        | Same PAT as above                                                                                                                                     | `SUPABASE_ACCESS_TOKEN` secret           | —                                                      |
-
-**Env keys (examples):** `STAGING_*`, `PRODUCTION_*`, `PREVIEW_*`, `PR_TESTING_*`, `SUPABASE_PREVIEW_*` → `.env.cloud.generated.local` / `.env.local`
-
-**Deep dive:** [supabase-staging-production-setup.md](supabase-staging-production-setup.md), [supabase-preview-setup.md](supabase-preview-setup.md)
-
-#### `aws`
-
-| You will be asked                                            | Have ready                                                                | Written to                   | One-time?      |
-| ------------------------------------------------------------ | ------------------------------------------------------------------------- | ---------------------------- | -------------- |
-| AWS login fix: SSO / configure / re-check / skip             | IAM user or SSO profile with CloudFormation, S3, CloudFront, Route53, ACM | `AWS_*` for CI               | Keys rotatable |
-| `APEX domain (e.g. example.com):`                            | Your production apex                                                      | `PR_PREVIEW_DOMAIN`          | —              |
-| Route53 hosted zone (discovered or manual)                   | Public zone for apex in this AWS account                                  | `PR_PREVIEW_HOSTED_ZONE_ID`  | —              |
-| ACM certificate ARN **us-east-1** (apex + `*.apex`)          | Issued, DNS-validated cert                                                | `PR_PREVIEW_CERTIFICATE_ARN` | —              |
-| `CloudFormation stack name […]:`                             | Unique stack name                                                         | `PR_PREVIEW_STACK_NAME`      | —              |
-| `AWS region [us-east-1]:`                                    | Region for stack                                                          | `PR_PREVIEW_AWS_REGION`      | —              |
-| `Preview URL prefix [pr-]:`                                  | Path prefix for PR URLs                                                   | `PR_PREVIEW_PREFIX`          | —              |
-| Preflight: delete FAILED change sets?                        | —                                                                         | —                            | —              |
-| Conflict: skip / continue / **destructive bucket teardown**  | Understand risk to S3 buckets named `<apex>-prod`, `-staging`, `-deploy`  | —                            | Destructive    |
-| `ACKNOWLEDGE CLOUDFRONT RISK` / `PERMANENTLY DELETE BUCKETS` | Only if destructive path                                                  | —                            | —              |
-| `(D)eploy or (R)efresh outputs`                              | Existing healthy stack                                                    | `.env.aws.generated.local`   | —              |
-
-**Deep dive:** [pr-preview-setup.md](pr-preview-setup.md)
-
-#### `expo` (skipped if mobile disabled)
-
-| You will be asked                             | Have ready                                                     | Written to                                         | One-time?                                     |
-| --------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------- | --------------------------------------------- |
-| `Run eas-cli login now? (Y/n/q)`              | Expo account                                                   | Session local to machine                           | —                                             |
-| Link UUID / new project / skip                | Existing EAS project UUID or run `eas init`                    | `EXPO_PROJECT_ID`, `apps/mobile/.eas/project.json` | —                                             |
-| `Existing EAS project UUID` or read from init | UUID from [expo.dev](https://expo.dev)                         | `EXPO_PROJECT_ID`                                  | —                                             |
-| `EXPO_TOKEN` (paste, file, or env)            | [Access token](https://expo.dev/settings/access-tokens) for CI | GitHub `EXPO_TOKEN`                                | **Save when created** — treat like a password |
-
-#### `google` (skipped if mobile disabled)
-
-| You will be asked              | Have ready                        | Written to                   | One-time?                 |
-| ------------------------------ | --------------------------------- | ---------------------------- | ------------------------- |
-| `Path to google-services.json` | File from Firebase / Google Cloud | `GOOGLE_SERVICES_*` env keys | File can be re-downloaded |
-
-#### `write`
-
-| You will be asked | Have ready | Written to                                 | One-time? |
-| ----------------- | ---------- | ------------------------------------------ | --------- |
-| (automatic merge) | —          | `.env.cloud.generated.local`, `.env.local` | —         |
-
-#### `github`
-
-| You will be asked                             | Have ready                                     | Written to                                                                   | One-time?                             |
-| --------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------- |
-| `Run gh auth login now? (Y/n/q)`              | GitHub admin on **your** fork                  | `gh` session                                                                 | —                                     |
-| Enter missing CI values / path to dotenv file | Any keys still empty after earlier phases      | GitHub secrets & variables per [manifest](../scripts/lib/setup-manifest.mjs) | Masked for secrets                    |
-| Per missing manifest entry                    | Stripe keys, signing keys, etc. if not set yet | `gh secret set` / `gh variable set`                                          | Webhook secrets: **save at creation** |
-
-Full name list: [reference/github-actions-secrets.md](reference/github-actions-secrets.md).
+**After:** copy keys from `supabase status` into `.env.local` if placeholders remain → `npm run dev:all` (http://localhost:5173).
 
 ---
 
-## Post-wizard (not in setup-full)
+## Track B — Full cloud
 
-The wizard does **not** walk through these end-to-end. Plan time after `setup:full` completes.
+**Phases:** `prereqs` → `identity` → `supabase` → `aws` → `expo` → `google` → `write` → `github`  
+**Skip a phase:** answer **N** at `Run "<phase>" now?`  
+**Resume:** `npm run setup:full -- --from=supabase` (etc.)
 
-| Topic                    | Why separate                                                                                 | Doc                                                            |
-| ------------------------ | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| **Stripe billing**       | Keys may only appear during GitHub “missing CI” prompts; webhooks need per-project endpoints | [stripe-billing-setup.md](stripe-billing-setup.md)             |
-| **Google / Apple OAuth** | Supabase Auth providers + redirect URLs per environment                                      | [OAUTH.md](OAUTH.md)                                           |
-| **Lighthouse CI**        | Optional PR status checks                                                                    | [lighthouse-ci.md](lighthouse-ci.md) — `LHCI_GITHUB_APP_TOKEN` |
-| **Branch protection**    | Rules on `develop` / `main`                                                                  | [branch-protection-setup.md](branch-protection-setup.md)       |
-| **Project label bridge** | Optional org Project automation                                                              | [project-label-bridge.md](project-label-bridge.md)             |
+### Decide first
+
+| Question                | If **no** / skip                          |
+| ----------------------- | ----------------------------------------- |
+| Mobile (Expo / EAS)?    | `--skip-mobile` → skips `expo` + `google` |
+| Rebrand template?       | `--skip-rename` → skips `identity`        |
+| Push secrets with `gh`? | `--skip-github` → skips `github` sync     |
+
+### At a glance
+
+| Phase    | One-time secrets?                | Notes                                                  |
+| -------- | -------------------------------- | ------------------------------------------------------ |
+| prereqs  | —                                | CLI checks only                                        |
+| identity | —                                | Optional rename                                        |
+| supabase | **DB passwords**                 | 3 tiers: preview, staging, production                  |
+| aws      | —                                | May ask destructive bucket teardown                    |
+| expo     | **EXPO_TOKEN**                   | Skipped if no mobile                                   |
+| google   | —                                | `google-services.json` path                            |
+| write    | —                                | Merges `.env*` files                                   |
+| github   | Stripe webhooks, etc. if missing | May prompt `CLOUDFRONT_*` if you set up signed cookies |
+
+---
+
+### prereqs
+
+**Have ready:** Node, npm; install `supabase`, `aws`, `gh` if you want those phases automated.
+
+**You will be asked:** nothing (checks only) → Press Enter after reading this doc / banner.
+
+---
+
+### identity (optional)
+
+**Have ready:** new product display name; optional new legal org name ([renaming.md](renaming.md)).
+
+**You will be asked:**
+
+- `New display name:`
+- `Also replace legal organization string? (y/N)` → optional `New legal organization name:`
+- If local Supabase is running: stop / proceed / quit
+
+**Saved as:** repo-wide rename (many files).
+
+---
+
+### supabase
+
+**Have ready:**
+
+- Supabase account + org
+- [Personal access token](https://supabase.com/dashboard/account/tokens) (or `supabase login` in **Terminal.app** — IDE terminals often break Supabase login)
+- Per tier (**preview**, **staging**, **production**): create new vs pick existing project
+- **DB password per tier if creating** — Supabase will **not** show it again (**one-time**)
+
+**You will be asked:**
+
+- Paste PAT if CLI not logged in
+- `Choose org index [0]:`
+- `Default region for new projects [us-east-1]:`
+- Each tier: `(c)reate or (s)elect?` → slug and **database password** (masked), or project index
+- PAT again for GitHub Actions
+
+**Saved as:** `STAGING_*`, `PRODUCTION_*`, `PREVIEW_*`, `PR_TESTING_*`, `SUPABASE_PREVIEW_*` → `.env.cloud.generated.local` / `.env.local`; `SUPABASE_ACCESS_TOKEN` on GitHub.
+
+**More:** [supabase-staging-production-setup.md](supabase-staging-production-setup.md), [supabase-preview-setup.md](supabase-preview-setup.md)
+
+---
+
+### aws
+
+**Have ready:**
+
+- AWS credentials (IAM or SSO) for CloudFormation, S3, CloudFront, Route53, ACM
+- **Apex domain** (e.g. `example.com`)
+- Route 53 **public** hosted zone for that apex
+- ACM cert in **us-east-1** covering apex + `*.apex` (DNS validated)
+- Stack name, region, preview URL prefix (defaults are fine)
+
+**You will be asked:**
+
+- Fix AWS login if `sts get-caller-identity` fails
+- `APEX domain` → confirm or enter hosted zone ID + ACM ARN (auto-discovered when possible)
+- `CloudFormation stack name`, `AWS region`, `Preview URL prefix`
+- On conflicts: skip / continue / **destructive** bucket teardown (`ACKNOWLEDGE CLOUDFRONT RISK`, `PERMANENTLY DELETE BUCKETS`)
+- Existing stack: deploy or refresh outputs
+
+**Saved as:** `PR_PREVIEW_*` → `.env.aws.generated.local` + GitHub variables.
+
+**More:** [pr-preview-setup.md](pr-preview-setup.md)
+
+---
+
+### expo (mobile only)
+
+**Have ready:** Expo account; optional existing EAS project UUID; [EXPO_TOKEN](https://expo.dev/settings/access-tokens) for CI (**save when created**).
+
+**You will be asked:** `eas login`? → link UUID / `eas init` / skip → paste `EXPO_TOKEN`.
+
+**Saved as:** `EXPO_PROJECT_ID`, `EXPO_TOKEN`, `EXPO_ACCOUNT` → env + GitHub.
+
+---
+
+### google (mobile only)
+
+**Have ready:** path to `google-services.json` (Firebase / Google Cloud).
+
+**You will be asked:** `Path to google-services.json`.
+
+**Saved as:** `GOOGLE_SERVICES_*` env keys.
+
+---
+
+### write
+
+**Have ready:** nothing.
+
+**You will be asked:** nothing (automatic merge to `.env.cloud.generated.local` and `.env.local`).
+
+---
+
+### github
+
+**Have ready:**
+
+- `gh auth login` with permission to set Actions secrets on **your** repo
+- Any values still missing after earlier phases (Stripe, optional CloudFront signing keys, etc.)
+- Optional: dotenv file path to bulk-fill secrets
+
+**You will be asked:**
+
+- `gh auth login`?
+- Enter missing CI values or path to a dotenv file
+- Per missing manifest key (masked when secret)
+
+**Saved as:** GitHub secrets/variables — see [reference/github-actions-secrets.md](reference/github-actions-secrets.md).
+
+---
+
+## After the wizard
+
+Not run by `setup-full`. Do these when you need them.
+
+| Task                             | In wizard?                               | What to do                                                     |
+| -------------------------------- | ---------------------------------------- | -------------------------------------------------------------- |
+| **Stripe billing**               | Only if keys missing at `github` sync    | [stripe-billing-setup.md](stripe-billing-setup.md)             |
+| **Google / Apple OAuth**         | No                                       | [OAUTH.md](OAUTH.md)                                           |
+| **Signed-cookie preview access** | **No** — separate script after AWS stack | See below                                                      |
+| **Lighthouse CI**                | No                                       | [lighthouse-ci.md](lighthouse-ci.md) — `LHCI_GITHUB_APP_TOKEN` |
+| **Branch protection**            | No                                       | [branch-protection-setup.md](branch-protection-setup.md)       |
+
+### Signed-cookie access (optional)
+
+By default PR previews and staging are **public**. To gate them with CloudFront **signed cookies** (internal stakeholders click a bootstrap link from the PR comment):
+
+**Have ready:** AWS stack already deployed (`PR_PREVIEW_STACK_NAME`, `PR_PREVIEW_DOMAIN` from the `aws` phase); `aws`, `openssl`, `jq`, `gh` in PATH.
+
+**You will be asked (separate script, not `setup-full`):**
+
+```bash
+./scripts/pr-preview/setup-signed-cookies.sh \
+  --stack-name "${PR_PREVIEW_STACK_NAME}" \
+  --domain "${PR_PREVIEW_DOMAIN}" \
+  --enable-preview
+```
+
+Add `--enable-staging` to lock staging too. The script generates an RSA key pair, updates CloudFormation (`signed-cookies` mode), and sets GitHub secrets `CLOUDFRONT_SIGNING_KEY` + `CLOUDFRONT_SIGNING_KEY_ID`. Allow **5–10 minutes** for CloudFront to propagate.
+
+If you skip the script but add those secrets manually, the `github` phase may still prompt for them when syncing CI.
+
+**More:** [preview-access-control.md](preview-access-control.md)
 
 ---
 
 ## My values (copy locally — do not commit)
-
-Duplicate this block into a password manager or a **gitignored** note. Leave blanks until you generate each value.
 
 ```text
 # Identity
 NEW_DISPLAY_NAME=
 NEW_LEGAL_NAME=
 
-# Supabase
+# Supabase (one-time: DB passwords)
 SUPABASE_ACCESS_TOKEN=
-SUPABASE_ORG_INDEX=
-SUPABASE_REGION=us-east-1
 PREVIEW_DB_PASSWORD=
 STAGING_DB_PASSWORD=
 PRODUCTION_DB_PASSWORD=
@@ -184,30 +226,26 @@ APEX_DOMAIN=
 ROUTE53_HOSTED_ZONE_ID=
 ACM_CERTIFICATE_ARN_us-east-1=
 CF_STACK_NAME=
-AWS_REGION=us-east-1
 PR_PREVIEW_PREFIX=pr-
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
 
-# Expo (if mobile enabled)
-EXPO_ACCOUNT=
+# Expo (mobile)
 EXPO_PROJECT_ID=
 EXPO_TOKEN=
 
-# Google mobile (if applicable)
-GOOGLE_SERVICES_JSON_PATH=
+# AWS CI
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+# Signed cookies (optional, post-wizard)
+CLOUDFRONT_SIGNING_KEY_ID=
 
 # Stripe (post-wizard)
-STAGING_STRIPE_SECRET_KEY=
 STAGING_STRIPE_WEBHOOK_SECRET=
-PRODUCTION_STRIPE_SECRET_KEY=
 PRODUCTION_STRIPE_WEBHOOK_SECRET=
-PREVIEW_STRIPE_SECRET_KEY=
-PREVIEW_STRIPE_WEBHOOK_SECRET=
 ```
 
 ---
 
 ## Maintenance
 
-If you add or change prompts in `scripts/setup-full.mjs` or phase text in `scripts/lib/setup-manual-instructions.mjs`, update this file in the same PR. If you change `scripts/lib/setup-manifest.mjs`, run `npm run docs:actions-secrets` and commit [reference/github-actions-secrets.md](reference/github-actions-secrets.md).
+Wizard prompt changes → update this file. Manifest changes → `npm run docs:actions-secrets`.

--- a/docs/setup-prep-checklist.md
+++ b/docs/setup-prep-checklist.md
@@ -181,7 +181,7 @@ Do not commit filled-in values or `.env*` files with secrets.
 
 **Have ready (before Yes — wizard shows checklist + Enter):**
 
-1. **Your fork, not upstream** — clone the repo you own (`git remote -v` → your `owner/name`). The wizard runs `gh secret set` / `gh variable set` on **`gh repo view`** for this directory. If you cloned `Artificer-Innovations/BeakerStack` directly, you would be asked to type the repo name to confirm before touching the public template. Prefer **N** / `--skip-github` on upstream clones; sync on your fork instead.
+1. **Your fork, not upstream** — clone the repo you own (`git remote -v` → your `owner/name`). The wizard runs `gh secret set` / `gh variable set` on **`gh repo view`** for this directory. If you cloned `Artificer-Innovations/BeakerStack` directly, you will be asked to type the repo name to confirm before touching the public template. Prefer **N** / `--skip-github` on upstream clones; sync on your fork instead.
 2. **[GitHub CLI](https://cli.github.com)** installed; `gh auth login`; **admin** on **your** fork (manage Actions secrets).
 3. **Values from earlier phases** in `.env.local` / `.env.cloud.generated.local` / `.env.aws.generated.local` (wizard merges them). Anything you skipped (AWS, Supabase, expo, google, Stripe) may be prompted now.
 4. **Web-only after skipping mobile?** Plan to set **`MOBILE_ENABLED=false`** when asked, or re-run with `--skip-mobile`.
@@ -237,6 +237,8 @@ If you skip the script but add those secrets manually, the `github` phase may st
 ---
 
 ## My values (copy locally — do not commit)
+
+> Copy this block to a file **outside** this repo (e.g. `~/beakerstack-setup.txt`) before filling in values.
 
 ```text
 # Identity

--- a/docs/supabase-staging-production-setup.md
+++ b/docs/supabase-staging-production-setup.md
@@ -82,6 +82,25 @@ You should have saved these when creating the projects. If not:
 4. Copy the token (you can only see it once!)
    - This is `SUPABASE_ACCESS_TOKEN` (same token works for all projects)
 
+### Token type and expiry (for CI)
+
+Create a **personal access token** at [Account → Access Tokens](https://supabase.com/dashboard/account/tokens) — **not** a project **anon** / **service_role** key from **Project Settings → API**.
+
+| Setting    | Recommendation                                                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Type**   | Personal access token (starts with `sbp_`)                                                                                                       |
+| **Name**   | e.g. `beakerstack-github-actions`                                                                                                                |
+| **Expiry** | **90 days–1 year** for team repos (set a calendar reminder before it expires). Use **Never expire** only if you will still rotate on a schedule. |
+
+When the token expires, deploy workflows that run `supabase link` / `db push` / Edge deploys will fail until you rotate.
+
+### Rotating `SUPABASE_ACCESS_TOKEN`
+
+1. [Generate a new token](https://supabase.com/dashboard/account/tokens) (same type and expiry policy as above).
+2. Update the GitHub repository secret **`SUPABASE_ACCESS_TOKEN`** (Settings → Secrets and variables → Actions), or run `npm run setup:full -- --from=github` and paste when prompted.
+3. **Revoke** the old token on the Supabase tokens page after a successful staging deploy confirms the new secret works.
+4. Optional local copy: update `SUPABASE_ACCESS_TOKEN` in `.env.local` if you use the CLI against remote projects from your machine.
+
 ## Step 3: Apply Database Migrations
 
 Your CI/CD will automatically apply migrations on first deploy, but you can also do it manually to verify everything works.
@@ -332,5 +351,5 @@ Migrations are applied automatically - you don't need to run them manually!
 - Never commit secrets to git
 - Use Pro tier for production (not free tier)
 - Enable email confirmation in production
-- Regularly rotate access tokens and passwords
+- Regularly rotate access tokens and passwords — see [Rotating `SUPABASE_ACCESS_TOKEN`](#rotating-supabase_access_token) above
 - Use different OAuth credentials per environment (optional but recommended)

--- a/scripts/__tests__/setup-github-repo.test.mjs
+++ b/scripts/__tests__/setup-github-repo.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  BEAKERSTACK_TEMPLATE_GITHUB_REPO,
+  isBeakerstackTemplateRepo,
+  parseGithubOwnerRepoFromRemoteUrl,
+} from '../lib/setup-github-repo.mjs';
+
+test('parseGithubOwnerRepoFromRemoteUrl https', () => {
+  assert.equal(
+    parseGithubOwnerRepoFromRemoteUrl(
+      'https://github.com/Artificer-Innovations/BeakerStack.git'
+    ),
+    'Artificer-Innovations/BeakerStack'
+  );
+});
+
+test('parseGithubOwnerRepoFromRemoteUrl ssh', () => {
+  assert.equal(
+    parseGithubOwnerRepoFromRemoteUrl('git@github.com:myorg/my-app.git'),
+    'myorg/my-app'
+  );
+});
+
+test('isBeakerstackTemplateRepo', () => {
+  assert.ok(isBeakerstackTemplateRepo(BEAKERSTACK_TEMPLATE_GITHUB_REPO));
+  assert.ok(isBeakerstackTemplateRepo('artificer-innovations/beakerstack'));
+  assert.ok(!isBeakerstackTemplateRepo('myuser/BeakerStack'));
+});

--- a/scripts/__tests__/setup-github-repo.test.mjs
+++ b/scripts/__tests__/setup-github-repo.test.mjs
@@ -37,9 +37,16 @@ test('parseGithubOwnerRepoFromRemoteUrl empty', () => {
   assert.equal(parseGithubOwnerRepoFromRemoteUrl(null), '');
 });
 
-test('parseGithubOwnerRepoFromRemoteUrl non-github', () => {
+test('parseGithubOwnerRepoFromRemoteUrl non-github https', () => {
   assert.equal(
     parseGithubOwnerRepoFromRemoteUrl('https://gitlab.com/myorg/my-app.git'),
+    ''
+  );
+});
+
+test('parseGithubOwnerRepoFromRemoteUrl non-github ssh', () => {
+  assert.equal(
+    parseGithubOwnerRepoFromRemoteUrl('git@gitlab.com:myorg/my-app.git'),
     ''
   );
 });

--- a/scripts/__tests__/setup-github-repo.test.mjs
+++ b/scripts/__tests__/setup-github-repo.test.mjs
@@ -3,7 +3,9 @@ import test from 'node:test';
 
 import {
   BEAKERSTACK_TEMPLATE_GITHUB_REPO,
+  confirmGithubRepoSyncTarget,
   isBeakerstackTemplateRepo,
+  logGithubSyncTargetSummary,
   parseGithubOwnerRepoFromRemoteUrl,
 } from '../lib/setup-github-repo.mjs';
 
@@ -16,6 +18,13 @@ test('parseGithubOwnerRepoFromRemoteUrl https', () => {
   );
 });
 
+test('parseGithubOwnerRepoFromRemoteUrl https without .git', () => {
+  assert.equal(
+    parseGithubOwnerRepoFromRemoteUrl('https://github.com/myorg/my-app'),
+    'myorg/my-app'
+  );
+});
+
 test('parseGithubOwnerRepoFromRemoteUrl ssh', () => {
   assert.equal(
     parseGithubOwnerRepoFromRemoteUrl('git@github.com:myorg/my-app.git'),
@@ -23,8 +32,168 @@ test('parseGithubOwnerRepoFromRemoteUrl ssh', () => {
   );
 });
 
+test('parseGithubOwnerRepoFromRemoteUrl empty', () => {
+  assert.equal(parseGithubOwnerRepoFromRemoteUrl(''), '');
+  assert.equal(parseGithubOwnerRepoFromRemoteUrl(null), '');
+});
+
+test('parseGithubOwnerRepoFromRemoteUrl non-github', () => {
+  assert.equal(
+    parseGithubOwnerRepoFromRemoteUrl('https://gitlab.com/myorg/my-app.git'),
+    ''
+  );
+});
+
 test('isBeakerstackTemplateRepo', () => {
   assert.ok(isBeakerstackTemplateRepo(BEAKERSTACK_TEMPLATE_GITHUB_REPO));
   assert.ok(isBeakerstackTemplateRepo('artificer-innovations/beakerstack'));
   assert.ok(!isBeakerstackTemplateRepo('myuser/BeakerStack'));
+});
+
+test('confirmGithubRepoSyncTarget skips when repo missing', async () => {
+  const logs = { info: [], warn: [] };
+  const ok = await confirmGithubRepoSyncTarget(
+    { question: async () => 'y' },
+    {
+      logInfo: s => logs.info.push(s),
+      logWarn: s => logs.warn.push(s),
+    },
+    {
+      repo: '',
+      isFork: false,
+      parentRepo: '',
+      originRepo: '',
+      originUrl: '',
+      repoFromOverride: false,
+    },
+    { dryRun: false, interactive: true }
+  );
+  assert.equal(ok, false);
+  assert.ok(logs.warn.some(l => l.includes('No GitHub repository')));
+});
+
+test('confirmGithubRepoSyncTarget non-interactive skips without override', async () => {
+  const logs = { info: [], warn: [] };
+  const ok = await confirmGithubRepoSyncTarget(
+    { question: async () => 'y' },
+    {
+      logInfo: s => logs.info.push(s),
+      logWarn: s => logs.warn.push(s),
+    },
+    {
+      repo: 'myuser/BeakerStack',
+      isFork: true,
+      parentRepo: BEAKERSTACK_TEMPLATE_GITHUB_REPO,
+      originRepo: 'myuser/BeakerStack',
+      originUrl: 'https://github.com/myuser/BeakerStack.git',
+      repoFromOverride: false,
+    },
+    { dryRun: false, interactive: false }
+  );
+  assert.equal(ok, false);
+  assert.ok(logs.warn.some(l => l.includes('--github-repo')));
+});
+
+test('confirmGithubRepoSyncTarget non-interactive proceeds with --github-repo override', async () => {
+  const logs = { info: [], warn: [] };
+  const ok = await confirmGithubRepoSyncTarget(
+    { question: async () => 'y' },
+    {
+      logInfo: s => logs.info.push(s),
+      logWarn: s => logs.warn.push(s),
+    },
+    {
+      repo: 'myuser/BeakerStack',
+      isFork: false,
+      parentRepo: '',
+      originRepo: 'Artificer-Innovations/BeakerStack',
+      originUrl: '',
+      repoFromOverride: true,
+    },
+    { dryRun: false, interactive: false, githubRepoOverride: true }
+  );
+  assert.equal(ok, true);
+  assert.ok(
+    logs.info.some(l => l.includes('--github-repo=myuser/BeakerStack'))
+  );
+});
+
+test('confirmGithubRepoSyncTarget template rejects wrong confirmation', async () => {
+  const logs = { info: [], warn: [] };
+  const ok = await confirmGithubRepoSyncTarget(
+    { question: async () => 'wrong-name' },
+    {
+      logInfo: s => logs.info.push(s),
+      logWarn: s => logs.warn.push(s),
+    },
+    {
+      repo: BEAKERSTACK_TEMPLATE_GITHUB_REPO,
+      isFork: false,
+      parentRepo: '',
+      originRepo: BEAKERSTACK_TEMPLATE_GITHUB_REPO,
+      originUrl: '',
+      repoFromOverride: false,
+    },
+    { dryRun: false, interactive: true }
+  );
+  assert.equal(ok, false);
+  assert.ok(logs.info.some(l => l.includes('cancelled')));
+});
+
+test('confirmGithubRepoSyncTarget template accepts exact repo name', async () => {
+  const ok = await confirmGithubRepoSyncTarget(
+    { question: async () => BEAKERSTACK_TEMPLATE_GITHUB_REPO },
+    { logInfo: () => {}, logWarn: () => {} },
+    {
+      repo: BEAKERSTACK_TEMPLATE_GITHUB_REPO,
+      isFork: false,
+      parentRepo: '',
+      originRepo: BEAKERSTACK_TEMPLATE_GITHUB_REPO,
+      originUrl: '',
+      repoFromOverride: false,
+    },
+    { dryRun: false, interactive: true }
+  );
+  assert.equal(ok, true);
+});
+
+test('confirmGithubRepoSyncTarget Y/n accepts default', async () => {
+  const ok = await confirmGithubRepoSyncTarget(
+    { question: async () => 'y' },
+    {
+      logInfo: () => {},
+      logWarn: () => {},
+    },
+    {
+      repo: 'myuser/BeakerStack',
+      isFork: false,
+      parentRepo: '',
+      originRepo: 'myuser/BeakerStack',
+      originUrl: '',
+      repoFromOverride: false,
+    },
+    { dryRun: false, interactive: true }
+  );
+  assert.equal(ok, true);
+});
+
+test('logGithubSyncTargetSummary mentions override not gh repo view', () => {
+  const logs = { info: [], warn: [] };
+  logGithubSyncTargetSummary(
+    {
+      logInfo: s => logs.info.push(s),
+      logWarn: s => logs.warn.push(s),
+    },
+    {
+      repo: 'myuser/BeakerStack',
+      isFork: false,
+      parentRepo: '',
+      originRepo: 'Artificer-Innovations/BeakerStack',
+      originUrl: 'https://github.com/Artificer-Innovations/BeakerStack.git',
+      repoFromOverride: true,
+    },
+    { secretCount: 2, variableCount: 1 }
+  );
+  assert.ok(logs.info.some(l => l.includes('--github-repo override')));
+  assert.ok(!logs.warn.some(l => l.includes('gh repo view resolved')));
 });

--- a/scripts/lib/setup-expo-eas.mjs
+++ b/scripts/lib/setup-expo-eas.mjs
@@ -55,7 +55,10 @@ export async function clearTemplateEasLinkageFromMobileApp(ctx) {
 
   let next = text;
   // Strip updates block only when it references the template project on Expo's update server
-  const updatesRe = new RegExp(`\\n  updates:\\s*\\{[^}]*${esc}[^}]*\\},?`, 'm');
+  const updatesRe = new RegExp(
+    `\\n  updates:\\s*\\{[^}]*${esc}[^}]*\\},?`,
+    'm'
+  );
   if (updatesRe.test(next)) {
     next = next.replace(updatesRe, '\n');
     logInfo('Stripped template updates.url block from app.config.js.');
@@ -64,7 +67,7 @@ export async function clearTemplateEasLinkageFromMobileApp(ctx) {
   // Strip extra.eas.projectId block only for the known template UUID
   const easRe = new RegExp(
     `\\n\\s+eas:\\s*\\{\\s*\\n\\s+projectId:\\s*['"]${esc}['"],?\\s*\\n\\s+\\},?`,
-    'm',
+    'm'
   );
   if (easRe.test(next)) {
     next = next.replace(easRe, '\n');
@@ -81,12 +84,15 @@ export async function clearTemplateEasLinkageFromMobileApp(ctx) {
  * @param {string} [templateId]
  * @returns {string} first plausible EAS project UUID not equal to template, else ''
  */
-export function extractEasProjectIdFromCliOutput(text, templateId = TEMPLATE_EAS_PROJECT_ID) {
+export function extractEasProjectIdFromCliOutput(
+  text,
+  templateId = TEMPLATE_EAS_PROJECT_ID
+) {
   const combined = String(text || '');
   const re = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
   const found = combined.match(re) || [];
   const tid = templateId.toLowerCase();
-  const nonTemplate = found.filter((id) => id.toLowerCase() !== tid);
+  const nonTemplate = found.filter(id => id.toLowerCase() !== tid);
   if (nonTemplate.length) {
     return nonTemplate[nonTemplate.length - 1];
   }
@@ -94,10 +100,23 @@ export function extractEasProjectIdFromCliOutput(text, templateId = TEMPLATE_EAS
 }
 
 /**
+ * EAS init often exits 1 for app.config.js repos after printing the project id to add manually.
+ * @param {string} combined stdout + stderr from eas init
+ */
+export function easInitFailedDueToDynamicAppConfig(combined) {
+  return /dynamic app configuration|Cannot automatically write to dynamic config/i.test(
+    String(combined || '')
+  );
+}
+
+/**
  * @param {string} text
  * @param {string} [templateId]
  */
-export function tryRecoverEasProjectFromInitOutput(text, templateId = TEMPLATE_EAS_PROJECT_ID) {
+export function tryRecoverEasProjectFromInitOutput(
+  text,
+  templateId = TEMPLATE_EAS_PROJECT_ID
+) {
   const id = extractEasProjectIdFromCliOutput(text, templateId);
   if (id) return id;
   const raw = String(text || '');
@@ -105,7 +124,9 @@ export function tryRecoverEasProjectFromInitOutput(text, templateId = TEMPLATE_E
   if (m) return m[2];
   const m2 = raw.match(/projectId['"]?\s*[:=]\s*['"]?([0-9a-f-]{36})['"]?/i);
   if (m2) return m2[1];
-  const m3 = raw.match(/Linked[^\n]*\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i);
+  const m3 = raw.match(
+    /Linked[^\n]*\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i
+  );
   if (m3) return m3[1];
   return '';
 }
@@ -134,7 +155,9 @@ export async function readResolvedEasProjectId(ctx) {
   try {
     const text = await fs.readFile(appConfigPath, 'utf8');
     const tid = templateId.toLowerCase();
-    const m = text.match(/eas:\s*\{[^}]*projectId:\s*['"]([0-9a-f-]{36})['"]/is);
+    const m = text.match(
+      /eas:\s*\{[^}]*projectId:\s*['"]([0-9a-f-]{36})['"]/is
+    );
     if (m && m[1].toLowerCase() !== tid) return m[1];
     // Any projectId line (multiline-safe; eas init may format extra.eas differently).
     const re = /projectId:\s*['"]([0-9a-f-]{36})['"]/gi;
@@ -187,18 +210,27 @@ export async function integrateEasProjectIdForDynamicConfig(ctx, projectId) {
   let next = text;
 
   if (/updates:\s*\{/.test(next)) {
-    next = next.replace(/url:\s*['"]https:\/\/u\.expo\.dev\/[^'"]+['"]/i, `url: '${updatesUrl}'`);
+    next = next.replace(
+      /url:\s*['"]https:\/\/u\.expo\.dev\/[^'"]+['"]/i,
+      `url: '${updatesUrl}'`
+    );
   } else {
     next = next.replace(
       /(runtimeVersion:\s*\{[^}]+\},)(\s*\n)/,
-      `$1\n  updates: {\n    url: '${updatesUrl}',\n  },$2`,
+      `$1\n  updates: {\n    url: '${updatesUrl}',\n  },$2`
     );
   }
 
   if (/\beas:\s*\{/.test(next) && /projectId:\s*['"]/.test(next)) {
-    next = next.replace(/projectId:\s*['"][0-9a-f-]{36}['"]/i, `projectId: '${projectId}'`);
+    next = next.replace(
+      /projectId:\s*['"][0-9a-f-]{36}['"]/i,
+      `projectId: '${projectId}'`
+    );
   } else if (!/\beas:\s*\{/.test(next)) {
-    next = next.replace(/(extra:\s*\{)/, `$1\n    eas: {\n      projectId: '${projectId}',\n    },`);
+    next = next.replace(
+      /(extra:\s*\{)/,
+      `$1\n    eas: {\n      projectId: '${projectId}',\n    },`
+    );
   }
 
   await fs.writeFile(appConfigPath, next, 'utf8');
@@ -212,7 +244,7 @@ export async function integrateEasProjectIdForDynamicConfig(ctx, projectId) {
       projectId,
     },
     null,
-    2,
+    2
   );
   await fs.writeFile(projectJson, `${body}\n`, 'utf8');
   logInfo('Wrote apps/mobile/.eas/project.json.');
@@ -230,7 +262,9 @@ export async function applyEasProjectJsonToAcc(acc, projectJsonPath, ctx = {}) {
     const j = JSON.parse(raw);
     if (j.accountName) acc.EXPO_ACCOUNT = String(j.accountName);
     if (j.projectId) acc.EXPO_PROJECT_ID = String(j.projectId);
-    logInfo('Merged Expo account / project id from .eas/project.json into setup accumulator (values not printed).');
+    logInfo(
+      'Merged Expo account / project id from .eas/project.json into setup accumulator (values not printed).'
+    );
   } catch {
     /* */
   }
@@ -251,28 +285,44 @@ export function clearExpoKeysFromAcc(acc) {
  */
 export async function ensureNonTemplateEasProject(ctx) {
   const templateId = ctx.templateId || TEMPLATE_EAS_PROJECT_ID;
-  const resolved = await readResolvedEasProjectId({ repoRoot: ctx.repoRoot, templateId });
+  const resolved = await readResolvedEasProjectId({
+    repoRoot: ctx.repoRoot,
+    templateId,
+  });
   if (resolved && resolved.toLowerCase() !== templateId.toLowerCase()) {
     ctx.logInfo('Mobile app is already linked to a non-template EAS project.');
     if (!ctx.dryRun) {
       await applyEasProjectJsonToAcc(ctx.acc, easProjectJsonPath(ctx), ctx);
     } else {
-      ctx.logInfo('[dry-run] would read .eas/project.json into EXPO_* keys (skipped).');
+      ctx.logInfo(
+        '[dry-run] would read .eas/project.json into EXPO_* keys (skipped).'
+      );
     }
     return 'ok';
   }
 
-  ctx.logWarn('apps/mobile is still using the template EAS project id (or none). Clearing template linkage…');
+  ctx.logWarn(
+    'apps/mobile is still using the template EAS project id (or none). Clearing template linkage…'
+  );
   if (!ctx.dryRun) {
     await clearTemplateEasLinkageFromMobileApp(ctx);
   }
 
   for (let attempt = 0; attempt < 12; attempt += 1) {
-    const choice = (await ctx.question('[l] Link existing EAS project UUID, [n] New (eas init), [s] Skip, [q] Quit: '))
+    const choice = (
+      await ctx.question(
+        '[l] Link existing EAS project UUID, [n] New (eas init), [s] Skip, [q] Quit: '
+      )
+    )
       .trim()
       .toLowerCase();
 
-    if (choice === 'q' || choice === 'quit' || choice === 'exit' || choice === 'x') {
+    if (
+      choice === 'q' ||
+      choice === 'quit' ||
+      choice === 'exit' ||
+      choice === 'x'
+    ) {
       throw new SetupQuit();
     }
 
@@ -288,23 +338,51 @@ export async function ensureNonTemplateEasProject(ctx) {
         continue;
       }
       if (ctx.dryRun) {
-        ctx.logInfo(`[dry-run] would run: npx eas-cli init --id ${id} --force --non-interactive`);
+        ctx.logInfo(
+          `[dry-run] would run: npx eas-cli init --id ${id} --force --non-interactive`
+        );
         return 'ok';
       }
-      const args = ['--yes', 'eas-cli', 'init', '--id', id, '--force', '--non-interactive'];
-      const code = ctx.runEasOnTty(args);
-      if (code !== 0) {
-        ctx.logWarn(`eas init --id failed (exit ${code}).`);
-        continue;
+      const args = [
+        '--yes',
+        'eas-cli',
+        'init',
+        '--id',
+        id,
+        '--force',
+        '--non-interactive',
+      ];
+      const r = ctx.runEasCapture(args);
+      const combined = `${r.stdout || ''}\n${r.stderr || ''}`.trim();
+      const linkedOnDisk =
+        (
+          await readResolvedEasProjectId({ repoRoot: ctx.repoRoot, templateId })
+        ).toLowerCase() === id.toLowerCase();
+      if (
+        r.status === 0 ||
+        easInitFailedDueToDynamicAppConfig(combined) ||
+        linkedOnDisk
+      ) {
+        if (r.status !== 0) {
+          ctx.logInfo(
+            'eas init could not edit app.config.js (dynamic config) — BeakerStack will patch app.config.js and .eas/project.json.'
+          );
+        }
+        await integrateEasProjectIdForDynamicConfig(ctx, id);
+        await applyEasProjectJsonToAcc(ctx.acc, easProjectJsonPath(ctx), ctx);
+        return 'ok';
       }
-      await integrateEasProjectIdForDynamicConfig(ctx, id);
-      await applyEasProjectJsonToAcc(ctx.acc, easProjectJsonPath(ctx), ctx);
-      return 'ok';
+      ctx.logWarn(`eas init --id failed (exit ${r.status ?? 1}).`);
+      const tail = combined.slice(-1600);
+      if (tail) ctx.logWarn(`EAS CLI output (truncated):\n${tail}`);
+      continue;
     }
 
     if (choice === 'n' || choice === 'new') {
       if (ctx.dryRun) {
-        ctx.logInfo('[dry-run] would run: npx --yes eas-cli init --force --non-interactive');
+        ctx.logInfo(
+          '[dry-run] would run: npx --yes eas-cli init --force --non-interactive'
+        );
         return 'ok';
       }
       // First --yes is for npx only; eas init accepts --force and --non-interactive (no --yes on eas).
@@ -312,7 +390,10 @@ export async function ensureNonTemplateEasProject(ctx) {
       const r = ctx.runEasCapture(args);
       const combined = `${r.stdout || ''}\n${r.stderr || ''}`.trim();
       // eas init almost always writes apps/mobile/.eas/project.json; CLI output often has no UUID.
-      let id = await readResolvedEasProjectId({ repoRoot: ctx.repoRoot, templateId });
+      let id = await readResolvedEasProjectId({
+        repoRoot: ctx.repoRoot,
+        templateId,
+      });
       if (id && id.toLowerCase() === templateId.toLowerCase()) {
         id = '';
       }
@@ -321,22 +402,39 @@ export async function ensureNonTemplateEasProject(ctx) {
           tryRecoverEasProjectFromInitOutput(combined, templateId) ||
           extractEasProjectIdFromCliOutput(combined, templateId);
       }
-      if (!id && r.status !== 0) {
-        ctx.logWarn(`eas init exited with status ${r.status}. Check EXPO_TOKEN / auth (eas whoami).`);
+      if (
+        !id &&
+        r.status !== 0 &&
+        !easInitFailedDueToDynamicAppConfig(combined)
+      ) {
+        ctx.logWarn(
+          `eas init exited with status ${r.status}. Check EXPO_TOKEN / auth (eas whoami).`
+        );
         const tail = combined.slice(-1600);
         if (tail) ctx.logWarn(`EAS CLI output (truncated):\n${tail}`);
       }
-      if (!id) {
-        ctx.logWarn(
-          'No project id found on disk or in CLI output after eas init. If the project was created, copy its ID from https://expo.dev → your account → Projects → open the app → Project settings → Project ID.',
-        );
-        const pasted = (
-          await ctx.question('Project UUID (paste Project ID; blank to return to [l]/[n] menu): ')
-        ).trim();
-        id = tryRecoverEasProjectFromInitOutput(pasted, templateId) || extractEasProjectIdFromCliOutput(pasted, templateId);
+      if (!id && easInitFailedDueToDynamicAppConfig(combined)) {
+        id =
+          tryRecoverEasProjectFromInitOutput(combined, templateId) ||
+          extractEasProjectIdFromCliOutput(combined, templateId);
       }
       if (!id) {
-        ctx.logWarn('Still no project id; choose [l] to link an existing UUID or [n] to retry after fixing eas whoami / EXPO_TOKEN.');
+        ctx.logWarn(
+          'No project id found on disk or in CLI output after eas init. If the project was created, copy its ID from https://expo.dev → your account → Projects → open the app → Project settings → Project ID.'
+        );
+        const pasted = (
+          await ctx.question(
+            'Project UUID (paste Project ID; blank to return to [l]/[n] menu): '
+          )
+        ).trim();
+        id =
+          tryRecoverEasProjectFromInitOutput(pasted, templateId) ||
+          extractEasProjectIdFromCliOutput(pasted, templateId);
+      }
+      if (!id) {
+        ctx.logWarn(
+          'Still no project id; choose [l] to link an existing UUID or [n] to retry after fixing eas whoami / EXPO_TOKEN.'
+        );
         continue;
       }
       await integrateEasProjectIdForDynamicConfig(ctx, id);

--- a/scripts/lib/setup-expo-eas.mjs
+++ b/scripts/lib/setup-expo-eas.mjs
@@ -82,7 +82,7 @@ export async function clearTemplateEasLinkageFromMobileApp(ctx) {
 /**
  * @param {string} text
  * @param {string} [templateId]
- * @returns {string} first plausible EAS project UUID not equal to template, else ''
+ * @returns {string} last plausible EAS project UUID not equal to template, else ''
  */
 export function extractEasProjectIdFromCliOutput(
   text,
@@ -101,6 +101,9 @@ export function extractEasProjectIdFromCliOutput(
 
 /**
  * EAS init often exits 1 for app.config.js repos after printing the project id to add manually.
+ * Dynamic config (app.config.js) cannot be patched by eas init automatically — it prints the
+ * project id and exits non-zero; we detect that so integrateEasProjectIdForDynamicConfig can apply
+ * the patch.
  * @param {string} combined stdout + stderr from eas init
  */
 export function easInitFailedDueToDynamicAppConfig(combined) {

--- a/scripts/lib/setup-github-repo.mjs
+++ b/scripts/lib/setup-github-repo.mjs
@@ -49,7 +49,7 @@ export function getGitOriginRemoteUrl(repoRoot) {
 /**
  * @param {string} repoRoot
  * @param {string} [override] owner/name
- * @returns {{ repo: string; isFork: boolean; parentRepo: string; url: string; originRepo: string; originUrl: string }}
+ * @returns {{ repo: string; isFork: boolean; parentRepo: string; url: string; originRepo: string; originUrl: string; repoFromOverride: boolean }}
  */
 export function resolveGhRepoContext(repoRoot, override = '') {
   const originUrl = getGitOriginRemoteUrl(repoRoot);
@@ -63,6 +63,7 @@ export function resolveGhRepoContext(repoRoot, override = '') {
       url: `https://github.com/${forced}`,
       originRepo,
       originUrl,
+      repoFromOverride: true,
     };
   }
   const r = spawnSync(
@@ -89,6 +90,7 @@ export function resolveGhRepoContext(repoRoot, override = '') {
       url: originRepo ? `https://github.com/${originRepo}` : '',
       originRepo,
       originUrl,
+      repoFromOverride: false,
     };
   }
   try {
@@ -100,6 +102,7 @@ export function resolveGhRepoContext(repoRoot, override = '') {
       url: String(data.url || '').trim(),
       originRepo,
       originUrl,
+      repoFromOverride: false,
     };
   } catch {
     return {
@@ -109,6 +112,7 @@ export function resolveGhRepoContext(repoRoot, override = '') {
       url: originRepo ? `https://github.com/${originRepo}` : '',
       originRepo,
       originUrl,
+      repoFromOverride: false,
     };
   }
 }
@@ -131,12 +135,20 @@ export function isBeakerstackTemplateRepo(repo) {
  */
 export function logGithubSyncTargetSummary(ctx, ghCtx, counts) {
   const { logInfo, logWarn } = ctx;
-  const { repo, isFork, parentRepo, originRepo, originUrl } = ghCtx;
+  const { repo, isFork, parentRepo, originRepo, originUrl, repoFromOverride } =
+    ghCtx;
   logInfo('');
   logInfo('── GitHub sync target ──');
   logInfo(`  Repository: ${repo || '(unknown)'}`);
   if (originUrl) logInfo(`  git remote origin: ${originUrl}`);
-  if (originRepo && originRepo !== repo) {
+  if (repoFromOverride) {
+    logInfo(`  Target from --github-repo override (not gh repo view).`);
+    if (originRepo && originRepo !== repo) {
+      logWarn(
+        `  origin parses as ${originRepo}; secrets will still go to ${repo}.`
+      );
+    }
+  } else if (originRepo && originRepo !== repo) {
     logWarn(
       `  origin parses as ${originRepo} but gh repo view resolved ${repo}.`
     );
@@ -157,26 +169,33 @@ export function logGithubSyncTargetSummary(ctx, ghCtx, counts) {
  * @param {import('node:readline/promises').ReadLine} rl
  * @param {{ logInfo: (s: string) => void; logWarn: (s: string) => void }} ctx
  * @param {ReturnType<typeof resolveGhRepoContext>} ghCtx
- * @param {{ dryRun: boolean; interactive: boolean }} opts
+ * @param {{ dryRun: boolean; interactive: boolean; githubRepoOverride?: boolean }} opts
  * @returns {Promise<boolean>}
  */
 export async function confirmGithubRepoSyncTarget(rl, ctx, ghCtx, opts) {
   const { logInfo, logWarn } = ctx;
   const { repo, isFork, parentRepo } = ghCtx;
+  // Belt-and-suspenders: setup-full returns early when repo is missing; keep for direct callers/tests.
   if (!repo) {
     logWarn('No GitHub repository resolved; skipping secret sync.');
     return false;
   }
 
   if (!opts.interactive) {
+    if (opts.githubRepoOverride && !isBeakerstackTemplateRepo(repo)) {
+      logInfo(
+        `Non-interactive: proceeding with --github-repo=${repo} (explicit target; no Y/n prompt).`
+      );
+      return true;
+    }
     logWarn(
-      'Non-interactive terminal: skipping GitHub secret sync (cannot confirm target repo). Use a TTY, or set secrets manually on your fork.'
+      'Non-interactive terminal: skipping GitHub secret sync (cannot confirm target repo). Use a TTY, pass --github-repo=OWNER/NAME to target a fork without prompts, or set secrets manually.'
     );
     return false;
   }
 
   if (isBeakerstackTemplateRepo(repo)) {
-    logWarn('');
+    logInfo('');
     logWarn(
       '⚠  You are about to write CI secrets to the public BeakerStack template repository.'
     );
@@ -186,7 +205,7 @@ export async function confirmGithubRepoSyncTarget(rl, ctx, ghCtx, opts) {
     logWarn(
       '   Only continue here if you are intentionally configuring CI for the template repo itself.'
     );
-    logWarn('');
+    logInfo('');
     const typed = (
       await rl.question(`Type ${repo} to confirm (anything else cancels): `)
     ).trim();

--- a/scripts/lib/setup-github-repo.mjs
+++ b/scripts/lib/setup-github-repo.mjs
@@ -1,0 +1,217 @@
+/**
+ * Resolve and confirm the GitHub repository targeted by setup-full's github phase.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+/** Public template repo — adopters should sync secrets to their fork, not here. */
+export const BEAKERSTACK_TEMPLATE_GITHUB_REPO =
+  'Artificer-Innovations/BeakerStack';
+
+/**
+ * @param {string} url
+ * @returns {string} owner/repo or ''
+ */
+export function parseGithubOwnerRepoFromRemoteUrl(url) {
+  const raw = String(url || '').trim();
+  if (!raw) return '';
+  const ssh = /^git@github\.com:([^/]+\/[^/]+?)(?:\.git)?$/i.exec(raw);
+  if (ssh) return ssh[1];
+  try {
+    const u = new URL(raw);
+    if (!/github\.com$/i.test(u.hostname)) return '';
+    const parts = u.pathname.replace(/^\/+|\/+$/g, '').split('/');
+    if (parts.length < 2) return '';
+    const owner = parts[0];
+    let name = parts[1];
+    if (name.endsWith('.git')) name = name.slice(0, -4);
+    if (!owner || !name) return '';
+    return `${owner}/${name}`;
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * @param {string} repoRoot
+ * @returns {string}
+ */
+export function getGitOriginRemoteUrl(repoRoot) {
+  const r = spawnSync('git', ['remote', 'get-url', 'origin'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  if (r.status !== 0) return '';
+  return (r.stdout || '').trim();
+}
+
+/**
+ * @param {string} repoRoot
+ * @param {string} [override] owner/name
+ * @returns {{ repo: string; isFork: boolean; parentRepo: string; url: string; originRepo: string; originUrl: string }}
+ */
+export function resolveGhRepoContext(repoRoot, override = '') {
+  const originUrl = getGitOriginRemoteUrl(repoRoot);
+  const originRepo = parseGithubOwnerRepoFromRemoteUrl(originUrl);
+  const forced = String(override || '').trim();
+  if (forced) {
+    return {
+      repo: forced,
+      isFork: false,
+      parentRepo: '',
+      url: `https://github.com/${forced}`,
+      originRepo,
+      originUrl,
+    };
+  }
+  const r = spawnSync(
+    'gh',
+    [
+      'repo',
+      'view',
+      '--json',
+      'nameWithOwner,isFork,parent,url',
+      '-q',
+      '{repo: .nameWithOwner, fork: .isFork, parent: (.parent.nameWithOwner // ""), url: .url}',
+    ],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }
+  );
+  if (r.status !== 0) {
+    return {
+      repo: originRepo,
+      isFork: false,
+      parentRepo: '',
+      url: originRepo ? `https://github.com/${originRepo}` : '',
+      originRepo,
+      originUrl,
+    };
+  }
+  try {
+    const data = JSON.parse((r.stdout || '').trim() || '{}');
+    return {
+      repo: String(data.repo || originRepo || '').trim(),
+      isFork: Boolean(data.fork),
+      parentRepo: String(data.parent || '').trim(),
+      url: String(data.url || '').trim(),
+      originRepo,
+      originUrl,
+    };
+  } catch {
+    return {
+      repo: originRepo,
+      isFork: false,
+      parentRepo: '',
+      url: originRepo ? `https://github.com/${originRepo}` : '',
+      originRepo,
+      originUrl,
+    };
+  }
+}
+
+/**
+ * @param {string} repo
+ */
+export function isBeakerstackTemplateRepo(repo) {
+  return (
+    String(repo || '')
+      .trim()
+      .toLowerCase() === BEAKERSTACK_TEMPLATE_GITHUB_REPO.toLowerCase()
+  );
+}
+
+/**
+ * @param {{ logInfo: (s: string) => void; logWarn: (s: string) => void }} ctx
+ * @param {ReturnType<typeof resolveGhRepoContext>} ghCtx
+ * @param {{ secretCount: number; variableCount: number }} counts
+ */
+export function logGithubSyncTargetSummary(ctx, ghCtx, counts) {
+  const { logInfo, logWarn } = ctx;
+  const { repo, isFork, parentRepo, originRepo, originUrl } = ghCtx;
+  logInfo('');
+  logInfo('── GitHub sync target ──');
+  logInfo(`  Repository: ${repo || '(unknown)'}`);
+  if (originUrl) logInfo(`  git remote origin: ${originUrl}`);
+  if (originRepo && originRepo !== repo) {
+    logWarn(
+      `  origin parses as ${originRepo} but gh repo view resolved ${repo}.`
+    );
+  }
+  if (isFork && parentRepo) {
+    logInfo(`  Fork parent (secrets are NOT written here): ${parentRepo}`);
+  }
+  logInfo(
+    `  Will run: gh secret set <name> --repo ${repo} and gh variable set (values not printed).`
+  );
+  logInfo(
+    `  Payload: ${counts.secretCount} secret(s), ${counts.variableCount} variable(s).`
+  );
+  logInfo('');
+}
+
+/**
+ * @param {import('node:readline/promises').ReadLine} rl
+ * @param {{ logInfo: (s: string) => void; logWarn: (s: string) => void }} ctx
+ * @param {ReturnType<typeof resolveGhRepoContext>} ghCtx
+ * @param {{ dryRun: boolean; interactive: boolean }} opts
+ * @returns {Promise<boolean>}
+ */
+export async function confirmGithubRepoSyncTarget(rl, ctx, ghCtx, opts) {
+  const { logInfo, logWarn } = ctx;
+  const { repo, isFork, parentRepo } = ghCtx;
+  if (!repo) {
+    logWarn('No GitHub repository resolved; skipping secret sync.');
+    return false;
+  }
+
+  if (!opts.interactive) {
+    logWarn(
+      'Non-interactive terminal: skipping GitHub secret sync (cannot confirm target repo). Use a TTY, or set secrets manually on your fork.'
+    );
+    return false;
+  }
+
+  if (isBeakerstackTemplateRepo(repo)) {
+    logWarn('');
+    logWarn(
+      '⚠  You are about to write CI secrets to the public BeakerStack template repository.'
+    );
+    logWarn(
+      '   Adopters should use their own fork: fork on GitHub, clone YOUR repo, then run setup.'
+    );
+    logWarn(
+      '   Only continue here if you are intentionally configuring CI for the template repo itself.'
+    );
+    logWarn('');
+    const typed = (
+      await rl.question(`Type ${repo} to confirm (anything else cancels): `)
+    ).trim();
+    if (typed !== repo) {
+      logInfo('GitHub sync cancelled (repository name did not match).');
+      return false;
+    }
+    return true;
+  }
+
+  if (isFork && parentRepo) {
+    logInfo(`This clone is a fork; secrets go to ${repo}, not ${parentRepo}.`);
+  } else if (!isFork && parentRepo) {
+    logWarn(
+      `Unexpected fork metadata (parent ${parentRepo}); confirm the target repo carefully.`
+    );
+  }
+
+  const q = opts.dryRun
+    ? `[dry-run] Proceed with GitHub sync to ${repo}? (Y/n): `
+    : `Write secrets/variables to ${repo}? (Y/n): `;
+  const a = (await rl.question(q)).trim().toLowerCase();
+  if (a === 'n' || a === 'no') {
+    logInfo('GitHub sync skipped by user.');
+    return false;
+  }
+  return true;
+}

--- a/scripts/lib/setup-manual-instructions.mjs
+++ b/scripts/lib/setup-manual-instructions.mjs
@@ -226,32 +226,28 @@ const PHASE_INTROS = {
     body: [
       'Creates or selects remote Supabase projects and fetches anon + service keys (not printed).',
       'Prepare: Supabase CLI auth (PASTE token or SUPABASE_ACCESS_TOKEN; avoid embedded supabase login in IDE).',
-      'Also collects SUPABASE_ACCESS_TOKEN for GitHub Actions migrations.',
+      'After all tiers: prompts for account personal access token (SUPABASE_ACCESS_TOKEN) for GitHub Actions — not project anon/service keys.',
     ],
   },
   aws: {
     title: 'AWS CloudFormation (PR preview stack)',
     body: [
-      'Runs scripts/pr-preview/bootstrap-aws-stack.sh to create/update the shared preview/staging/prod buckets and CloudFront.',
-      'Prepare: apex domain in Route53; hosted zone ID and ACM certificate ARN in us-east-1 (apex + *.wildcard) can be auto-detected from the apex when they exist in the same AWS account.',
-      'AWS credentials with CloudFormation + S3 + CloudFront + IAM.',
-      'S3 bucket names are fixed as <apex>-prod, <apex>-staging, <apex>-deploy with Retain policies; if the stack was removed, leftover buckets block redeploy until you delete or empty them (CloudFormation early validation).',
-      'If preflight detects conflicts, setup can skip AWS, continue deploy anyway, delete FAILED change sets, or run an interactive teardown of only those three buckets (not CloudFront).',
+      'Creates/updates S3 + CloudFront for production, staging, and PR previews (bootstrap-aws-stack.sh).',
+      'If you choose Yes, a full prerequisites checklist prints next — Route53, ACM cert, AWS CLI login.',
     ],
   },
   expo: {
     title: 'Expo / EAS',
     body: [
-      'Ensures apps/mobile is not stuck on the template EAS project; may run eas init or link by UUID.',
-      'Prepare: Expo account; run eas login in Terminal.app if the IDE terminal fails; EXPO_TOKEN for CI.',
-      'After eas init, the script reads the new project id from apps/mobile/.eas/project.json (and app.config.js), not only from CLI text.',
+      'Links apps/mobile to your Expo project and collects EXPO_TOKEN for CI (EAS Update / Build).',
+      'If you choose Yes, a prerequisites checklist prints next — account, project link vs create, access token.',
     ],
   },
   google: {
     title: 'Google Services (optional)',
     body: [
-      'Imports GOOGLE_SERVICES_* from a google-services.json path for EAS/CI.',
-      'Prepare: path to the JSON file from Firebase / Google Cloud.',
+      'Imports google-services.json into GOOGLE_SERVICES_* keys for mobile CI (EAS Build / Update).',
+      'If you choose Yes, a prerequisites checklist prints next — optional; press Enter to skip.',
     ],
   },
   write: {
@@ -264,13 +260,296 @@ const PHASE_INTROS = {
   github: {
     title: 'GitHub Actions sync',
     body: [
-      'Uses gh to set repository secrets and variables from the manifest, merged with .env.local, .env.cloud.generated.local, and .env.aws.generated.local (wizard values override files on conflicts).',
-      'If required CI keys are still missing, you can enter them here (masked where appropriate) or point at a dotenv file; they are merged into the gitignored env files then pushed to GitHub.',
-      'Deploy and PR-preview workflows need AWS credentials, Supabase tokens/URLs, and PR preview domain/stack vars—not only Expo/Google; see docs/reference/github-actions-secrets.md (npm run docs:actions-secrets).',
-      'Prepare: gh auth login; repo permission to configure Actions secrets.',
+      'Pushes secrets/variables to GitHub from merged .env files + values collected earlier in this run.',
+      'If you choose Yes, a prerequisites checklist prints next — gh auth, what may still be missing, and prompts.',
     ],
   },
 };
+
+/**
+ * Prerequisites checklist shown after you confirm the AWS phase (before bootstrap runs).
+ * @param {LogCtx} ctx
+ */
+export function printAwsPhaseReadinessBriefing(ctx) {
+  const { logInfo } = ctx;
+  const doc = 'docs/pr-preview-setup.md#before-the-aws-wizard-phase';
+  logInfo('');
+  logInfo('── Before AWS bootstrap runs ──');
+  logInfo('');
+  logInfo(
+    'Complete these in the AWS account you will use (same account as `aws sts get-caller-identity`):'
+  );
+  logInfo('');
+  logInfo('1) Apex domain in Route 53');
+  logInfo(
+    '   • You own a domain (e.g. example.com) with a **public** Route 53 hosted zone for that apex.'
+  );
+  logInfo(
+    '   • If the domain is registered elsewhere, its NS records must point at that hosted zone.'
+  );
+  logInfo(
+    '   • The wizard can auto-detect the zone ID when it exists in this account.'
+  );
+  logInfo('');
+  logInfo('2) TLS certificate in ACM (required for CloudFront)');
+  logInfo(
+    '   • Region: **us-east-1 only** (CloudFront requirement — not your stack region choice).'
+  );
+  logInfo(
+    '   • Request a certificate for the **apex** and ***.apex** (e.g. example.com + *.example.com).'
+  );
+  logInfo(
+    '   • Validation: **DNS** in Route 53; status must be **Issued** before bootstrap.'
+  );
+  logInfo(
+    '   • The wizard can auto-detect the certificate ARN when one matches.'
+  );
+  logInfo('');
+  logInfo('3) AWS credentials on this machine (for the wizard right now)');
+  logInfo(
+    '   • `aws sts get-caller-identity` must succeed (IAM access keys via `aws configure`, or SSO profile).'
+  );
+  logInfo(
+    '   • IAM needs CloudFormation, S3, CloudFront, Route 53, ACM (read), and IAM pass-role for the stack.'
+  );
+  logInfo(
+    '   • This is separate from GitHub Actions deploy keys (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY in github phase).'
+  );
+  logInfo('');
+  logInfo('4) Know your apex domain name');
+  logInfo(
+    '   • You will type it when prompted (e.g. example.com — no https://, no path).'
+  );
+  logInfo('');
+  logInfo(
+    'During bootstrap the wizard may ask for stack name, region, and preview URL prefix (defaults are fine).'
+  );
+  logInfo(
+    'S3 buckets are named <apex>-prod, <apex>-staging, <apex>-deploy. Leftover buckets from a'
+  );
+  logInfo(
+    'removed stack can block redeploy; preflight may offer skip, continue, or destructive cleanup.'
+  );
+  logInfo('');
+  logInfo(`Full checklist and rotation notes: ${doc}`);
+  logInfo('');
+}
+
+/**
+ * Prerequisites checklist shown after you confirm the Expo phase.
+ * @param {LogCtx} ctx
+ */
+export function printExpoPhaseReadinessBriefing(ctx) {
+  const { logInfo } = ctx;
+  const doc = 'docs/MOBILE_BUILD_TESTING.md#before-the-expo-wizard-phase';
+  logInfo('');
+  logInfo('── Before Expo / EAS setup runs ──');
+  logInfo('');
+  logInfo(
+    'This phase wires apps/mobile to **your** Expo account (not the template BeakerStack project).'
+  );
+  logInfo('');
+  logInfo('1) Expo account');
+  logInfo('   • Sign in at https://expo.dev (personal or org account).');
+  logInfo(
+    '   • `eas whoami` should work after login — use Terminal.app if the IDE terminal hangs on `eas login`.'
+  );
+  logInfo('');
+  logInfo('2) EAS project for this app (choose during setup)');
+  logInfo(
+    '   • **[l] Link** — paste **Project ID** UUID (expo.dev → Projects → your app → Project settings).'
+  );
+  logInfo(
+    '   •     apps/mobile uses dynamic app.config.js — eas init may exit 1; setup patches projectId for you.'
+  );
+  logInfo(
+    '   • **[n] New** — run `eas init` to create a project under your account (wizard patches app.config.js + .eas/project.json).'
+  );
+  logInfo(
+    '   • **[s] Skip** — web-only repo or mobile later (`--skip-mobile` skips this entire phase).'
+  );
+  logInfo(
+    '   • The template EAS project id is removed — do not keep the shipped BeakerStack project id.'
+  );
+  logInfo('');
+  logInfo('3) Expo access token for GitHub Actions (end of this phase)');
+  logInfo(
+    '   • Type: **Access token** at https://expo.dev/settings/access-tokens (automation / CI — not your password).'
+  );
+  logInfo(
+    '   • Stored as GitHub secret **EXPO_TOKEN** for PR preview OTA, staging/production mobile deploys, and `eas build` in CI.'
+  );
+  logInfo(
+    '   • Also collected: **EXPO_PROJECT_ID**, **EXPO_ACCOUNT** (variable) from your linked project.'
+  );
+  logInfo(
+    '   • Copy the token when created — you cannot view it again. Rotate: see doc below.'
+  );
+  logInfo('');
+  logInfo(
+    '4) Optional next phase: google-services.json (Firebase) for native Google Sign-In in mobile CI builds.'
+  );
+  logInfo('');
+  logInfo(`Full checklist, scopes, and rotation: ${doc}`);
+  logInfo('');
+}
+
+/**
+ * Prerequisites checklist shown after you confirm the Google phase.
+ * @param {LogCtx} ctx
+ */
+export function printGooglePhaseReadinessBriefing(ctx) {
+  const { logInfo } = ctx;
+  const doc = 'docs/MOBILE_BUILD_TESTING.md#before-the-google-wizard-phase';
+  const oauthDoc = 'docs/OAUTH.md';
+  logInfo('');
+  logInfo('── Before Google Services import (optional) ──');
+  logInfo('');
+  logInfo(
+    'This phase is **optional**. Press Enter at the path prompt with blank to skip.'
+  );
+  logInfo('');
+  logInfo('What it is for:');
+  logInfo(
+    '  • **Native Android Google Sign-In** in mobile CI builds (EAS), not web OAuth in the browser.'
+  );
+  logInfo(
+    '  • The wizard reads **google-services.json** and stores **GOOGLE_SERVICES_*** for GitHub Actions.'
+  );
+  logInfo(
+    '  • Web + Supabase Google OAuth (client id/secret in Supabase) is separate — see OAUTH.md.'
+  );
+  logInfo('');
+  logInfo('If you want mobile Google Sign-In in CI, have ready:');
+  logInfo('');
+  logInfo('1) Firebase / Google Cloud project');
+  logInfo(
+    '   • https://console.firebase.google.com (or link an existing GCP project).'
+  );
+  logInfo(
+    '   • Register an **Android** app whose package name matches apps/mobile (see app.config.js `android.package`).'
+  );
+  logInfo(
+    '   • Default template package: **com.anonymous.beakerstack** (change after `npm run rename`).'
+  );
+  logInfo('');
+  logInfo('2) Download google-services.json');
+  logInfo(
+    '   • Firebase Console → your project → Project settings (gear) → **Your apps** → Android app'
+  );
+  logInfo(
+    '   • Download **google-services.json** (not the OAuth client JSON from GCP Credentials alone).'
+  );
+  logInfo(
+    '   • Know the full path on disk (e.g. ~/Downloads/google-services.json).'
+  );
+  logInfo('');
+  logInfo('3) What the wizard does');
+  logInfo(
+    '   • Parses the file and fills GOOGLE_SERVICES_PROJECT_*, *_CLIENT_ID, API_KEY, etc.'
+  );
+  logInfo(
+    '   • Values sync to GitHub in the **github** phase (optional secrets in manifest).'
+  );
+  logInfo(
+    '   • CI can regenerate apps/mobile/google-services.json from those secrets during deploy.'
+  );
+  logInfo('');
+  logInfo(
+    'Skip if: web-only repo, no native Google login yet, or you will add secrets later (`--from=google` or github phase).'
+  );
+  logInfo('');
+  logInfo(`Full steps: ${doc}`);
+  logInfo(`Supabase / web Google OAuth (different credentials): ${oauthDoc}`);
+  logInfo('');
+}
+
+/**
+ * Prerequisites checklist shown after you confirm the GitHub sync phase.
+ * @param {LogCtx} ctx
+ */
+export function printGithubPhaseReadinessBriefing(ctx) {
+  const { logInfo } = ctx;
+  const secretsDoc = 'docs/reference/github-actions-secrets.md';
+  logInfo('');
+  logInfo('── Before GitHub Actions sync ──');
+  logInfo('');
+  logInfo(
+    'This phase uses the **GitHub CLI** (`gh`) to set repository **secrets** and **variables**'
+  );
+  logInfo('from values in this wizard run and your gitignored .env files.');
+  logInfo('');
+  logInfo('1) Which repository? (read this before Yes)');
+  logInfo(
+    '   • Secrets go to **`gh repo view`** in this folder — usually `git remote origin`.'
+  );
+  logInfo(
+    '   • **Adopters:** fork BeakerStack, clone **your** fork, then sync — not the upstream template.'
+  );
+  logInfo(
+    '   • If `origin` is Artificer-Innovations/BeakerStack, you will get an extra type-to-confirm warning.'
+  );
+  logInfo('   • Override: `--github-repo=youruser/YourRepo`');
+  logInfo('');
+  logInfo('2) GitHub CLI + permissions');
+  logInfo(
+    '   • Install https://cli.github.com and run `gh auth login` (HTTPS or SSH).'
+  );
+  logInfo(
+    '   • Your user needs **admin** on the target repo (manage Actions secrets/variables).'
+  );
+  logInfo('');
+  logInfo('3) What gets synced (from earlier phases + .env files)');
+  logInfo('   • **Core:** SUPABASE_ACCESS_TOKEN');
+  logInfo(
+    '   • **AWS:** AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (+ optional session token)'
+  );
+  logInfo(
+    '   • **Supabase tiers:** staging / production / preview URLs, keys, project refs, DB passwords'
+  );
+  logInfo(
+    '   • **PR preview:** PR_PREVIEW_* domain, hosted zone, stack name, certificate ARN, etc.'
+  );
+  logInfo(
+    '   • **Stripe (if set):** STAGING_*, PRODUCTION_*, PREVIEW_* Stripe keys + webhook secrets'
+  );
+  logInfo(
+    '   • **Mobile (if enabled):** EXPO_TOKEN, EXPO_PROJECT_ID, EXPO_ACCOUNT, GOOGLE_SERVICES_*'
+  );
+  logInfo('');
+  logInfo('4) If you skipped earlier phases');
+  logInfo(
+    '   • Missing values are listed and you can paste them now (masked for secrets).'
+  );
+  logInfo(
+    '   • Skipped **expo** / **google** but still want web-only CI? Set MOBILE_ENABLED=false (variable) when prompted,'
+  );
+  logInfo('     or re-run setup with `--skip-mobile`.');
+  logInfo(
+    '   • Skipped **AWS** or **Supabase**? Add secrets manually later or re-run `--from=aws` / `--from=supabase`.'
+  );
+  logInfo('');
+  logInfo('5) During this phase');
+  logInfo('   • `gh auth login` if needed');
+  logInfo('   • Optional: path to a .env file to bulk-import missing keys');
+  logInfo(
+    '   • Per-key prompts for anything still missing → then `gh secret set` / `gh variable set`'
+  );
+  logInfo('   • Nothing is printed to the terminal except secret **names**');
+  logInfo('');
+  logInfo('6) Skip entirely');
+  logInfo(
+    '   • Answer **N** at Run github now, use `--skip-github`, or set secrets in GitHub Settings manually.'
+  );
+  logInfo('');
+  logInfo(
+    `Full name list (generated): ${secretsDoc}  (npm run docs:actions-secrets)`
+  );
+  logInfo(
+    'Post-wizard: Stripe webhooks, OAuth providers — docs/stripe-billing-setup.md, docs/OAUTH.md'
+  );
+  logInfo('');
+}
 
 /**
  * @param {LogCtx} ctx
@@ -376,19 +655,24 @@ export function printManualInstructions(ctx, phaseId) {
       logInfo('5. https://docs.expo.dev/eas/');
       break;
     case 'google':
-      logInfo('1. Obtain google-services.json from Firebase Console.');
       logInfo(
-        '2. Set each GOOGLE_SERVICES_* secret in GitHub or merge into .env.cloud.generated.local'
+        '1. Download google-services.json from Firebase (Android app matching your package name).'
+      );
+      logInfo('2. Re-run: npm run setup:full -- --from=google');
+      logInfo(
+        '3. Or set GOOGLE_SERVICES_* GitHub secrets manually — see docs/reference/github-actions-secrets.md'
+      );
+      logInfo(
+        '4. See docs/MOBILE_BUILD_TESTING.md#before-the-google-wizard-phase'
       );
       break;
     case 'github':
-      logInfo('1. gh auth login');
+      logInfo('1. gh auth login with admin on the repository');
       logInfo(
-        "2. For each name in scripts/lib/setup-manifest.mjs: printf '…' | gh secret set NAME --repo OWNER/REPO"
+        '2. Set secrets/variables per docs/reference/github-actions-secrets.md'
       );
-      logInfo(
-        '3. gh variable set for PR_PREVIEW_* and EXPO_ACCOUNT per workflows'
-      );
+      logInfo('3. Or re-run: npm run setup:full -- --from=github');
+      logInfo('4. See docs/setup-prep-checklist.md (github section)');
       break;
     default:
       logInfo('(No extra manual text for this phase.)');

--- a/scripts/lib/setup-manual-instructions.mjs
+++ b/scripts/lib/setup-manual-instructions.mjs
@@ -17,7 +17,12 @@ export class SetupQuit extends Error {
  * @returns {boolean}
  */
 export function isSetupQuit(e) {
-  return Boolean(e && typeof e === 'object' && 'name' in e && /** @type {{ name: string }} */ (e).name === 'SetupQuit');
+  return Boolean(
+    e &&
+    typeof e === 'object' &&
+    'name' in e &&
+    /** @type {{ name: string }} */ (e).name === 'SetupQuit'
+  );
 }
 
 const BANNER_W = 72;
@@ -41,13 +46,123 @@ function bannerRow(text) {
   return `+${' '.repeat(l)}${t}${' '.repeat(r)}+`;
 }
 
+/** @typedef {'full' | 'brief'} SetupGuideLevel */
+
+/**
+ * @param {(s: string) => void} logInfo
+ */
+function printExternalPrerequisites(logInfo) {
+  logInfo(
+    'Before you run this wizard — required outside the repo for a complete setup:'
+  );
+  logInfo('');
+  logInfo('  GitHub');
+  logInfo(
+    '    • Repo you can administer; branches develop (staging) and main (production) for workflows.'
+  );
+  logInfo(
+    '    • For automated secret sync: gh CLI + gh auth login with permission to set Actions secrets/variables.'
+  );
+  logInfo('');
+  logInfo('  Supabase');
+  logInfo(
+    '    • Account + organization; PAT (dashboard) or supabase login (prefer Terminal.app if IDE login fails).'
+  );
+  logInfo(
+    '    • Plan to create or link preview, staging, and production projects + database passwords for CI link.'
+  );
+  logInfo('');
+  logInfo('  AWS');
+  logInfo('    • Route 53 hosted zone for your apex domain.');
+  logInfo(
+    '    • ACM certificate in us-east-1 covering apex + *.yourdomain (DNS validated).'
+  );
+  logInfo(
+    '    • IAM credentials allowed to run the CloudFormation bootstrap (S3, CloudFront, etc.).'
+  );
+  logInfo('');
+  logInfo('  Expo');
+  logInfo(
+    '    • Expo account; EAS project for apps/mobile; EXPO_TOKEN from expo.dev for CI.'
+  );
+  logInfo('');
+  logInfo(
+    '  Google OAuth / Firebase (for Google sign-in + mobile native config)'
+  );
+  logInfo(
+    '    • OAuth clients (web/iOS/Android) and Supabase Auth Google provider + redirect URLs per env.'
+  );
+  logInfo(
+    '    • google-services.json path ready if you import mobile keys in this wizard.'
+  );
+}
+
+/**
+ * @param {(s: string) => void} logInfo
+ * @param {{ brief: boolean }} opts
+ */
+function printGuidePointers(logInfo, opts) {
+  if (opts.brief) {
+    logInfo(
+      'Before you run this wizard — read docs/setup-prep-checklist.md (prompts, one-time secrets, post-wizard work).'
+    );
+    logInfo(
+      'For the in-terminal GitHub / Supabase / AWS / Expo checklist: npm run setup:full -- --guide=full'
+    );
+    logInfo(
+      'Short account checklist: QUICKSTART.md §6.4. Actions secret names: docs/reference/github-actions-secrets.md'
+    );
+  } else {
+    printExternalPrerequisites(logInfo);
+    logInfo('');
+    logInfo(
+      'Also see docs/setup-prep-checklist.md for every wizard prompt and one-time secrets.'
+    );
+    logInfo(
+      'Short account checklist: QUICKSTART.md §6.4. Actions secret names: docs/reference/github-actions-secrets.md'
+    );
+  }
+}
+
+/**
+ * @param {(s: string) => void} logInfo
+ */
+function printWizardCapabilities(logInfo) {
+  logInfo('-'.repeat(72));
+  logInfo('This wizard can:');
+  logInfo(
+    '  • Optionally rebrand the template (display name + legal organization).'
+  );
+  logInfo(
+    '  • Create or link Supabase projects and write keys to gitignored .env files.'
+  );
+  logInfo('  • Optionally deploy the AWS PR-preview CloudFormation stack.');
+  logInfo(
+    '  • Link or create an Expo (EAS) project and collect EXPO_TOKEN for CI.'
+  );
+  logInfo('  • Optionally import google-services.json keys for mobile CI.');
+  logInfo('  • Merge results into .env.local / .env.cloud.generated.local.');
+  logInfo('  • Optionally push secrets and variables to GitHub Actions (gh).');
+  logInfo('');
+  logInfo(
+    'Also read: README.md, docs/pr-preview-setup.md, docs/supabase-staging-production-setup.md, docs/renaming.md'
+  );
+  logInfo('');
+  logInfo(
+    'If you skip every automated step, env files may stay empty until you complete manual steps.'
+  );
+  logInfo('-'.repeat(72));
+}
+
 /**
  * @param {LogCtx} ctx
- * @param {{ resumeFrom?: string; variant?: 'menu' }} [opts]
+ * @param {{ resumeFrom?: string; variant?: 'menu'; guide?: SetupGuideLevel }} [opts]
  */
 export function printIntroBanner(ctx, opts = {}) {
   const resume = opts.resumeFrom;
   const isMenu = opts.variant === 'menu';
+  const guide = opts.guide ?? (resume ? 'brief' : 'full');
+  const brief = guide === 'brief';
   const { logInfo } = ctx;
 
   console.log('');
@@ -80,47 +195,12 @@ export function printIntroBanner(ctx, opts = {}) {
   console.log('');
 
   logInfo(
-    'CI note: GitHub Actions only reads repository secrets (e.g. SUPABASE_ACCESS_TOKEN, EXPO_TOKEN, AWS keys)—not your local supabase/aws/eas CLI logins.',
+    'CI note: GitHub Actions only reads repository secrets (e.g. SUPABASE_ACCESS_TOKEN, EXPO_TOKEN, AWS keys)—not your local supabase/aws/eas CLI logins.'
   );
   logInfo('');
-  logInfo('Before you run this wizard — required outside the repo for a complete setup:');
+  printGuidePointers(logInfo, { brief });
   logInfo('');
-  logInfo('  GitHub');
-  logInfo('    • Repo you can administer; branches develop (staging) and main (production) for workflows.');
-  logInfo('    • For automated secret sync: gh CLI + gh auth login with permission to set Actions secrets/variables.');
-  logInfo('');
-  logInfo('  Supabase');
-  logInfo('    • Account + organization; PAT (dashboard) or supabase login (prefer Terminal.app if IDE login fails).');
-  logInfo('    • Plan to create or link preview, staging, and production projects + database passwords for CI link.');
-  logInfo('');
-  logInfo('  AWS');
-  logInfo('    • Route 53 hosted zone for your apex domain.');
-  logInfo('    • ACM certificate in us-east-1 covering apex + *.yourdomain (DNS validated).');
-  logInfo('    • IAM credentials allowed to run the CloudFormation bootstrap (S3, CloudFront, etc.).');
-  logInfo('');
-  logInfo('  Expo');
-  logInfo('    • Expo account; EAS project for apps/mobile; EXPO_TOKEN from expo.dev for CI.');
-  logInfo('');
-  logInfo('  Google OAuth / Firebase (for Google sign-in + mobile native config)');
-  logInfo('    • OAuth clients (web/iOS/Android) and Supabase Auth Google provider + redirect URLs per env.');
-  logInfo('    • google-services.json path ready if you import mobile keys in this wizard.');
-  logInfo('');
-  logInfo('Skim QUICKSTART.md; Actions names table: docs/reference/github-actions-secrets.md (npm run docs:actions-secrets).');
-  logInfo('');
-  logInfo('-'.repeat(72));
-  logInfo('This wizard can:');
-  logInfo('  • Optionally rebrand the template (display name + legal organization).');
-  logInfo('  • Create or link Supabase projects and write keys to gitignored .env files.');
-  logInfo('  • Optionally deploy the AWS PR-preview CloudFormation stack.');
-  logInfo('  • Link or create an Expo (EAS) project and collect EXPO_TOKEN for CI.');
-  logInfo('  • Optionally import google-services.json keys for mobile CI.');
-  logInfo('  • Merge results into .env.local / .env.cloud.generated.local.');
-  logInfo('  • Optionally push secrets and variables to GitHub Actions (gh).');
-  logInfo('');
-  logInfo('Also read: README.md, docs/pr-preview-setup.md, docs/supabase-staging-production-setup.md, docs/renaming.md');
-  logInfo('');
-  logInfo('If you skip every automated step, env files may stay empty until you complete manual steps.');
-  logInfo('-'.repeat(72));
+  printWizardCapabilities(logInfo);
   logInfo('');
 }
 
@@ -169,11 +249,17 @@ const PHASE_INTROS = {
   },
   google: {
     title: 'Google Services (optional)',
-    body: ['Imports GOOGLE_SERVICES_* from a google-services.json path for EAS/CI.', 'Prepare: path to the JSON file from Firebase / Google Cloud.'],
+    body: [
+      'Imports GOOGLE_SERVICES_* from a google-services.json path for EAS/CI.',
+      'Prepare: path to the JSON file from Firebase / Google Cloud.',
+    ],
   },
   write: {
     title: 'Write env files',
-    body: ['Merges collected keys into .env.cloud.generated.local and .env.local (gitignored).', 'No preparation.'],
+    body: [
+      'Merges collected keys into .env.cloud.generated.local and .env.local (gitignored).',
+      'No preparation.',
+    ],
   },
   github: {
     title: 'GitHub Actions sync',
@@ -209,7 +295,9 @@ export function printPhaseIntro(ctx, phaseId) {
  */
 export async function confirmRunPhase(rl, phaseLabel) {
   const a = (
-    await rl.question(`Run "${phaseLabel}" now? (Y)es / (N)o skip / (Q)uit [Y]: `)
+    await rl.question(
+      `Run "${phaseLabel}" now? (Y)es / (N)o skip / (Q)uit [Y]: `
+    )
   )
     .trim()
     .toLowerCase();
@@ -233,46 +321,74 @@ export function printManualInstructions(ctx, phaseId) {
   logInfo(`══ Manual steps (you skipped: ${phaseId}) ══`);
   switch (phaseId) {
     case 'identity':
-      logInfo('1. Run: npm run rename -- --from "<display-from>" --to "<display-to>" \\');
+      logInfo(
+        '1. Run: npm run rename -- --from "<display-from>" --to "<display-to>" \\'
+      );
       logInfo('     --from-legal "<legal-from>" --to-legal "<legal-to>"');
       logInfo('2. Add --dry-run first to preview, then rerun without it.');
       logInfo('3. See docs/renaming.md');
       break;
     case 'supabase':
-      logInfo('1. supabase login (use Terminal.app or: supabase login --token <PAT>)');
-      logInfo('2. Create/link staging, production, and preview projects in the Supabase dashboard.');
-      logInfo('3. Set STAGING_*, PRODUCTION_*, PREVIEW_*, PR_TESTING_*, SUPABASE_PREVIEW_* in .env.local / .env.cloud.generated.local');
-      logInfo('4. Set GitHub secret SUPABASE_ACCESS_TOKEN and project refs/passwords per .github/workflows/*.yml');
-      logInfo('5. supabase link + supabase db push per environment; see docs/supabase-staging-production-setup.md');
+      logInfo(
+        '1. supabase login (use Terminal.app or: supabase login --token <PAT>)'
+      );
+      logInfo(
+        '2. Create/link staging, production, and preview projects in the Supabase dashboard.'
+      );
+      logInfo(
+        '3. Set STAGING_*, PRODUCTION_*, PREVIEW_*, PR_TESTING_*, SUPABASE_PREVIEW_* in .env.local / .env.cloud.generated.local'
+      );
+      logInfo(
+        '4. Set GitHub secret SUPABASE_ACCESS_TOKEN and project refs/passwords per .github/workflows/*.yml'
+      );
+      logInfo(
+        '5. supabase link + supabase db push per environment; see docs/supabase-staging-production-setup.md'
+      );
       break;
     case 'aws':
-      logInfo('1. Issue ACM cert in us-east-1 (apex + wildcard); validate in Route53.');
+      logInfo(
+        '1. Issue ACM cert in us-east-1 (apex + wildcard); validate in Route53.'
+      );
       logInfo('2. Run from repo root:');
       logInfo(
-        `   bash scripts/pr-preview/bootstrap-aws-stack.sh --domain YOUR_DOMAIN --hosted-zone-id ZONE \\`,
+        `   bash scripts/pr-preview/bootstrap-aws-stack.sh --domain YOUR_DOMAIN --hosted-zone-id ZONE \\`
       );
       logInfo(
-        `     --certificate-arn arn:aws:acm:us-east-1:…:certificate/… --stack-name beakerstack-pr-preview --region us-east-1 \\`,
+        `     --certificate-arn arn:aws:acm:us-east-1:…:certificate/… --stack-name beakerstack-pr-preview --region us-east-1 \\`
       );
-      logInfo(`     --preview-prefix pr- --env-file ${R}/.env.aws.generated.local`);
-      logInfo('3. Map stack outputs to PR_PREVIEW_* / bucket env vars; set GitHub vars per workflows.');
+      logInfo(
+        `     --preview-prefix pr- --env-file ${R}/.env.aws.generated.local`
+      );
+      logInfo(
+        '3. Map stack outputs to PR_PREVIEW_* / bucket env vars; set GitHub vars per workflows.'
+      );
       logInfo('4. See docs/pr-preview-setup.md');
       break;
     case 'expo':
       logInfo('1. cd apps/mobile && npx eas-cli login');
       logInfo('2. npx eas-cli init (or link an existing project UUID)');
-      logInfo('3. If dynamic app.config.js: set extra.eas.projectId, updates.url, and .eas/project.json');
-      logInfo('4. Set EXPO_TOKEN, EXPO_PROJECT_ID, EXPO_ACCOUNT for GitHub (see workflows)');
+      logInfo(
+        '3. If dynamic app.config.js: set extra.eas.projectId, updates.url, and .eas/project.json'
+      );
+      logInfo(
+        '4. Set EXPO_TOKEN, EXPO_PROJECT_ID, EXPO_ACCOUNT for GitHub (see workflows)'
+      );
       logInfo('5. https://docs.expo.dev/eas/');
       break;
     case 'google':
       logInfo('1. Obtain google-services.json from Firebase Console.');
-      logInfo('2. Set each GOOGLE_SERVICES_* secret in GitHub or merge into .env.cloud.generated.local');
+      logInfo(
+        '2. Set each GOOGLE_SERVICES_* secret in GitHub or merge into .env.cloud.generated.local'
+      );
       break;
     case 'github':
       logInfo('1. gh auth login');
-      logInfo('2. For each name in scripts/lib/setup-manifest.mjs: printf \'…\' | gh secret set NAME --repo OWNER/REPO');
-      logInfo('3. gh variable set for PR_PREVIEW_* and EXPO_ACCOUNT per workflows');
+      logInfo(
+        "2. For each name in scripts/lib/setup-manifest.mjs: printf '…' | gh secret set NAME --repo OWNER/REPO"
+      );
+      logInfo(
+        '3. gh variable set for PR_PREVIEW_* and EXPO_ACCOUNT per workflows'
+      );
       break;
     default:
       logInfo('(No extra manual text for this phase.)');

--- a/scripts/lib/setup-manual-instructions.mjs
+++ b/scripts/lib/setup-manual-instructions.mjs
@@ -145,7 +145,7 @@ function printWizardCapabilities(logInfo) {
   logInfo('  • Optionally push secrets and variables to GitHub Actions (gh).');
   logInfo('');
   logInfo(
-    'Also read: README.md, docs/pr-preview-setup.md, docs/supabase-staging-production-setup.md, docs/renaming.md'
+    'Also read: README.md, docs/pr-preview-setup.md, docs/preview-access-control.md (optional signed cookies), docs/renaming.md'
   );
   logInfo('');
   logInfo(

--- a/scripts/pr-preview/teardown-preview-domain-buckets.sh
+++ b/scripts/pr-preview/teardown-preview-domain-buckets.sh
@@ -48,23 +48,49 @@ build_aws() {
   fi
 }
 
+# Prefix for `env VAR=val command` — never sets AWS_PROFILE to an empty string (breaks AWS CLI).
+run_with_aws_env() {
+  if [[ -n "${AWS_PROFILE:-}" ]]; then
+    env AWS_REGION="${AWS_REGION}" AWS_PROFILE="${AWS_PROFILE}" "$@"
+  else
+    env -u AWS_PROFILE AWS_REGION="${AWS_REGION}" "$@"
+  fi
+}
+
 cloudfront_conflicts_for_domain() {
-  DOMAIN_NAME="${DOMAIN_NAME}" python3 <<'PY'
-import json, os, subprocess, sys
+  run_with_aws_env \
+    DOMAIN_NAME="${DOMAIN_NAME}" \
+    python3 <<'PY'
+import json, os, subprocess, sys, shutil
 
 domain = os.environ.get("DOMAIN_NAME", "").strip().lower().rstrip(".")
 if not domain:
     print("0")
     sys.exit(0)
 want = {domain, f"www.{domain}", f"staging.{domain}", f"deploy.{domain}"}
+aws = shutil.which("aws") or "aws"
+region = os.environ.get("AWS_REGION", "us-east-1")
+profile = (os.environ.get("AWS_PROFILE") or "").strip()
+cmd_prefix = [aws, "--region", region]
+if profile:
+    cmd_prefix += ["--profile", profile]
+
+
+def aws_env():
+    env = os.environ.copy()
+    if not profile:
+        env.pop("AWS_PROFILE", None)
+    return env
+
+
 items = []
 marker = None
 for _ in range(500):
-    cli = ["aws", "cloudfront", "list-distributions", "--output", "json", "--max-items", "100"]
+    cli = cmd_prefix + ["cloudfront", "list-distributions", "--output", "json", "--max-items", "100"]
     if marker:
         cli.extend(["--starting-token", marker])
     try:
-        raw = subprocess.check_output(cli, stderr=subprocess.DEVNULL, text=True, timeout=120)
+        raw = subprocess.check_output(cli, stderr=subprocess.DEVNULL, text=True, timeout=120, env=aws_env())
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
         print("0")
         sys.exit(0)
@@ -93,7 +119,7 @@ purge_bucket() {
   "${AWS_CLI[@]}" s3api put-bucket-logging --bucket "${bucket}" --bucket-logging-status '{}' 2>/dev/null || true
   "${AWS_CLI[@]}" s3 rm "s3://${bucket}/" --recursive >/dev/null 2>&1 || true
 
-  AWS_REGION="${AWS_REGION}" AWS_PROFILE="${AWS_PROFILE:-}" BUCKET="${bucket}" python3 <<'PY'
+  run_with_aws_env BUCKET="${bucket}" python3 <<'PY'
 import json, os, subprocess, sys, shutil, tempfile
 
 bucket = os.environ["BUCKET"]
@@ -105,8 +131,15 @@ if profile:
     cmd_prefix += ["--profile", profile]
 
 
+def aws_env():
+    env = os.environ.copy()
+    if not profile:
+        env.pop("AWS_PROFILE", None)
+    return env
+
+
 def run(args):
-    return subprocess.run(cmd_prefix + args, capture_output=True, text=True)
+    return subprocess.run(cmd_prefix + args, capture_output=True, text=True, env=aws_env())
 
 
 def aws_json(args):

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -34,9 +34,18 @@ import {
   resolveValueForGithub,
   SETUP_FROM_PHASE_ALIASES,
 } from './lib/setup-manifest.mjs';
-import { escapeDotEnvDoubleQuotedValue, parseDotEnv } from './lib/setup-dotenv.mjs';
-import { readMaskedLineIfTty, resolveSecretInputLine } from './lib/setup-secret-input.mjs';
-import { clearGoogleKeysFromAcc, envVarsFromGoogleServicesJson } from './lib/setup-google-services.mjs';
+import {
+  escapeDotEnvDoubleQuotedValue,
+  parseDotEnv,
+} from './lib/setup-dotenv.mjs';
+import {
+  readMaskedLineIfTty,
+  resolveSecretInputLine,
+} from './lib/setup-secret-input.mjs';
+import {
+  clearGoogleKeysFromAcc,
+  envVarsFromGoogleServicesJson,
+} from './lib/setup-google-services.mjs';
 import {
   printIntroBanner,
   printPhaseIntro,
@@ -45,7 +54,10 @@ import {
   SetupQuit,
   isSetupQuit,
 } from './lib/setup-manual-instructions.mjs';
-import { clearExpoKeysFromAcc, ensureNonTemplateEasProject } from './lib/setup-expo-eas.mjs';
+import {
+  clearExpoKeysFromAcc,
+  ensureNonTemplateEasProject,
+} from './lib/setup-expo-eas.mjs';
 import {
   formatSupabaseProjectChoiceLine,
   parseApiKeysJson,
@@ -75,12 +87,22 @@ const STATE_PATH = path.join(REPO_ROOT, '.setup-state.json');
 const MOBILE_DIR = path.join(REPO_ROOT, 'apps', 'mobile');
 const MOBILE_APP_CONFIG = path.join(MOBILE_DIR, 'app.config.js');
 
-const PHASE_ORDER = ['prereqs', 'identity', 'supabase', 'aws', 'expo', 'google', 'write', 'github'];
+// If you add or change interactive prompts, update docs/setup-prep-checklist.md in the same PR.
+const PHASE_ORDER = [
+  'prereqs',
+  'identity',
+  'supabase',
+  'aws',
+  'expo',
+  'google',
+  'write',
+  'github',
+];
 
 /** Merged from dotenv-style secret files / pastes (allowlisted keys only). */
 const MERGEABLE_SETUP_ENV_KEYS = mergeableSetupEnvKeys();
 
-/** @typedef {{ dryRun: boolean; fromPhase: string; skipRename: boolean; awsProfile: string; skipGithub: boolean; mobileEnabled: boolean; plainSecretPrompts: boolean }} CliFlags */
+/** @typedef {{ dryRun: boolean; fromPhase: string; skipRename: boolean; awsProfile: string; skipGithub: boolean; mobileEnabled: boolean; plainSecretPrompts: boolean; guide: 'full' | 'brief'; guideFromCli: boolean }} CliFlags */
 
 function printHelp() {
   console.log(`Usage: node scripts/setup-full.mjs [options]
@@ -96,6 +118,9 @@ Options:
   --skip-mobile          Skip Expo, EAS, and Google Services setup (web-only repos)
   --aws-profile=NAME     Pass through to bootstrap-aws-stack.sh
   --plain-secret-prompts Echo secret prompts in plain text (default: mask typed secrets on a TTY)
+  --guide=full|brief     Intro banner: full = in-terminal GitHub/Supabase/AWS/Expo checklist (default);
+                         brief = pointers to docs/setup-prep-checklist.md only
+  --brief-guide          Same as --guide=brief
 
 Secrets are written only to gitignored files; values are never printed.
 
@@ -133,6 +158,8 @@ function parseArgv(argv) {
     skipGithub: false,
     mobileEnabled: true,
     plainSecretPrompts: false,
+    guide: 'full',
+    guideFromCli: false,
   };
   for (const a of argv) {
     if (a === '--dry-run') flags.dryRun = true;
@@ -140,15 +167,29 @@ function parseArgv(argv) {
     else if (a === '--skip-github') flags.skipGithub = true;
     else if (a === '--skip-mobile') flags.mobileEnabled = false;
     else if (a === '--plain-secret-prompts') flags.plainSecretPrompts = true;
-    else if (a.startsWith('--from=')) flags.fromPhase = resolveSetupFromPhase(a.slice('--from='.length));
-    else if (a.startsWith('--aws-profile=')) flags.awsProfile = a.slice('--aws-profile='.length);
+    else if (a === '--brief-guide') {
+      flags.guide = 'brief';
+      flags.guideFromCli = true;
+    } else if (a.startsWith('--guide=')) {
+      const v = a.slice('--guide='.length).toLowerCase();
+      if (v === 'full' || v === 'brief') {
+        flags.guide = v;
+        flags.guideFromCli = true;
+      } else {
+        console.error(`Unknown --guide=${v}. Use full or brief.`);
+        process.exit(1);
+      }
+    } else if (a.startsWith('--from='))
+      flags.fromPhase = resolveSetupFromPhase(a.slice('--from='.length));
+    else if (a.startsWith('--aws-profile='))
+      flags.awsProfile = a.slice('--aws-profile='.length);
   }
   if (!PHASE_ORDER.includes(flags.fromPhase)) {
     const aliasHint = Object.entries(SETUP_FROM_PHASE_ALIASES)
       .map(([k, v]) => `${k}→${v}`)
       .join(', ');
     console.error(
-      `Unknown --from=${flags.fromPhase}. Use one of: ${PHASE_ORDER.join(', ')}${aliasHint ? `; aliases: ${aliasHint}` : ''}`,
+      `Unknown --from=${flags.fromPhase}. Use one of: ${PHASE_ORDER.join(', ')}${aliasHint ? `; aliases: ${aliasHint}` : ''}`
     );
     process.exit(1);
   }
@@ -158,8 +199,14 @@ function parseArgv(argv) {
 export function redactForLog(message) {
   return String(message)
     .replace(/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, '[jwt]')
-    .replace(/postgresql:\/\/[^:]+:[^@]+@/g, 'postgresql://postgres:[redacted]@')
-    .replace(/(api_key|apikey|secret|password|token)=([^\s&]+)/gi, '$1=[redacted]');
+    .replace(
+      /postgresql:\/\/[^:]+:[^@]+@/g,
+      'postgresql://postgres:[redacted]@'
+    )
+    .replace(
+      /(api_key|apikey|secret|password|token)=([^\s&]+)/gi,
+      '$1=[redacted]'
+    );
 }
 
 export function formatSetupLogMessage(msg) {
@@ -181,10 +228,10 @@ function logMissingRequiredGithubForCi(acc) {
   const missing = listMissingRequiredGithubForCi(acc);
   if (!missing.length) return;
   logWarn(
-    `Required GitHub secrets/variables still missing (${missing.length}): deploy/preview CI may fail until these are set in env files or on GitHub.`,
+    `Required GitHub secrets/variables still missing (${missing.length}): deploy/preview CI may fail until these are set in env files or on GitHub.`
   );
   logWarn(
-    'Use the exact variable names from docs/reference/github-actions-secrets.md (npm run docs:actions-secrets). Lines like export KEY=value in .env files are supported.',
+    'Use the exact variable names from docs/reference/github-actions-secrets.md (npm run docs:actions-secrets). Lines like export KEY=value in .env files are supported.'
   );
   /** @type {Map<string, { secrets: string[]; variables: string[] }>} */
   const byGroup = new Map();
@@ -200,9 +247,14 @@ function logMissingRequiredGithubForCi(acc) {
   for (const g of groups) {
     const { secrets, variables } = byGroup.get(g);
     const parts = [];
-    if (secrets.length) parts.push(`secrets: ${[...secrets].sort((a, b) => a.localeCompare(b)).join(', ')}`);
+    if (secrets.length)
+      parts.push(
+        `secrets: ${[...secrets].sort((a, b) => a.localeCompare(b)).join(', ')}`
+      );
     if (variables.length) {
-      parts.push(`variables: ${[...variables].sort((a, b) => a.localeCompare(b)).join(', ')}`);
+      parts.push(
+        `variables: ${[...variables].sort((a, b) => a.localeCompare(b)).join(', ')}`
+      );
     }
     logWarn(`  [${g}] ${parts.join(' | ')}`);
   }
@@ -214,7 +266,11 @@ function logMissingRequiredGithubForCi(acc) {
  * @param {unknown} e
  */
 function isReadlineQuestionAbortError(e) {
-  return typeof e === 'object' && e !== null && /** @type {{ name?: string }} */ (e).name === 'AbortError';
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    /** @type {{ name?: string }} */ (e).name === 'AbortError'
+  );
 }
 
 /**
@@ -280,7 +336,9 @@ function applySecretResolutionToAcc(acc, resolved, primaryKey) {
   }
   if (Object.keys(resolved.merged).length) {
     Object.assign(acc, resolved.merged);
-    logInfo(`Merged from secret input: ${Object.keys(resolved.merged).sort().join(', ')}`);
+    logInfo(
+      `Merged from secret input: ${Object.keys(resolved.merged).sort().join(', ')}`
+    );
   }
   if (!(primaryKey in resolved.merged) && resolved.primary) {
     acc[primaryKey] = resolved.primary;
@@ -305,7 +363,7 @@ async function resolveSecretInputForSetup(line, primaryKey) {
     allowKeys: MERGEABLE_SETUP_ENV_KEYS,
     homedir,
     repoRoot: REPO_ROOT,
-    readFileUtf8: (p) => fs.readFile(p, 'utf8'),
+    readFileUtf8: p => fs.readFile(p, 'utf8'),
   });
 }
 
@@ -343,7 +401,7 @@ function stringifyDotEnv(record) {
     if (v === undefined || v === null) continue;
     const needsQuote = /[\s#]/.test(v) || v === '';
     lines.push(
-      needsQuote ? `${k}="${escapeDotEnvDoubleQuotedValue(v)}"` : `${k}=${v}`,
+      needsQuote ? `${k}="${escapeDotEnvDoubleQuotedValue(v)}"` : `${k}=${v}`
     );
   }
   lines.push('');
@@ -397,24 +455,35 @@ function runInteractive(cmd, args, opts = {}) {
 function runInteractiveOnControllingTty(cmd, args, opts = {}) {
   const cwd = opts.cwd || REPO_ROOT;
   if (platform() === 'win32') {
-    return spawnSync(cmd, args, { cwd, stdio: 'inherit', encoding: 'utf8' }).status ?? 1;
+    return (
+      spawnSync(cmd, args, { cwd, stdio: 'inherit', encoding: 'utf8' })
+        .status ?? 1
+    );
   }
   const ttyPath = '/dev/tty';
   if (!existsSync(ttyPath)) {
-    return spawnSync(cmd, args, { cwd, stdio: 'inherit', encoding: 'utf8' }).status ?? 1;
+    return (
+      spawnSync(cmd, args, { cwd, stdio: 'inherit', encoding: 'utf8' })
+        .status ?? 1
+    );
   }
   let fd;
   try {
     fd = openSync(ttyPath, fsConstants.O_RDWR);
   } catch {
-    return spawnSync(cmd, args, { cwd, stdio: 'inherit', encoding: 'utf8' }).status ?? 1;
+    return (
+      spawnSync(cmd, args, { cwd, stdio: 'inherit', encoding: 'utf8' })
+        .status ?? 1
+    );
   }
   try {
-    return spawnSync(cmd, args, {
-      cwd,
-      stdio: [fd, fd, fd],
-      encoding: 'utf8',
-    }).status ?? 1;
+    return (
+      spawnSync(cmd, args, {
+        cwd,
+        stdio: [fd, fd, fd],
+        encoding: 'utf8',
+      }).status ?? 1
+    );
   } finally {
     closeSync(fd);
   }
@@ -477,11 +546,13 @@ async function promptSupabaseAuthResolution(rl, promptInput, acc, flags) {
   logInfo('');
   logInfo('Supabase CLI needs authentication. Recommended:');
   logInfo('  • Open Terminal.app (outside the IDE) and run: supabase login');
-  logInfo('  • Or paste a personal access token from https://supabase.com/dashboard/account/tokens');
+  logInfo(
+    '  • Or paste a personal access token from https://supabase.com/dashboard/account/tokens'
+  );
   const choice = (
     await rlQuestion(
       rl,
-      '(p)aste token for `supabase login --token`, (r)etry after manual login, (s)kip, (q)uit: ',
+      '(p)aste token for `supabase login --token`, (r)etry after manual login, (s)kip, (q)uit: '
     )
   )
     .trim()
@@ -494,21 +565,26 @@ async function promptSupabaseAuthResolution(rl, promptInput, acc, flags) {
       rl,
       promptInput,
       flags,
-      'Token (paste, path to bare secret or .env file, or masked type; q=quit setup): ',
+      'Token (paste, path to bare secret or .env file, or masked type; q=quit setup): '
     );
     checkSecretInputQuit(line);
     if (!line.trim()) {
       logWarn('No token provided; choose (r)etry or (s)kip.');
       return 'retry';
     }
-    const resolved = await resolveSecretInputForSetup(line, 'SUPABASE_ACCESS_TOKEN');
+    const resolved = await resolveSecretInputForSetup(
+      line,
+      'SUPABASE_ACCESS_TOKEN'
+    );
     applySecretResolutionToAcc(acc, resolved, 'SUPABASE_ACCESS_TOKEN');
     const token = (acc.SUPABASE_ACCESS_TOKEN || '').trim();
     if (token && trySupabaseLoginFromEnvToken(token)) {
       logInfo('supabase login --token succeeded.');
       return 'retry';
     }
-    logWarn('Token login failed; fix token or use Terminal.app, then choose (r)etry.');
+    logWarn(
+      'Token login failed; fix token or use Terminal.app, then choose (r)etry.'
+    );
     return 'retry';
   }
   return 'retry';
@@ -522,13 +598,17 @@ async function promptSupabaseAuthResolution(rl, promptInput, acc, flags) {
  */
 async function promptSupabaseAccessTokenForGithub(rl, promptInput, acc, flags) {
   if (flags.dryRun) {
-    logInfo('[dry-run] would prompt for SUPABASE_ACCESS_TOKEN (skipped; not reading env or paste).');
+    logInfo(
+      '[dry-run] would prompt for SUPABASE_ACCESS_TOKEN (skipped; not reading env or paste).'
+    );
     return;
   }
   const env = process.env.SUPABASE_ACCESS_TOKEN?.trim();
   if (env) {
     acc.SUPABASE_ACCESS_TOKEN = env;
-    logInfo('Using SUPABASE_ACCESS_TOKEN from environment (value not printed).');
+    logInfo(
+      'Using SUPABASE_ACCESS_TOKEN from environment (value not printed).'
+    );
     return;
   }
   const dash = 'https://supabase.com/dashboard/account/tokens';
@@ -540,11 +620,14 @@ async function promptSupabaseAccessTokenForGithub(rl, promptInput, acc, flags) {
     rl,
     promptInput,
     flags,
-    'Paste token, path to file (bare secret or .env), blank to skip, q=quit entire setup: ',
+    'Paste token, path to file (bare secret or .env), blank to skip, q=quit entire setup: '
   );
   checkSecretInputQuit(line);
   if (!line.trim()) return;
-  const resolved = await resolveSecretInputForSetup(line, 'SUPABASE_ACCESS_TOKEN');
+  const resolved = await resolveSecretInputForSetup(
+    line,
+    'SUPABASE_ACCESS_TOKEN'
+  );
   applySecretResolutionToAcc(acc, resolved, 'SUPABASE_ACCESS_TOKEN');
 }
 
@@ -556,7 +639,9 @@ async function promptSupabaseAccessTokenForGithub(rl, promptInput, acc, flags) {
  */
 async function promptExpoTokenForGithub(rl, promptInput, acc, flags) {
   if (flags.dryRun) {
-    logInfo('[dry-run] would prompt for EXPO_TOKEN (skipped; not reading env or paste).');
+    logInfo(
+      '[dry-run] would prompt for EXPO_TOKEN (skipped; not reading env or paste).'
+    );
     return;
   }
   const env = process.env.EXPO_TOKEN?.trim();
@@ -566,16 +651,20 @@ async function promptExpoTokenForGithub(rl, promptInput, acc, flags) {
     return;
   }
   const dash = 'https://expo.dev/accounts/[account]/settings/access-tokens';
-  logInfo(`Expo access token (EXPO_TOKEN) for CI: create at expo.dev → Account → Access tokens`);
+  logInfo(
+    `Expo access token (EXPO_TOKEN) for CI: create at expo.dev → Account → Access tokens`
+  );
   logInfo(`Docs: ${dash}`);
   if (process.platform === 'darwin') {
-    spawnSync('open', ['https://expo.dev/settings/access-tokens'], { stdio: 'ignore' });
+    spawnSync('open', ['https://expo.dev/settings/access-tokens'], {
+      stdio: 'ignore',
+    });
   }
   const line = await readSecretLineMaskedOrVisible(
     rl,
     promptInput,
     flags,
-    'Paste EXPO_TOKEN, path to file (bare secret or .env), blank to skip, q=quit entire setup: ',
+    'Paste EXPO_TOKEN, path to file (bare secret or .env), blank to skip, q=quit entire setup: '
   );
   checkSecretInputQuit(line);
   if (!line.trim()) return;
@@ -590,7 +679,9 @@ async function promptExpoTokenForGithub(rl, promptInput, acc, flags) {
  */
 async function offerInteractiveLogin(rl, flags, spec) {
   if (flags.dryRun) {
-    logInfo(`[dry-run] would offer ${spec.label}: ${spec.command} ${spec.args.join(' ')}`);
+    logInfo(
+      `[dry-run] would offer ${spec.label}: ${spec.command} ${spec.args.join(' ')}`
+    );
     return false;
   }
   const a = (await rlQuestion(rl, spec.question)).trim().toLowerCase();
@@ -598,7 +689,9 @@ async function offerInteractiveLogin(rl, flags, spec) {
     return false;
   }
   logInfo(`Running ${spec.label}: ${spec.command} ${spec.args.join(' ')}`);
-  const code = runInteractiveWithRl(rl, spec.command, spec.args, { cwd: spec.cwd || REPO_ROOT });
+  const code = runInteractiveWithRl(rl, spec.command, spec.args, {
+    cwd: spec.cwd || REPO_ROOT,
+  });
   if (code !== 0) {
     logWarn(`${spec.label} exited with code ${code}`);
     return false;
@@ -630,12 +723,16 @@ function childProcessEnvForSpawn() {
  * @param {CliFlags} flags
  */
 function awsCallerIdentityOk(flags) {
-  const r = spawnSync('aws', ['sts', 'get-caller-identity', ...awsProfileArgs(flags)], {
-    cwd: REPO_ROOT,
-    stdio: 'pipe',
-    encoding: 'utf8',
-    env: childProcessEnvForSpawn(),
-  });
+  const r = spawnSync(
+    'aws',
+    ['sts', 'get-caller-identity', ...awsProfileArgs(flags)],
+    {
+      cwd: REPO_ROOT,
+      stdio: 'pipe',
+      encoding: 'utf8',
+      env: childProcessEnvForSpawn(),
+    }
+  );
   return r.status === 0;
 }
 
@@ -645,7 +742,11 @@ function awsCallerIdentityOk(flags) {
  * @param {string[]} profileArgs from awsProfileArgs(flags)
  * @returns {Promise<string | null>} StackStatus or null if missing / error
  */
-async function describeCloudFormationStackStatus(stackName, region, profileArgs) {
+async function describeCloudFormationStackStatus(
+  stackName,
+  region,
+  profileArgs
+) {
   const res = await runCmd(
     'aws',
     [
@@ -661,7 +762,7 @@ async function describeCloudFormationStackStatus(stackName, region, profileArgs)
       '--output',
       'text',
     ],
-    { cwd: REPO_ROOT },
+    { cwd: REPO_ROOT }
   );
   if (res.code !== 0) {
     return null;
@@ -699,16 +800,20 @@ function runBootstrapPreflightJson(bootstrapArgs) {
   });
   const errOut = `${r.stderr || ''}${r.stdout || ''}`.trim();
   if (r.status !== 0) {
-    logWarn(`AWS preflight (--print-preflight-json) failed (exit ${r.status ?? 1}). ${errOut.slice(0, 500)}`);
+    logWarn(
+      `AWS preflight (--print-preflight-json) failed (exit ${r.status ?? 1}). ${errOut.slice(0, 500)}`
+    );
     return null;
   }
   const raw = (r.stdout || '').trim();
-  const lines = raw.split(/\r?\n/).filter((l) => l.trim());
+  const lines = raw.split(/\r?\n/).filter(l => l.trim());
   const last = lines[lines.length - 1] || raw;
   try {
     return /** @type {AwsPreflightJson} */ (JSON.parse(last));
   } catch {
-    logWarn('Could not parse AWS preflight JSON; continuing without conflict menu.');
+    logWarn(
+      'Could not parse AWS preflight JSON; continuing without conflict menu.'
+    );
     return null;
   }
 }
@@ -718,12 +823,16 @@ function runBootstrapPreflightJson(bootstrapArgs) {
  * @returns {boolean}
  */
 function runBootstrapDeleteFailedChangeSets(bootstrapArgs) {
-  const r = spawnSync('bash', [...bootstrapArgs, '--delete-failed-change-sets'], {
-    cwd: REPO_ROOT,
-    encoding: 'utf8',
-    stdio: ['ignore', 'inherit', 'inherit'],
-    env: childProcessEnvForSpawn(),
-  });
+  const r = spawnSync(
+    'bash',
+    [...bootstrapArgs, '--delete-failed-change-sets'],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'inherit', 'inherit'],
+      env: childProcessEnvForSpawn(),
+    }
+  );
   if (r.status !== 0) {
     logWarn(`delete-failed-change-sets exited ${r.status ?? 1}.`);
     return false;
@@ -738,7 +847,11 @@ function runBootstrapDeleteFailedChangeSets(bootstrapArgs) {
  * @param {string[]} bootstrapArgs
  * @returns {Promise<{ skipAwsPhase: boolean; allowConflictingBuckets: boolean }>}
  */
-async function resolveAwsPreflightConflictsInteractive(rl, flags, bootstrapArgs) {
+async function resolveAwsPreflightConflictsInteractive(
+  rl,
+  flags,
+  bootstrapArgs
+) {
   if (!input.isTTY) {
     return { skipAwsPhase: false, allowConflictingBuckets: false };
   }
@@ -748,9 +861,16 @@ async function resolveAwsPreflightConflictsInteractive(rl, flags, bootstrapArgs)
 
   while (pf && pf.stuckReviewSuggestedFix) {
     logWarn(
-      'CloudFormation may be stuck (REVIEW_IN_PROGRESS and/or FAILED change sets). Deleting FAILED change sets is usually safe.',
+      'CloudFormation may be stuck (REVIEW_IN_PROGRESS and/or FAILED change sets). Deleting FAILED change sets is usually safe.'
     );
-    const del = (await rlQuestion(rl, 'Delete FAILED change sets for this stack now? (y/N): ')).trim().toLowerCase();
+    const del = (
+      await rlQuestion(
+        rl,
+        'Delete FAILED change sets for this stack now? (y/N): '
+      )
+    )
+      .trim()
+      .toLowerCase();
     if (del !== 'y' && del !== 'yes') {
       break;
     }
@@ -764,21 +884,27 @@ async function resolveAwsPreflightConflictsInteractive(rl, flags, bootstrapArgs)
     return { skipAwsPhase: false, allowConflictingBuckets: false };
   }
 
-  const reasons = Array.isArray(pf.deployLikelyFailReasons) ? pf.deployLikelyFailReasons.join(', ') : '';
-  logWarn(`AWS preflight: deploy will likely fail until this is addressed (${reasons}).`);
+  const reasons = Array.isArray(pf.deployLikelyFailReasons)
+    ? pf.deployLikelyFailReasons.join(', ')
+    : '';
+  logWarn(
+    `AWS preflight: deploy will likely fail until this is addressed (${reasons}).`
+  );
   if ((pf.cloudFrontAliasConflicts || []).length > 0) {
     for (const c of pf.cloudFrontAliasConflicts) {
-      logWarn(`  CloudFront distribution ${c.distributionId} uses aliases: ${(c.matchedAliases || []).join(', ')}`);
+      logWarn(
+        `  CloudFront distribution ${c.distributionId} uses aliases: ${(c.matchedAliases || []).join(', ')}`
+      );
     }
   }
   if (pf.orphanBuckets) {
     logWarn(
-      `  Orphan named buckets may block create: ${pf.buckets?.prodName || ''}, ${pf.buckets?.stagingName || ''}, ${pf.buckets?.deployName || ''}`,
+      `  Orphan named buckets may block create: ${pf.buckets?.prodName || ''}, ${pf.buckets?.stagingName || ''}, ${pf.buckets?.deployName || ''}`
     );
   }
   if (pf.stackStatusBlocksDeploy && pf.stackStatus) {
     logWarn(
-      `  Stack "${pf.stackName}" is ${pf.stackStatus}: delete this CloudFormation stack before re-using the same stack name (aws cloudformation delete-stack --stack-name "${pf.stackName}"; then wait for delete-complete).`,
+      `  Stack "${pf.stackName}" is ${pf.stackStatus}: delete this CloudFormation stack before re-using the same stack name (aws cloudformation delete-stack --stack-name "${pf.stackName}"; then wait for delete-complete).`
     );
   }
 
@@ -786,12 +912,18 @@ async function resolveAwsPreflightConflictsInteractive(rl, flags, bootstrapArgs)
     const choice = (
       await rlQuestion(
         rl,
-        '(S)kip AWS bootstrap  /  (C)ontinue deploy anyway  /  (D)estructive: empty+delete apex prod/staging/deploy buckets [S]: ',
+        '(S)kip AWS bootstrap  /  (C)ontinue deploy anyway  /  (D)estructive: empty+delete apex prod/staging/deploy buckets [S]: '
       )
     )
       .trim()
       .toLowerCase();
-    if (choice === '' || choice === 's' || choice === 'skip' || choice === 'q' || choice === 'quit') {
+    if (
+      choice === '' ||
+      choice === 's' ||
+      choice === 'skip' ||
+      choice === 'q' ||
+      choice === 'quit'
+    ) {
       return { skipAwsPhase: true, allowConflictingBuckets: false };
     }
     if (choice === 'c' || choice === 'continue') {
@@ -800,12 +932,12 @@ async function resolveAwsPreflightConflictsInteractive(rl, flags, bootstrapArgs)
     if (choice === 'd' || choice === 'destructive') {
       if ((pf.cloudFrontAliasConflicts || []).length > 0) {
         logWarn(
-          'WARNING: CloudFront distributions still use this apex on alternate domains. Deleting buckets can break live sites that use those origins.',
+          'WARNING: CloudFront distributions still use this apex on alternate domains. Deleting buckets can break live sites that use those origins.'
         );
         const ack = (
           await rlQuestion(
             rl,
-            "Type exactly 'ACKNOWLEDGE CLOUDFRONT RISK' to run bucket teardown anyway (or Enter to cancel): ",
+            "Type exactly 'ACKNOWLEDGE CLOUDFRONT RISK' to run bucket teardown anyway (or Enter to cancel): "
           )
         ).trim();
         if (ack !== 'ACKNOWLEDGE CLOUDFRONT RISK') {
@@ -813,18 +945,31 @@ async function resolveAwsPreflightConflictsInteractive(rl, flags, bootstrapArgs)
           continue;
         }
       }
-      const td = [path.join(REPO_ROOT, 'scripts', 'pr-preview', 'teardown-preview-domain-buckets.sh'), '--domain', pf.domain, '--region', pf.region];
+      const td = [
+        path.join(
+          REPO_ROOT,
+          'scripts',
+          'pr-preview',
+          'teardown-preview-domain-buckets.sh'
+        ),
+        '--domain',
+        pf.domain,
+        '--region',
+        pf.region,
+      ];
       if (flags.awsProfile) {
         td.push('--aws-profile', flags.awsProfile);
       }
       if ((pf.cloudFrontAliasConflicts || []).length > 0) {
         td.push('--i-acknowledge-cloudfront-may-break');
       }
-      logWarn('WARNING: This permanently deletes data in the three named S3 buckets.');
+      logWarn(
+        'WARNING: This permanently deletes data in the three named S3 buckets.'
+      );
       const phrase = (
         await rlQuestion(
           rl,
-          "Type exactly 'PERMANENTLY DELETE BUCKETS' to confirm (or Enter to cancel): ",
+          "Type exactly 'PERMANENTLY DELETE BUCKETS' to confirm (or Enter to cancel): "
         )
       ).trim();
       if (phrase !== 'PERMANENTLY DELETE BUCKETS') {
@@ -832,7 +977,10 @@ async function resolveAwsPreflightConflictsInteractive(rl, flags, bootstrapArgs)
         continue;
       }
       // Pass confirmation via env so teardown never calls `read` (freezes under IDE readline + TTY).
-      const tdEnv = { ...childProcessEnvForSpawn(), BEAKER_DELETE_BUCKETS_CONFIRM: 'PERMANENTLY DELETE BUCKETS' };
+      const tdEnv = {
+        ...childProcessEnvForSpawn(),
+        BEAKER_DELETE_BUCKETS_CONFIRM: 'PERMANENTLY DELETE BUCKETS',
+      };
       const tdCode =
         spawnSync('bash', td, {
           cwd: REPO_ROOT,
@@ -841,15 +989,21 @@ async function resolveAwsPreflightConflictsInteractive(rl, flags, bootstrapArgs)
           encoding: 'utf8',
         }).status ?? 1;
       if (tdCode !== 0) {
-        logWarn('Bucket teardown did not complete successfully; choose another option.');
+        logWarn(
+          'Bucket teardown did not complete successfully; choose another option.'
+        );
         continue;
       }
       pf = runBootstrapPreflightJson(bootstrapArgs);
       if (!pf || !pf.deployLikelyFails) {
-        logInfo('Preflight: deploy-blocking issues appear cleared; proceeding to bootstrap.');
+        logInfo(
+          'Preflight: deploy-blocking issues appear cleared; proceeding to bootstrap.'
+        );
         return { skipAwsPhase: false, allowConflictingBuckets: false };
       }
-      logWarn('Conflicts still reported after teardown; choose Skip, Continue anyway, or retry destructive after fixing CloudFormation/CloudFront in the console.');
+      logWarn(
+        'Conflicts still reported after teardown; choose Skip, Continue anyway, or retry destructive after fixing CloudFormation/CloudFront in the console.'
+      );
       continue;
     }
     logWarn('Unrecognized choice; enter S, C, or D.');
@@ -888,7 +1042,8 @@ function easWhoamiOk() {
  * @param {import('stream').Readable & { isTTY?: boolean; setRawMode?: (flag: boolean) => void }} promptInput
  */
 async function ensureSupabaseCliAuth(rl, flags, acc, promptInput) {
-  const tryList = async () => runCmd('supabase', ['projects', 'list', '-o', 'json'], { cwd: REPO_ROOT });
+  const tryList = async () =>
+    runCmd('supabase', ['projects', 'list', '-o', 'json'], { cwd: REPO_ROOT });
 
   let listRes = await tryList();
   if (listRes.code === 0) {
@@ -904,7 +1059,9 @@ async function ensureSupabaseCliAuth(rl, flags, acc, promptInput) {
   }
 
   for (let attempt = 0; attempt < 8; attempt += 1) {
-    logWarn('Supabase CLI is not authenticated (or the projects list request failed).');
+    logWarn(
+      'Supabase CLI is not authenticated (or the projects list request failed).'
+    );
     logWarn(redactForLog(listRes.stderr || listRes.stdout));
     const res = await promptSupabaseAuthResolution(rl, promptInput, acc, flags);
     if (res === 'skip') {
@@ -929,12 +1086,14 @@ async function ensureAwsCredentials(rl, flags) {
   if (awsCallerIdentityOk(flags)) {
     return;
   }
-  logWarn('AWS CLI: `aws sts get-caller-identity` failed (missing or expired credentials).');
+  logWarn(
+    'AWS CLI: `aws sts get-caller-identity` failed (missing or expired credentials).'
+  );
   for (let i = 0; i < 8; i += 1) {
     const c = (
       await rlQuestion(
         rl,
-        'Fix AWS — (l) aws sso login, (c) aws configure, (r) re-check caller identity, (s)kip, (q)uit: ',
+        'Fix AWS — (l) aws sso login, (c) aws configure, (r) re-check caller identity, (s)kip, (q)uit: '
       )
     )
       .trim()
@@ -958,12 +1117,15 @@ async function ensureAwsCredentials(rl, flags) {
       logInfo(`Running: aws ${args.join(' ')}`);
       if (input.isTTY) {
         logInfo(
-          'If this hangs, use Terminal.app and run the same command there (IDE readline + AWS prompts often conflict).',
+          'If this hangs, use Terminal.app and run the same command there (IDE readline + AWS prompts often conflict).'
         );
       }
       pauseRl(rl);
       try {
-        runInteractive('aws', args, { cwd: REPO_ROOT, env: childProcessEnvForSpawn() });
+        runInteractive('aws', args, {
+          cwd: REPO_ROOT,
+          env: childProcessEnvForSpawn(),
+        });
       } finally {
         resumeRl(rl);
       }
@@ -973,12 +1135,15 @@ async function ensureAwsCredentials(rl, flags) {
       logInfo('Running: aws configure');
       if (input.isTTY) {
         logInfo(
-          'If prompts freeze here, use Terminal.app: aws configure (IDE readline + AWS configure often conflict).',
+          'If prompts freeze here, use Terminal.app: aws configure (IDE readline + AWS configure often conflict).'
         );
       }
       pauseRl(rl);
       try {
-        runInteractive('aws', ['configure'], { cwd: REPO_ROOT, env: childProcessEnvForSpawn() });
+        runInteractive('aws', ['configure'], {
+          cwd: REPO_ROOT,
+          env: childProcessEnvForSpawn(),
+        });
       } finally {
         resumeRl(rl);
       }
@@ -999,7 +1164,9 @@ function ghSecretSetSync(repo, name, value, dryRun) {
     stdio: ['pipe', 'pipe', 'pipe'],
   });
   if (r.status !== 0) {
-    logWarn(`gh secret set ${name} failed: ${redactForLog(r.stderr || r.stdout || '')}`);
+    logWarn(
+      `gh secret set ${name} failed: ${redactForLog(r.stderr || r.stdout || '')}`
+    );
   }
   return r.status ?? 1;
 }
@@ -1009,10 +1176,14 @@ function ghVariableSetSync(repo, name, value, dryRun) {
     logInfo(`[dry-run] gh variable set ${name} --repo ${repo}`);
     return 0;
   }
-  const r = spawnSync('gh', ['variable', 'set', name, '--repo', repo, '--body', value], {
-    encoding: 'utf8',
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
+  const r = spawnSync(
+    'gh',
+    ['variable', 'set', name, '--repo', repo, '--body', value],
+    {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }
+  );
   if (r.status !== 0) {
     logWarn(`gh variable set ${name} failed: ${redactForLog(r.stderr || '')}`);
   }
@@ -1020,18 +1191,24 @@ function ghVariableSetSync(repo, name, value, dryRun) {
 }
 
 function resolveGhRepo() {
-  const r = spawnSync('gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], {
-    cwd: REPO_ROOT,
-    encoding: 'utf8',
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
+  const r = spawnSync(
+    'gh',
+    ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }
+  );
   if (r.status !== 0) return '';
   return (r.stdout || '').trim();
 }
 
 function which(cmd) {
   if (!/^[a-zA-Z0-9_.-]+$/.test(cmd)) return '';
-  const r = spawnSync('sh', ['-c', `command -v "${cmd}" 2>/dev/null`], { encoding: 'utf8' });
+  const r = spawnSync('sh', ['-c', `command -v "${cmd}" 2>/dev/null`], {
+    encoding: 'utf8',
+  });
   return r.status === 0 ? (r.stdout || '').trim().split('\n')[0] : '';
 }
 
@@ -1049,7 +1226,10 @@ function createPromptInterface() {
       /* interactive prompts may not work without a TTY */
     }
   }
-  return { rl: createInterface({ input: inStream, output }), promptInput: inStream };
+  return {
+    rl: createInterface({ input: inStream, output }),
+    promptInput: inStream,
+  };
 }
 
 /**
@@ -1089,7 +1269,9 @@ async function phaseIdentity(flags, rl) {
     logWarn(w);
   }
   logInfo(`Detected product display name: "${identity.displayName}"`);
-  logInfo(`Detected legal entity (package.json author): "${identity.legalAuthor}"`);
+  logInfo(
+    `Detected legal entity (package.json author): "${identity.legalAuthor}"`
+  );
 
   const fromName = identity.displayName;
   const fromLegal = identity.legalAuthor;
@@ -1100,27 +1282,48 @@ async function phaseIdentity(flags, rl) {
     return;
   }
 
-  const doLegal = await rlQuestion(rl, 'Also replace legal organization string across the repo? (y/N): ');
+  const doLegal = await rlQuestion(
+    rl,
+    'Also replace legal organization string across the repo? (y/N): '
+  );
   let toLegal = '';
   if (/^y(es)?$/i.test(doLegal.trim())) {
     toLegal = (await rlQuestion(rl, 'New legal organization name: ')).trim();
     if (!toLegal) {
-      logWarn('Legal rename requested but no new value; run rename without --from-legal/--to-legal.');
+      logWarn(
+        'Legal rename requested but no new value; run rename without --from-legal/--to-legal.'
+      );
     }
   }
 
   const dry = flags.dryRun ? ['--dry-run'] : [];
   const legalArgs =
-    toLegal && fromLegal && fromLegal !== toLegal ? ['--from-legal', fromLegal, '--to-legal', toLegal] : [];
-  logInfo(`Running rename: display "${fromName}" -> "${toName}"${legalArgs.length ? ' + legal entity' : ''}`);
+    toLegal && fromLegal && fromLegal !== toLegal
+      ? ['--from-legal', fromLegal, '--to-legal', toLegal]
+      : [];
+  logInfo(
+    `Running rename: display "${fromName}" -> "${toName}"${legalArgs.length ? ' + legal entity' : ''}`
+  );
   const code = runInteractiveWithRl(
     rl,
     'npm',
-    ['run', 'rename', '--', '--from', fromName, '--to', toName, ...legalArgs, ...dry],
-    { cwd: REPO_ROOT },
+    [
+      'run',
+      'rename',
+      '--',
+      '--from',
+      fromName,
+      '--to',
+      toName,
+      ...legalArgs,
+      ...dry,
+    ],
+    { cwd: REPO_ROOT }
   );
   if (code !== 0) {
-    logWarn('rename exited non-zero; fix issues and re-run with --skip-rename or repeat this phase.');
+    logWarn(
+      'rename exited non-zero; fix issues and re-run with --skip-rename or repeat this phase.'
+    );
   }
 }
 
@@ -1137,18 +1340,29 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
   }
   const listRes = await ensureSupabaseCliAuth(rl, flags, acc, promptInput);
   if (listRes.code !== 0) {
-    logWarn('Supabase phase skipped: not authenticated (run `supabase login` and try again).');
+    logWarn(
+      'Supabase phase skipped: not authenticated (run `supabase login` and try again).'
+    );
     return;
   }
 
-  let orgsRes = await runCmd('supabase', ['orgs', 'list', '-o', 'json'], { cwd: REPO_ROOT });
+  let orgsRes = await runCmd('supabase', ['orgs', 'list', '-o', 'json'], {
+    cwd: REPO_ROOT,
+  });
   if (orgsRes.code !== 0) {
     logWarn('Could not list Supabase organizations.');
     logWarn(redactForLog(orgsRes.stderr || orgsRes.stdout));
     for (let oi = 0; oi < 8 && orgsRes.code !== 0; oi += 1) {
-      const res = await promptSupabaseAuthResolution(rl, promptInput, acc, flags);
+      const res = await promptSupabaseAuthResolution(
+        rl,
+        promptInput,
+        acc,
+        flags
+      );
       if (res === 'skip') break;
-      orgsRes = await runCmd('supabase', ['orgs', 'list', '-o', 'json'], { cwd: REPO_ROOT });
+      orgsRes = await runCmd('supabase', ['orgs', 'list', '-o', 'json'], {
+        cwd: REPO_ROOT,
+      });
     }
   }
   if (orgsRes.code !== 0) {
@@ -1170,7 +1384,7 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
   orgs.forEach((o, i) => logInfo(`  [${i}] ${o.id}  ${o.name}`));
   const orgIdx = parseInt(
     (await rlQuestion(rl, `Choose org index [0]: `)).trim() || '0',
-    10,
+    10
   );
   const org = orgs[Number.isFinite(orgIdx) ? orgIdx : 0];
   if (!org) {
@@ -1187,11 +1401,13 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
   }
 
   const region =
-    (await rlQuestion(rl, 'Default region for new projects [us-east-1]: ')).trim() || 'us-east-1';
+    (
+      await rlQuestion(rl, 'Default region for new projects [us-east-1]: ')
+    ).trim() || 'us-east-1';
 
   const supabaseSlugBase = await readSupabaseProjectSlugBase();
   logInfo(
-    `Default new Supabase project slug per tier: ${supabaseSlugBase}-<staging|production|preview> (from apps/mobile/app.config.js; same word rules as rename).`,
+    `Default new Supabase project slug per tier: ${supabaseSlugBase}-<staging|production|preview> (from apps/mobile/app.config.js; same word rules as rename).`
   );
 
   /**
@@ -1199,9 +1415,16 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
    */
   async function configureTier(tier) {
     const prefix =
-      tier === 'staging' ? 'STAGING' : tier === 'production' ? 'PRODUCTION' : 'PREVIEW';
+      tier === 'staging'
+        ? 'STAGING'
+        : tier === 'production'
+          ? 'PRODUCTION'
+          : 'PREVIEW';
     const mode = (
-      await rlQuestion(rl, `[${tier}] (c)reate new project or (s)elect existing? [s]: `)
+      await rlQuestion(
+        rl,
+        `[${tier}] (c)reate new project or (s)elect existing? [s]: `
+      )
     )
       .trim()
       .toLowerCase();
@@ -1212,18 +1435,20 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
 
     if (create) {
       const suggestedSlug = `${supabaseSlugBase}-${tier}`;
-      const slugAnswer = (await rlQuestion(rl, `[${tier}] project name slug [${suggestedSlug}]: `)).trim();
+      const slugAnswer = (
+        await rlQuestion(rl, `[${tier}] project name slug [${suggestedSlug}]: `)
+      ).trim();
       const defaultName = slugAnswer || suggestedSlug;
       const genPw = crypto.randomBytes(16).toString('base64url');
       const dbPk = supabaseDbPasswordEnvKey(tier);
       logInfo(
-        `[${tier}] Next: database password for the new project (Enter = random). Typed input is masked on a real TTY.`,
+        `[${tier}] Next: database password for the new project (Enter = random). Typed input is masked on a real TTY.`
       );
       const rawPw = await readSecretLineMaskedOrVisible(
         rl,
         promptInput,
         flags,
-        `[${tier}] Database password — blank for random; paste, path, or masked type (q=quit): `,
+        `[${tier}] Database password — blank for random; paste, path, or masked type (q=quit): `
       );
       checkSecretInputQuit(rawPw);
       if (!rawPw.trim()) {
@@ -1231,7 +1456,10 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
       } else {
         const resolved = await resolveSecretInputForSetup(rawPw, dbPk);
         applySecretResolutionToAcc(acc, resolved, dbPk);
-        dbPassword = (acc[dbPk] && String(acc[dbPk]).trim()) || resolved.primary.trim() || genPw;
+        dbPassword =
+          (acc[dbPk] && String(acc[dbPk]).trim()) ||
+          resolved.primary.trim() ||
+          genPw;
       }
       const args = [
         'projects',
@@ -1248,7 +1476,9 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
         '--yes',
       ];
       if (flags.dryRun) {
-        logInfo(`[dry-run] supabase ${args.map((a) => (a === dbPassword ? '[db-password]' : a)).join(' ')}`);
+        logInfo(
+          `[dry-run] supabase ${args.map(a => (a === dbPassword ? '[db-password]' : a)).join(' ')}`
+        );
         const dbPlaceholder = 'dry-run-db-password';
         acc[`${prefix}_SUPABASE_URL`] = 'https://dry-run.supabase.co';
         acc[`${prefix}_SUPABASE_ANON_KEY`] = 'dry-run-anon';
@@ -1257,7 +1487,8 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
         if (tier === 'preview') {
           acc.SUPABASE_PREVIEW_PROJECT_REF = 'dry-run-ref';
           acc.SUPABASE_PREVIEW_DB_PASSWORD = dbPlaceholder;
-          acc.SUPABASE_PREVIEW_DB_URL = 'postgresql://postgres:[redacted]@db.dry-run-ref.supabase.co:5432/postgres';
+          acc.SUPABASE_PREVIEW_DB_URL =
+            'postgresql://postgres:[redacted]@db.dry-run-ref.supabase.co:5432/postgres';
           acc.PR_TESTING_SUPABASE_URL = 'https://dry-run.supabase.co';
           acc.PR_TESTING_SUPABASE_ANON_KEY = 'dry-run-anon';
           acc.PR_TESTING_SUPABASE_PROJECT_REF = 'dry-run-ref';
@@ -1275,10 +1506,16 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
         try {
           ref = parseProjectCreateJson(cr.stdout).id;
         } catch {
-          logWarn('Could not parse create output; check Supabase dashboard for project ref.');
+          logWarn(
+            'Could not parse create output; check Supabase dashboard for project ref.'
+          );
           return;
         }
-        const refreshed = await runCmd('supabase', ['projects', 'list', '-o', 'json'], { cwd: REPO_ROOT });
+        const refreshed = await runCmd(
+          'supabase',
+          ['projects', 'list', '-o', 'json'],
+          { cwd: REPO_ROOT }
+        );
         if (refreshed.code === 0) {
           try {
             projects = parseProjectsListJson(refreshed.stdout);
@@ -1288,7 +1525,9 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
         }
       }
     } else {
-      const filtered = projects.filter((p) => p.organization_id === org.id || !p.organization_id);
+      const filtered = projects.filter(
+        p => p.organization_id === org.id || !p.organization_id
+      );
       const choices = filtered.length ? filtered : projects;
       const suggestedSlug = `${supabaseSlugBase}-${tier}`;
       const envHint =
@@ -1298,19 +1537,25 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
       logInfo(`This step configures the ${tier} tier (${envHint}).`);
       logInfo(`Expected create slug for this tier: ${suggestedSlug}.`);
       logInfo('Projects (org-filtered if possible):');
-      choices.forEach((p, i) => logInfo(`  ${formatSupabaseProjectChoiceLine(i, p)}`));
-      const recommended = pickRecommendedSupabaseProject(choices, tier, supabaseSlugBase);
+      choices.forEach((p, i) =>
+        logInfo(`  ${formatSupabaseProjectChoiceLine(i, p)}`)
+      );
+      const recommended = pickRecommendedSupabaseProject(
+        choices,
+        tier,
+        supabaseSlugBase
+      );
       const last = choices.length - 1;
       const indexQuestion = recommended
         ? `[${tier}] Project index (0-${last}) recommending "${formatSupabaseProjectChoiceLine(
             recommended.index,
-            recommended.project,
+            recommended.project
           )}" [${recommended.index}]: `
         : `[${tier}] Project index (0-${last}) — enter index (no automatic recommendation): `;
       const indexAnswer = (await rlQuestion(rl, indexQuestion)).trim();
       const pick = parseInt(
         indexAnswer || (recommended ? String(recommended.index) : ''),
-        10,
+        10
       );
       const proj = choices[Number.isFinite(pick) ? pick : -1];
       if (!proj) {
@@ -1323,7 +1568,7 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
         rl,
         promptInput,
         flags,
-        `[${tier}] Database password — paste, path to file, or masked type (q=quit): `,
+        `[${tier}] Database password — paste, path to file, or masked type (q=quit): `
       );
       checkSecretInputQuit(rawPw);
       if (!rawPw.trim() && !flags.dryRun) {
@@ -1333,7 +1578,8 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
       if (rawPw.trim()) {
         const resolved = await resolveSecretInputForSetup(rawPw, dbPk);
         applySecretResolutionToAcc(acc, resolved, dbPk);
-        dbPassword = (acc[dbPk] && String(acc[dbPk]).trim()) || resolved.primary.trim();
+        dbPassword =
+          (acc[dbPk] && String(acc[dbPk]).trim()) || resolved.primary.trim();
       } else {
         dbPassword = '';
       }
@@ -1344,7 +1590,9 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
     }
 
     if (flags.dryRun) {
-      logInfo(`[dry-run] would run: supabase projects api-keys --project-ref ${ref} (${tier})`);
+      logInfo(
+        `[dry-run] would run: supabase projects api-keys --project-ref ${ref} (${tier})`
+      );
       const apiUrl = projectApiUrl(ref);
       const anon = 'dry-run-anon';
       const service = 'dry-run-service';
@@ -1366,13 +1614,19 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
         acc[`${prefix}_SUPABASE_DB_PASSWORD`] = dbPw;
         acc[`${prefix}_SUPABASE_SERVICE_ROLE_KEY`] = service;
       }
-      logInfo(`[dry-run] ${tier} tier: placeholder keys only (no api-keys CLI call).`);
+      logInfo(
+        `[dry-run] ${tier} tier: placeholder keys only (no api-keys CLI call).`
+      );
       return;
     }
 
-    const keysRes = await runCmd('supabase', ['projects', 'api-keys', '--project-ref', ref, '-o', 'json'], {
-      cwd: REPO_ROOT,
-    });
+    const keysRes = await runCmd(
+      'supabase',
+      ['projects', 'api-keys', '--project-ref', ref, '-o', 'json'],
+      {
+        cwd: REPO_ROOT,
+      }
+    );
     if (keysRes.code !== 0) {
       logWarn(`api-keys failed for ${ref}`);
       return;
@@ -1406,7 +1660,9 @@ async function phaseSupabase(flags, rl, acc, promptInput) {
       acc[`${prefix}_SUPABASE_DB_PASSWORD`] = dbPassword;
       acc[`${prefix}_SUPABASE_SERVICE_ROLE_KEY`] = service;
     }
-    logInfo(`[${tier}] Configured project ref ${ref} (keys stored locally, not printed).`);
+    logInfo(
+      `[${tier}] Configured project ref ${ref} (keys stored locally, not printed).`
+    );
   }
 
   await configureTier('staging');
@@ -1427,13 +1683,22 @@ async function promptHostedZoneAfterDiscovery(rl, zonesRes) {
     return (await rlQuestion(rl, 'Route53 hosted zone ID: ')).trim();
   }
   if (zonesRes.zones.length === 0) {
-    logWarn('No public Route53 hosted zone for this apex domain in the current AWS account.');
+    logWarn(
+      'No public Route53 hosted zone for this apex domain in the current AWS account.'
+    );
     return (await rlQuestion(rl, 'Route53 hosted zone ID: ')).trim();
   }
   if (zonesRes.zones.length === 1) {
     const only = zonesRes.zones[0];
     logInfo(`Discovered public hosted zone ${only.id} (${only.name}).`);
-    const a = (await rlQuestion(rl, 'Use this hosted zone? [Y/e to enter a different ID]: ')).trim().toLowerCase();
+    const a = (
+      await rlQuestion(
+        rl,
+        'Use this hosted zone? [Y/e to enter a different ID]: '
+      )
+    )
+      .trim()
+      .toLowerCase();
     if (a === 'e' || a === 'edit') {
       return (await rlQuestion(rl, 'Route53 hosted zone ID: ')).trim();
     }
@@ -1445,7 +1710,12 @@ async function promptHostedZoneAfterDiscovery(rl, zonesRes) {
     logInfo(`  ${i + 1}. ${z.id}  ${z.name}`);
   }
   for (;;) {
-    const raw = (await rlQuestion(rl, 'Choose number (1–n), or 0 to type hosted zone ID manually: ')).trim();
+    const raw = (
+      await rlQuestion(
+        rl,
+        'Choose number (1–n), or 0 to type hosted zone ID manually: '
+      )
+    ).trim();
     const n = parseInt(raw, 10);
     if (raw === '0') {
       return (await rlQuestion(rl, 'Route53 hosted zone ID: ')).trim();
@@ -1453,7 +1723,9 @@ async function promptHostedZoneAfterDiscovery(rl, zonesRes) {
     if (!Number.isNaN(n) && n >= 1 && n <= zonesRes.zones.length) {
       return zonesRes.zones[n - 1].id;
     }
-    logWarn('Invalid choice; enter a number shown above, or 0 for manual input.');
+    logWarn(
+      'Invalid choice; enter a number shown above, or 0 for manual input.'
+    );
   }
 }
 
@@ -1465,20 +1737,44 @@ async function promptHostedZoneAfterDiscovery(rl, zonesRes) {
 async function promptAcmCertAfterDiscovery(rl, certsRes) {
   if (!certsRes.ok) {
     logWarn(`ACM discovery failed: ${certsRes.error || 'unknown error'}`);
-    return (await rlQuestion(rl, 'ACM certificate ARN (us-east-1, covers apex + wildcard): ')).trim();
+    return (
+      await rlQuestion(
+        rl,
+        'ACM certificate ARN (us-east-1, covers apex + wildcard): '
+      )
+    ).trim();
   }
   if (certsRes.matches.length === 0) {
     logWarn(
-      `No issued ACM certificate in ${ACM_CLOUDFRONT_REGION} covers both the apex and *.apex for this domain.`,
+      `No issued ACM certificate in ${ACM_CLOUDFRONT_REGION} covers both the apex and *.apex for this domain.`
     );
-    return (await rlQuestion(rl, 'ACM certificate ARN (us-east-1, covers apex + wildcard): ')).trim();
+    return (
+      await rlQuestion(
+        rl,
+        'ACM certificate ARN (us-east-1, covers apex + wildcard): '
+      )
+    ).trim();
   }
   if (certsRes.matches.length === 1) {
     const only = certsRes.matches[0];
-    logInfo(`Discovered ACM certificate in ${ACM_CLOUDFRONT_REGION} (primary name: ${only.domainName}).`);
-    const a = (await rlQuestion(rl, 'Use this certificate? [Y/e to enter a different ARN]: ')).trim().toLowerCase();
+    logInfo(
+      `Discovered ACM certificate in ${ACM_CLOUDFRONT_REGION} (primary name: ${only.domainName}).`
+    );
+    const a = (
+      await rlQuestion(
+        rl,
+        'Use this certificate? [Y/e to enter a different ARN]: '
+      )
+    )
+      .trim()
+      .toLowerCase();
     if (a === 'e' || a === 'edit') {
-      return (await rlQuestion(rl, 'ACM certificate ARN (us-east-1, covers apex + wildcard): ')).trim();
+      return (
+        await rlQuestion(
+          rl,
+          'ACM certificate ARN (us-east-1, covers apex + wildcard): '
+        )
+      ).trim();
     }
     return only.arn;
   }
@@ -1488,15 +1784,27 @@ async function promptAcmCertAfterDiscovery(rl, certsRes) {
     logInfo(`  ${i + 1}. ${c.domainName}  ${c.arn}`);
   }
   for (;;) {
-    const raw = (await rlQuestion(rl, 'Choose number (1–n), or 0 to type certificate ARN manually: ')).trim();
+    const raw = (
+      await rlQuestion(
+        rl,
+        'Choose number (1–n), or 0 to type certificate ARN manually: '
+      )
+    ).trim();
     const n = parseInt(raw, 10);
     if (raw === '0') {
-      return (await rlQuestion(rl, 'ACM certificate ARN (us-east-1, covers apex + wildcard): ')).trim();
+      return (
+        await rlQuestion(
+          rl,
+          'ACM certificate ARN (us-east-1, covers apex + wildcard): '
+        )
+      ).trim();
     }
     if (!Number.isNaN(n) && n >= 1 && n <= certsRes.matches.length) {
       return certsRes.matches[n - 1].arn;
     }
-    logWarn('Invalid choice; enter a number shown above, or 0 for manual input.');
+    logWarn(
+      'Invalid choice; enter a number shown above, or 0 for manual input.'
+    );
   }
 }
 
@@ -1513,15 +1821,27 @@ async function resolveAwsHostedZoneAndCertificate(rl, zonesRes, certsRes) {
     const z = zonesRes.zones[0];
     const c = certsRes.matches[0];
     logInfo(`Discovered hosted zone ${z.id} (${z.name}).`);
-    logInfo(`Discovered ACM certificate in ${ACM_CLOUDFRONT_REGION} (primary name: ${c.domainName}).`);
-    const a = (await rlQuestion(rl, 'Use these values? [Y/e to enter zone ID and ARN manually]: '))
+    logInfo(
+      `Discovered ACM certificate in ${ACM_CLOUDFRONT_REGION} (primary name: ${c.domainName}).`
+    );
+    const a = (
+      await rlQuestion(
+        rl,
+        'Use these values? [Y/e to enter zone ID and ARN manually]: '
+      )
+    )
       .trim()
       .toLowerCase();
     if (a !== 'e' && a !== 'edit') {
       return { zone: z.id, cert: c.arn };
     }
     const zone = (await rlQuestion(rl, 'Route53 hosted zone ID: ')).trim();
-    const cert = (await rlQuestion(rl, 'ACM certificate ARN (us-east-1, covers apex + wildcard): ')).trim();
+    const cert = (
+      await rlQuestion(
+        rl,
+        'ACM certificate ARN (us-east-1, covers apex + wildcard): '
+      )
+    ).trim();
     return { zone, cert };
   }
   const zone = await promptHostedZoneAfterDiscovery(rl, zonesRes);
@@ -1541,27 +1861,45 @@ async function phaseAws(flags, rl, acc) {
   }
   await ensureAwsCredentials(rl, flags);
 
-  const domain = (await rlQuestion(rl, 'APEX domain (e.g. example.com): ')).trim();
+  const domain = (
+    await rlQuestion(rl, 'APEX domain (e.g. example.com): ')
+  ).trim();
   if (!domain) {
-    logWarn('No domain provided; skipping AWS bootstrap (re-run this phase when ready).');
+    logWarn(
+      'No domain provided; skipping AWS bootstrap (re-run this phase when ready).'
+    );
     return;
   }
-  logInfo(`Querying AWS for Route53 hosted zone and ACM certificate (${ACM_CLOUDFRONT_REGION})…`);
+  logInfo(
+    `Querying AWS for Route53 hosted zone and ACM certificate (${ACM_CLOUDFRONT_REGION})…`
+  );
   const profileArgs = awsProfileArgs(flags);
   const zonesRes = await discoverRoute53PublicZonesForApex(domain, profileArgs);
-  const certsRes = await discoverIssuedCertsCoveringApexWildcard(domain, profileArgs);
-  const { zone, cert } = await resolveAwsHostedZoneAndCertificate(rl, zonesRes, certsRes);
+  const certsRes = await discoverIssuedCertsCoveringApexWildcard(
+    domain,
+    profileArgs
+  );
+  const { zone, cert } = await resolveAwsHostedZoneAndCertificate(
+    rl,
+    zonesRes,
+    certsRes
+  );
   if (!zone || !cert) {
-    logWarn('Missing hosted zone ID or ACM certificate ARN; skipping AWS bootstrap.');
+    logWarn(
+      'Missing hosted zone ID or ACM certificate ARN; skipping AWS bootstrap.'
+    );
     return;
   }
   const slugBase = await readSupabaseProjectSlugBase();
   const defaultCfStack = `${slugBase}-pr-preview`;
   const stack =
-    (await rlQuestion(rl, `CloudFormation stack name [${defaultCfStack}]: `)).trim() || defaultCfStack;
+    (
+      await rlQuestion(rl, `CloudFormation stack name [${defaultCfStack}]: `)
+    ).trim() || defaultCfStack;
   const region =
     (await rlQuestion(rl, 'AWS region [us-east-1]: ')).trim() || 'us-east-1';
-  const prefix = (await rlQuestion(rl, 'Preview URL prefix [pr-]: ')).trim() || 'pr-';
+  const prefix =
+    (await rlQuestion(rl, 'Preview URL prefix [pr-]: ')).trim() || 'pr-';
 
   acc.PR_PREVIEW_DOMAIN = domain;
   acc.PR_PREVIEW_HOSTED_ZONE_ID = zone;
@@ -1592,14 +1930,20 @@ async function phaseAws(flags, rl, acc) {
   }
   if (flags.dryRun) {
     logInfo(
-      `[dry-run] would run bootstrap-aws-stack.sh (domain=${domain}, hostedZone=${zone}, stack=${stack}, certificateArn=(set)); no script execution or .env.aws.generated.local read.`,
+      `[dry-run] would run bootstrap-aws-stack.sh (domain=${domain}, hostedZone=${zone}, stack=${stack}, certificateArn=(set)); no script execution or .env.aws.generated.local read.`
     );
     return;
   }
 
-  const conflictOutcome = await resolveAwsPreflightConflictsInteractive(rl, flags, args);
+  const conflictOutcome = await resolveAwsPreflightConflictsInteractive(
+    rl,
+    flags,
+    args
+  );
   if (conflictOutcome.skipAwsPhase) {
-    logWarn('Skipping AWS bootstrap by your choice; re-run with --from=aws when ready.');
+    logWarn(
+      'Skipping AWS bootstrap by your choice; re-run with --from=aws when ready.'
+    );
     return;
   }
   if (conflictOutcome.allowConflictingBuckets) {
@@ -1607,13 +1951,17 @@ async function phaseAws(flags, rl, acc) {
   }
 
   if (input.isTTY) {
-    const cfStatus = await describeCloudFormationStackStatus(stack, region, profileArgs);
+    const cfStatus = await describeCloudFormationStackStatus(
+      stack,
+      region,
+      profileArgs
+    );
     if (cfStatus === 'CREATE_COMPLETE' || cfStatus === 'UPDATE_COMPLETE') {
       logInfo(`CloudFormation stack "${stack}" is already ${cfStatus}.`);
       const mode = (
         await rlQuestion(
           rl,
-          '(D)eploy / update stack  or  (R)efresh outputs only (skip CloudFormation) [D]: ',
+          '(D)eploy / update stack  or  (R)efresh outputs only (skip CloudFormation) [D]: '
         )
       )
         .trim()
@@ -1624,22 +1972,35 @@ async function phaseAws(flags, rl, acc) {
     }
   }
 
-  logInfo('Running bootstrap-aws-stack.sh (outputs go to .env.aws.generated.local)');
+  logInfo(
+    'Running bootstrap-aws-stack.sh (outputs go to .env.aws.generated.local)'
+  );
   // Merge accumulated Supabase URLs into the child environment so bootstrap-aws-stack.sh
   // can inject them into the CloudFormation CSP parameters. These values live in acc (not
   // process.env) because they were discovered interactively during this setup session.
   const bootstrapEnv = {
     ...childProcessEnvForSpawn(),
-    ...(acc.PRODUCTION_SUPABASE_URL && { PRODUCTION_SUPABASE_URL: acc.PRODUCTION_SUPABASE_URL }),
-    ...(acc.STAGING_SUPABASE_URL && { STAGING_SUPABASE_URL: acc.STAGING_SUPABASE_URL }),
-    ...(acc.PREVIEW_SUPABASE_URL && { PREVIEW_SUPABASE_URL: acc.PREVIEW_SUPABASE_URL }),
+    ...(acc.PRODUCTION_SUPABASE_URL && {
+      PRODUCTION_SUPABASE_URL: acc.PRODUCTION_SUPABASE_URL,
+    }),
+    ...(acc.STAGING_SUPABASE_URL && {
+      STAGING_SUPABASE_URL: acc.STAGING_SUPABASE_URL,
+    }),
+    ...(acc.PREVIEW_SUPABASE_URL && {
+      PREVIEW_SUPABASE_URL: acc.PREVIEW_SUPABASE_URL,
+    }),
   };
-  const code = runInteractive('bash', args, { cwd: REPO_ROOT, env: bootstrapEnv });
+  const code = runInteractive('bash', args, {
+    cwd: REPO_ROOT,
+    env: bootstrapEnv,
+  });
   if (code !== 0) {
     logWarn(
-      'AWS bootstrap failed. Common causes: retained S3 buckets for this apex (see preflight), duplicate CloudFront aliases, IAM permissions, or ACM in us-east-1. Scroll up for [DIAG] lines from bootstrap-aws-stack.sh.',
+      'AWS bootstrap failed. Common causes: retained S3 buckets for this apex (see preflight), duplicate CloudFront aliases, IAM permissions, or ACM in us-east-1. Scroll up for [DIAG] lines from bootstrap-aws-stack.sh.'
     );
-    logWarn('Fix the issue, then re-run with: node scripts/setup-full.mjs --from=aws');
+    logWarn(
+      'Fix the issue, then re-run with: node scripts/setup-full.mjs --from=aws'
+    );
     return;
   }
   const awsFile = await readEnvFileIfExists(AWS_ENV_PATH);
@@ -1656,11 +2017,13 @@ async function phaseAws(flags, rl, acc) {
  */
 async function phaseExpo(flags, rl, acc, promptInput) {
   logInfo(
-    'If `eas login` misbehaves in this terminal, use Terminal.app — Expo often expects a real TTY (this script uses /dev/tty when available).',
+    'If `eas login` misbehaves in this terminal, use Terminal.app — Expo often expects a real TTY (this script uses /dev/tty when available).'
   );
 
   if (!flags.dryRun && !easWhoamiOk()) {
-    logWarn('EAS CLI: `eas whoami` failed (not logged in or invalid EXPO_TOKEN).');
+    logWarn(
+      'EAS CLI: `eas whoami` failed (not logged in or invalid EXPO_TOKEN).'
+    );
     await offerInteractiveLogin(rl, flags, {
       label: 'Expo / EAS login',
       question: 'Run `npx eas-cli login` in apps/mobile now? (Y/n/q quit): ',
@@ -1669,11 +2032,14 @@ async function phaseExpo(flags, rl, acc, promptInput) {
       cwd: MOBILE_DIR,
     });
     if (!easWhoamiOk()) {
-      logWarn('EAS still not authenticated; set EXPO_TOKEN or complete login, then re-run --from=expo.');
+      logWarn(
+        'EAS still not authenticated; set EXPO_TOKEN or complete login, then re-run --from=expo.'
+      );
     }
   }
 
-  const runEasOnTty = (/** @type {string[]} */ args) => runInteractiveWithRl(rl, 'npx', args, { cwd: MOBILE_DIR });
+  const runEasOnTty = (/** @type {string[]} */ args) =>
+    runInteractiveWithRl(rl, 'npx', args, { cwd: MOBILE_DIR });
   const runEasCapture = (/** @type {string[]} */ args) => {
     const r = spawnSync('npx', args, {
       cwd: MOBILE_DIR,
@@ -1682,7 +2048,11 @@ async function phaseExpo(flags, rl, acc, promptInput) {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: childProcessEnvForSpawn(),
     });
-    return { status: r.status ?? 1, stdout: r.stdout || '', stderr: r.stderr || '' };
+    return {
+      status: r.status ?? 1,
+      stdout: r.stdout || '',
+      stderr: r.stderr || '',
+    };
   };
 
   const outcome = await ensureNonTemplateEasProject({
@@ -1692,7 +2062,7 @@ async function phaseExpo(flags, rl, acc, promptInput) {
     mobileDir: MOBILE_DIR,
     logInfo,
     logWarn,
-    question: (q) => rlQuestion(rl, q),
+    question: q => rlQuestion(rl, q),
     runEasOnTty,
     runEasCapture,
   });
@@ -1711,18 +2081,25 @@ async function phaseExpo(flags, rl, acc, promptInput) {
  * @param {Record<string, string>} acc
  */
 async function phaseGoogle(flags, rl, acc) {
-  const p = await rlQuestion(rl, 'Path to google-services.json for CI (optional, Enter to skip): ');
+  const p = await rlQuestion(
+    rl,
+    'Path to google-services.json for CI (optional, Enter to skip): '
+  );
   const fp = p.trim();
   if (!fp) return;
   if (flags.dryRun) {
-    logInfo(`[dry-run] would import GOOGLE_SERVICES_* from ${fp} (skipped; no file read).`);
+    logInfo(
+      `[dry-run] would import GOOGLE_SERVICES_* from ${fp} (skipped; no file read).`
+    );
     return;
   }
   try {
     const abs = path.isAbsolute(fp) ? fp : path.join(REPO_ROOT, fp);
     const vars = await envVarsFromGoogleServicesJson(abs);
     Object.assign(acc, vars);
-    logInfo(`Imported ${Object.keys(vars).length} GOOGLE_SERVICES_* keys from file (values not printed).`);
+    logInfo(
+      `Imported ${Object.keys(vars).length} GOOGLE_SERVICES_* keys from file (values not printed).`
+    );
   } catch (e) {
     logWarn(`Could not parse google-services.json: ${(e && e.message) || e}`);
   }
@@ -1736,7 +2113,7 @@ async function phaseWrite(acc, flags) {
   if (flags.dryRun) {
     const n = Object.keys(acc).length;
     logInfo(
-      `[dry-run] would merge ${n} accumulated keys into .env.cloud.generated.local and .env.local (no file writes).`,
+      `[dry-run] would merge ${n} accumulated keys into .env.cloud.generated.local and .env.local (no file writes).`
     );
     logInfo('[dry-run] would write .setup-state.json (no file write).');
     return;
@@ -1744,12 +2121,16 @@ async function phaseWrite(acc, flags) {
   const existing = await readEnvFileIfExists(CLOUD_ENV_PATH);
   const merged = mergeRecords(existing, acc);
   await fs.writeFile(CLOUD_ENV_PATH, stringifyDotEnv(merged), 'utf8');
-  logInfo(`Wrote ${Object.keys(merged).length} entries to .env.cloud.generated.local (contents not shown).`);
+  logInfo(
+    `Wrote ${Object.keys(merged).length} entries to .env.cloud.generated.local (contents not shown).`
+  );
 
   const local = await readEnvFileIfExists(LOCAL_ENV_PATH);
   const mergedLocal = mergeRecords(local, acc);
   await fs.writeFile(LOCAL_ENV_PATH, stringifyDotEnv(mergedLocal), 'utf8');
-  logInfo(`Merged cloud keys into .env.local (${Object.keys(mergedLocal).length} total keys).`);
+  logInfo(
+    `Merged cloud keys into .env.local (${Object.keys(mergedLocal).length} total keys).`
+  );
 
   await fs.writeFile(
     STATE_PATH,
@@ -1761,9 +2142,9 @@ async function phaseWrite(acc, flags) {
         note: 'No secrets stored in this file.',
       },
       null,
-      2,
+      2
     ),
-    'utf8',
+    'utf8'
   );
 }
 
@@ -1780,7 +2161,7 @@ async function collectMissingGithubCiEnvIntoAcc(flags, rl, promptInput, acc) {
     const n = listMissingRequiredGithubForCi(acc).length;
     if (n) {
       logInfo(
-        `[dry-run] ${n} required CI env value(s) missing; would offer masked prompts and re-write .env*.local before gh sync.`,
+        `[dry-run] ${n} required CI env value(s) missing; would offer masked prompts and re-write .env*.local before gh sync.`
       );
     }
     return 'none';
@@ -1791,7 +2172,7 @@ async function collectMissingGithubCiEnvIntoAcc(flags, rl, promptInput, acc) {
 
   if (!input.isTTY) {
     logWarn(
-      `${details.length} required GitHub CI value(s) missing locally; skipping prompts (stdin not a TTY). Add keys to .env.local / .env.cloud.generated.local or run this phase in a full terminal.`,
+      `${details.length} required GitHub CI value(s) missing locally; skipping prompts (stdin not a TTY). Add keys to .env.local / .env.cloud.generated.local or run this phase in a full terminal.`
     );
     return 'none';
   }
@@ -1799,7 +2180,7 @@ async function collectMissingGithubCiEnvIntoAcc(flags, rl, promptInput, acc) {
   const head = (
     await rlQuestion(
       rl,
-      `${details.length} value(s) required for GitHub Actions are missing from merged .env files. Enter them now (masked when sensitive)? (Y)es / (N)o [Y]: `,
+      `${details.length} value(s) required for GitHub Actions are missing from merged .env files. Enter them now (masked when sensitive)? (Y)es / (N)o [Y]: `
     )
   )
     .trim()
@@ -1809,7 +2190,12 @@ async function collectMissingGithubCiEnvIntoAcc(flags, rl, promptInput, acc) {
     return 'declined';
   }
 
-  const pathLine = (await rlQuestion(rl, 'Path to .env-style file with any of these keys (Enter to skip): ')).trim();
+  const pathLine = (
+    await rlQuestion(
+      rl,
+      'Path to .env-style file with any of these keys (Enter to skip): '
+    )
+  ).trim();
   if (pathLine) {
     checkSecretInputQuit(pathLine);
     const primary = details[0].primaryEnvKey;
@@ -1821,12 +2207,18 @@ async function collectMissingGithubCiEnvIntoAcc(flags, rl, promptInput, acc) {
   for (const d of details) {
     if (resolveValueForGithub(acc, d.def)) continue;
 
-    const hint = d.envKeys.length > 1 ? ` (aliases: ${d.envKeys.join(', ')})` : '';
+    const hint =
+      d.envKeys.length > 1 ? ` (aliases: ${d.envKeys.join(', ')})` : '';
     const label = `${d.primaryEnvKey} → GitHub ${d.kind} ${d.name}${hint}`;
 
     let raw;
     if (d.kind === 'secret') {
-      raw = await readSecretLineMaskedOrVisible(rl, promptInput, flags, `${label} (Enter to skip): `);
+      raw = await readSecretLineMaskedOrVisible(
+        rl,
+        promptInput,
+        flags,
+        `${label} (Enter to skip): `
+      );
     } else {
       raw = (await rlQuestion(rl, `${label} (Enter to skip): `)).trim();
     }
@@ -1863,7 +2255,9 @@ async function phaseGithub(flags, rl, acc, promptInput) {
       args: ['auth', 'login'],
     });
     if (!ghAuthOk()) {
-      logWarn('Still not authenticated to GitHub; secret sync will likely fail.');
+      logWarn(
+        'Still not authenticated to GitHub; secret sync will likely fail.'
+      );
     }
   }
 
@@ -1879,18 +2273,28 @@ async function phaseGithub(flags, rl, acc, promptInput) {
   const awsEnv = await readEnvFileIfExists(AWS_ENV_PATH);
   const mergedForGithub = mergeGithubSyncEnv(acc, localEnv, cloudEnv, awsEnv);
   Object.assign(acc, mergedForGithub);
-  logInfo('Merged .env.local, .env.cloud.generated.local, and .env.aws.generated.local for GitHub sync (wizard values override file values; contents not printed).');
   logInfo(
-    `Env file key counts (names/values not listed): .env.local=${Object.keys(localEnv).length}, .env.cloud.generated.local=${Object.keys(cloudEnv).length}, .env.aws.generated.local=${Object.keys(awsEnv).length}`,
+    'Merged .env.local, .env.cloud.generated.local, and .env.aws.generated.local for GitHub sync (wizard values override file values; contents not printed).'
+  );
+  logInfo(
+    `Env file key counts (names/values not listed): .env.local=${Object.keys(localEnv).length}, .env.cloud.generated.local=${Object.keys(cloudEnv).length}, .env.aws.generated.local=${Object.keys(awsEnv).length}`
   );
 
-  const collectOutcome = await collectMissingGithubCiEnvIntoAcc(flags, rl, promptInput, acc);
+  const collectOutcome = await collectMissingGithubCiEnvIntoAcc(
+    flags,
+    rl,
+    promptInput,
+    acc
+  );
   if (collectOutcome === 'completed' && !flags.dryRun) {
     await phaseWrite(acc, flags);
     const localAfter = await readEnvFileIfExists(LOCAL_ENV_PATH);
     const cloudAfter = await readEnvFileIfExists(CLOUD_ENV_PATH);
     const awsAfter = await readEnvFileIfExists(AWS_ENV_PATH);
-    Object.assign(acc, mergeGithubSyncEnv(acc, localAfter, cloudAfter, awsAfter));
+    Object.assign(
+      acc,
+      mergeGithubSyncEnv(acc, localAfter, cloudAfter, awsAfter)
+    );
     logInfo('Re-loaded env files after saving values for GitHub sync.');
   }
 
@@ -1905,7 +2309,11 @@ async function phaseGithub(flags, rl, acc, promptInput) {
     const c = ghSecretSetSync(repo, name, value, flags.dryRun);
     if (c === 0) {
       ok += 1;
-      logInfo(flags.dryRun ? `[dry-run] would set GitHub secret: ${name}` : `GitHub secret set: ${name}`);
+      logInfo(
+        flags.dryRun
+          ? `[dry-run] would set GitHub secret: ${name}`
+          : `GitHub secret set: ${name}`
+      );
     } else fail += 1;
   }
   for (const [name, value] of Object.entries(variables)) {
@@ -1913,10 +2321,16 @@ async function phaseGithub(flags, rl, acc, promptInput) {
     const c = ghVariableSetSync(repo, name, value, flags.dryRun);
     if (c === 0) {
       ok += 1;
-      logInfo(flags.dryRun ? `[dry-run] would set GitHub variable: ${name}` : `GitHub variable set: ${name}`);
+      logInfo(
+        flags.dryRun
+          ? `[dry-run] would set GitHub variable: ${name}`
+          : `GitHub variable set: ${name}`
+      );
     } else fail += 1;
   }
-  logInfo(`GitHub sync finished: ${ok} ok, ${fail} failed (missing permissions skips).`);
+  logInfo(
+    `GitHub sync finished: ${ok} ok, ${fail} failed (missing permissions skips).`
+  );
 }
 
 async function main() {
@@ -1929,18 +2343,35 @@ async function main() {
   const startIdx = PHASE_ORDER.indexOf(flags.fromPhase);
 
   const logCtx = { logInfo, logWarn, repoRoot: REPO_ROOT };
-  printIntroBanner(logCtx, { resumeFrom: startIdx > 0 ? flags.fromPhase : undefined });
+  if (startIdx === 0 && !flags.guideFromCli && input.isTTY) {
+    const g = (
+      await rlQuestion(
+        rl,
+        'Setup guide: (F)ull prerequisites in terminal / (B)rief [F]: '
+      )
+    )
+      .trim()
+      .toLowerCase();
+    if (g === 'b' || g === 'brief') flags.guide = 'brief';
+  }
+  const guideLevel = startIdx > 0 ? 'brief' : flags.guide;
+  printIntroBanner(logCtx, {
+    resumeFrom: startIdx > 0 ? flags.fromPhase : undefined,
+    guide: guideLevel,
+  });
 
   if (startIdx === 0 && !flags.dryRun) {
-    await rl.question(
-      '\nPress Enter after you have reviewed the checklist above (see QUICKSTART.md if needed)…\n',
-    );
+    const reviewHint =
+      guideLevel === 'brief'
+        ? 'docs/setup-prep-checklist.md (and the banner above)'
+        : 'the prerequisites above and docs/setup-prep-checklist.md';
+    await rl.question(`\nPress Enter after you have reviewed ${reviewHint}…\n`);
   }
 
   if (startIdx > 0) {
     if (flags.dryRun) {
       logInfo(
-        `[dry-run] would load merged keys from .env.local / .env.cloud.generated.local / .env.aws.generated.local (--from=${flags.fromPhase}); skipped (no disk read).`,
+        `[dry-run] would load merged keys from .env.local / .env.cloud.generated.local / .env.aws.generated.local (--from=${flags.fromPhase}); skipped (no disk read).`
       );
     } else {
       logInfo(`Loading existing env files (--from=${flags.fromPhase})`);
@@ -1952,20 +2383,32 @@ async function main() {
 
   if (!flags.mobileEnabled) {
     acc.MOBILE_ENABLED = 'false';
-    logInfo('Mobile disabled (--skip-mobile) — skipping Expo, EAS, and Google Services setup.');
+    logInfo(
+      'Mobile disabled (--skip-mobile) — skipping Expo, EAS, and Google Services setup.'
+    );
   } else if (startIdx <= PHASE_ORDER.indexOf('expo')) {
     if (acc.MOBILE_ENABLED) {
       // Resume: honour the stored choice instead of re-prompting with a true default.
       flags.mobileEnabled = acc.MOBILE_ENABLED !== 'false';
-      logInfo(`Resuming with mobile ${flags.mobileEnabled ? 'enabled' : 'disabled'} (stored MOBILE_ENABLED=${acc.MOBILE_ENABLED}).`);
+      logInfo(
+        `Resuming with mobile ${flags.mobileEnabled ? 'enabled' : 'disabled'} (stored MOBILE_ENABLED=${acc.MOBILE_ENABLED}).`
+      );
     } else if (!flags.dryRun) {
-      const mobileAns = (await rlQuestion(rl, 'Enable mobile (Expo / EAS) builds? [Y/n]: ')).trim().toLowerCase();
+      const mobileAns = (
+        await rlQuestion(rl, 'Enable mobile (Expo / EAS) builds? [Y/n]: ')
+      )
+        .trim()
+        .toLowerCase();
       if (mobileAns === 'n' || mobileAns === 'no') {
         flags.mobileEnabled = false;
-        logInfo('Mobile disabled — skipping Expo, EAS, and Google Services setup.');
+        logInfo(
+          'Mobile disabled — skipping Expo, EAS, and Google Services setup.'
+        );
       }
     } else {
-      logInfo('[dry-run] would prompt for mobile setup choice (defaulting to enabled).');
+      logInfo(
+        '[dry-run] would prompt for mobile setup choice (defaulting to enabled).'
+      );
     }
     acc.MOBILE_ENABLED = flags.mobileEnabled ? 'true' : 'false';
   } else {
@@ -1994,7 +2437,10 @@ async function main() {
         logInfo('Skipping GitHub sync (--skip-github).');
         continue;
       }
-      if ((phase === 'expo' || phase === 'google') && acc.MOBILE_ENABLED === 'false') {
+      if (
+        (phase === 'expo' || phase === 'google') &&
+        acc.MOBILE_ENABLED === 'false'
+      ) {
         logInfo(`Skipping ${phase} phase (mobile disabled).`);
         if (phase === 'expo') clearExpoKeysFromAcc(acc);
         if (phase === 'google') clearGoogleKeysFromAcc(acc);
@@ -2034,7 +2480,9 @@ async function main() {
       }
     }
     if (flags.dryRun) {
-      logInfo('[dry-run] finished: no env/state files written; no real API keys or tokens merged by this script.');
+      logInfo(
+        '[dry-run] finished: no env/state files written; no real API keys or tokens merged by this script.'
+      );
     } else {
       logInfo('Done. Verify with: gh secret list && gh variable list');
     }
@@ -2050,8 +2498,11 @@ async function main() {
 }
 
 if (import.meta.url === url.pathToFileURL(process.argv[1] || '').href) {
-  main().catch((err) => {
-    console.error('[setup] Fatal:', redactForLog(String(err && err.stack ? err.stack : err)));
+  main().catch(err => {
+    console.error(
+      '[setup] Fatal:',
+      redactForLog(String(err && err.stack ? err.stack : err))
+    );
     process.exit(1);
   });
 }

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -49,6 +49,10 @@ import {
 import {
   printIntroBanner,
   printPhaseIntro,
+  printAwsPhaseReadinessBriefing,
+  printExpoPhaseReadinessBriefing,
+  printGooglePhaseReadinessBriefing,
+  printGithubPhaseReadinessBriefing,
   confirmRunPhase,
   printManualInstructions,
   SetupQuit,
@@ -58,6 +62,11 @@ import {
   clearExpoKeysFromAcc,
   ensureNonTemplateEasProject,
 } from './lib/setup-expo-eas.mjs';
+import {
+  confirmGithubRepoSyncTarget,
+  logGithubSyncTargetSummary,
+  resolveGhRepoContext,
+} from './lib/setup-github-repo.mjs';
 import {
   formatSupabaseProjectChoiceLine,
   parseApiKeysJson,
@@ -102,7 +111,7 @@ const PHASE_ORDER = [
 /** Merged from dotenv-style secret files / pastes (allowlisted keys only). */
 const MERGEABLE_SETUP_ENV_KEYS = mergeableSetupEnvKeys();
 
-/** @typedef {{ dryRun: boolean; fromPhase: string; skipRename: boolean; awsProfile: string; skipGithub: boolean; mobileEnabled: boolean; plainSecretPrompts: boolean; guide: 'full' | 'brief'; guideFromCli: boolean }} CliFlags */
+/** @typedef {{ dryRun: boolean; fromPhase: string; skipRename: boolean; awsProfile: string; skipGithub: boolean; githubRepo: string; mobileEnabled: boolean; plainSecretPrompts: boolean; guide: 'full' | 'brief'; guideFromCli: boolean }} CliFlags */
 
 function printHelp() {
   console.log(`Usage: node scripts/setup-full.mjs [options]
@@ -115,6 +124,7 @@ Options:
                          merges existing .env*.local first when resuming)
   --skip-rename          Skip the identity / rename phase entirely
   --skip-github          Skip GitHub Actions secret/variable sync
+  --github-repo=OWNER/NAME  Override repo for gh secret/variable sync (default: gh repo view in cwd)
   --skip-mobile          Skip Expo, EAS, and Google Services setup (web-only repos)
   --aws-profile=NAME     Pass through to bootstrap-aws-stack.sh
   --plain-secret-prompts Echo secret prompts in plain text (default: mask typed secrets on a TTY)
@@ -156,6 +166,7 @@ function parseArgv(argv) {
     skipRename: false,
     awsProfile: '',
     skipGithub: false,
+    githubRepo: '',
     mobileEnabled: true,
     plainSecretPrompts: false,
     guide: 'full',
@@ -165,6 +176,8 @@ function parseArgv(argv) {
     if (a === '--dry-run') flags.dryRun = true;
     else if (a === '--skip-rename') flags.skipRename = true;
     else if (a === '--skip-github') flags.skipGithub = true;
+    else if (a.startsWith('--github-repo='))
+      flags.githubRepo = a.slice('--github-repo='.length).trim();
     else if (a === '--skip-mobile') flags.mobileEnabled = false;
     else if (a === '--plain-secret-prompts') flags.plainSecretPrompts = true;
     else if (a === '--brief-guide') {
@@ -611,24 +624,91 @@ async function promptSupabaseAccessTokenForGithub(rl, promptInput, acc, flags) {
     );
     return;
   }
+  const existing = (acc.SUPABASE_ACCESS_TOKEN || '').trim();
+  if (existing) {
+    logInfo(
+      'SUPABASE_ACCESS_TOKEN already collected in this run (stored for GitHub sync in the github phase; value not printed).'
+    );
+    return;
+  }
+
   const dash = 'https://supabase.com/dashboard/account/tokens';
-  logInfo(`Supabase access token for GitHub migrations: ${dash}`);
+  const rotateDoc =
+    'docs/supabase-staging-production-setup.md#rotating-supabase_access_token';
+  logInfo('');
+  logInfo('── Supabase account token for GitHub Actions ──');
+  logInfo('');
+  logInfo(
+    'Project URLs and API keys for preview/staging/production are already saved locally.'
+  );
+  logInfo(
+    'GitHub Actions cannot use your laptop supabase login — it needs a separate account token.'
+  );
+  logInfo('');
+  logInfo('Create this token type (on the page that opens next):');
+  logInfo(
+    '  • Personal access token — Account → Access Tokens (value starts with sbp_)'
+  );
+  logInfo('  • NOT project anon / service_role keys (Project Settings → API)');
+  logInfo('  • NOT a database password or connection string');
+  logInfo('');
+  logInfo('Suggested settings when generating:');
+  logInfo('  • Name: beakerstack-github-actions (any label is fine)');
+  logInfo(
+    '  • Expiry: 90 days to 1 year (recommended); set a reminder before it expires'
+  );
+  logInfo(
+    '  • Never expire: only if you will still rotate on a schedule (see rotation doc below)'
+  );
+  logInfo('');
+  logInfo('CI stores it as GitHub secret SUPABASE_ACCESS_TOKEN for:');
+  logInfo(
+    '  • supabase link, database migrations (db push), Edge Function deploys'
+  );
+  logInfo('');
+  logInfo(`Rotate later: ${rotateDoc}`);
+  logInfo('');
+  logInfo(
+    'If you pasted the same token earlier for supabase login in this wizard, paste it again here.'
+  );
+  logInfo(
+    'Press Enter at the paste prompt with blank to skip (github phase or manual secret).'
+  );
+  logInfo('');
+
+  if (input.isTTY) {
+    await rlQuestion(
+      rl,
+      'Press Enter to open the Supabase access tokens page in your browser…'
+    );
+  } else {
+    logInfo(`Open in your browser: ${dash}`);
+  }
   if (process.platform === 'darwin') {
     spawnSync('open', [dash], { stdio: 'ignore' });
+  } else if (input.isTTY) {
+    logInfo(`If the page did not open: ${dash}`);
   }
+
   const line = await readSecretLineMaskedOrVisible(
     rl,
     promptInput,
     flags,
-    'Paste token, path to file (bare secret or .env), blank to skip, q=quit entire setup: '
+    'Paste SUPABASE_ACCESS_TOKEN (account PAT), path to file, blank to skip, q=quit entire setup: '
   );
   checkSecretInputQuit(line);
-  if (!line.trim()) return;
+  if (!line.trim()) {
+    logInfo(
+      'Skipped SUPABASE_ACCESS_TOKEN for now — add it during the github phase or set the GitHub secret manually.'
+    );
+    return;
+  }
   const resolved = await resolveSecretInputForSetup(
     line,
     'SUPABASE_ACCESS_TOKEN'
   );
   applySecretResolutionToAcc(acc, resolved, 'SUPABASE_ACCESS_TOKEN');
+  logInfo('SUPABASE_ACCESS_TOKEN stored for this run (value not printed).');
 }
 
 /**
@@ -650,26 +730,80 @@ async function promptExpoTokenForGithub(rl, promptInput, acc, flags) {
     logInfo('Using EXPO_TOKEN from environment (value not printed).');
     return;
   }
-  const dash = 'https://expo.dev/accounts/[account]/settings/access-tokens';
-  logInfo(
-    `Expo access token (EXPO_TOKEN) for CI: create at expo.dev → Account → Access tokens`
-  );
-  logInfo(`Docs: ${dash}`);
-  if (process.platform === 'darwin') {
-    spawnSync('open', ['https://expo.dev/settings/access-tokens'], {
-      stdio: 'ignore',
-    });
+  const existing = (acc.EXPO_TOKEN || '').trim();
+  if (existing) {
+    logInfo(
+      'EXPO_TOKEN already collected in this run (stored for GitHub sync in the github phase; value not printed).'
+    );
+    return;
   }
+
+  const dash = 'https://expo.dev/settings/access-tokens';
+  const rotateDoc = 'docs/MOBILE_BUILD_TESTING.md#rotating-expo_token';
+  logInfo('');
+  logInfo('── Expo access token for GitHub Actions ──');
+  logInfo('');
+  logInfo(
+    'CI cannot use your local `eas login` session — it needs a separate access token (EXPO_TOKEN).'
+  );
+  logInfo('');
+  logInfo('Create this token type (on the page that opens next):');
+  logInfo(
+    '  • **Access token** — expo.dev → Account settings → Access tokens → Create token'
+  );
+  logInfo(
+    '  • Use for automation / CI (EAS Update, EAS Build in GitHub Actions)'
+  );
+  logInfo(
+    '  • NOT your Expo account password; NOT the project UUID (that is EXPO_PROJECT_ID)'
+  );
+  logInfo('');
+  logInfo('Suggested settings:');
+  logInfo('  • Name: beakerstack-github-actions');
+  logInfo(
+    '  • Expiry: match your security policy (set a reminder; expired token breaks mobile CI)'
+  );
+  logInfo(
+    '  • Scopes: allow EAS Build + Update for this project if the UI asks'
+  );
+  logInfo('');
+  logInfo(`Rotate later: ${rotateDoc}`);
+  logInfo('');
+  logInfo(
+    'Press Enter at the paste prompt with blank to skip (github phase or GitHub secret manually).'
+  );
+  logInfo('');
+
+  if (input.isTTY) {
+    await rlQuestion(
+      rl,
+      'Press Enter to open Expo access tokens in your browser…'
+    );
+  } else {
+    logInfo(`Open in your browser: ${dash}`);
+  }
+  if (process.platform === 'darwin') {
+    spawnSync('open', [dash], { stdio: 'ignore' });
+  } else if (input.isTTY) {
+    logInfo(`If the page did not open: ${dash}`);
+  }
+
   const line = await readSecretLineMaskedOrVisible(
     rl,
     promptInput,
     flags,
-    'Paste EXPO_TOKEN, path to file (bare secret or .env), blank to skip, q=quit entire setup: '
+    'Paste EXPO_TOKEN (access token), path to file, blank to skip, q=quit entire setup: '
   );
   checkSecretInputQuit(line);
-  if (!line.trim()) return;
+  if (!line.trim()) {
+    logInfo(
+      'Skipped EXPO_TOKEN for now — add it during the github phase or set the GitHub secret manually.'
+    );
+    return;
+  }
   const resolved = await resolveSecretInputForSetup(line, 'EXPO_TOKEN');
   applySecretResolutionToAcc(acc, resolved, 'EXPO_TOKEN');
+  logInfo('EXPO_TOKEN stored for this run (value not printed).');
 }
 
 /**
@@ -1188,20 +1322,6 @@ function ghVariableSetSync(repo, name, value, dryRun) {
     logWarn(`gh variable set ${name} failed: ${redactForLog(r.stderr || '')}`);
   }
   return r.status ?? 1;
-}
-
-function resolveGhRepo() {
-  const r = spawnSync(
-    'gh',
-    ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'],
-    {
-      cwd: REPO_ROOT,
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }
-  );
-  if (r.status !== 0) return '';
-  return (r.stdout || '').trim();
 }
 
 function which(cmd) {
@@ -2016,10 +2136,6 @@ async function phaseAws(flags, rl, acc) {
  * @param {import('stream').Readable & { isTTY?: boolean; setRawMode?: (flag: boolean) => void }} promptInput
  */
 async function phaseExpo(flags, rl, acc, promptInput) {
-  logInfo(
-    'If `eas login` misbehaves in this terminal, use Terminal.app — Expo often expects a real TTY (this script uses /dev/tty when available).'
-  );
-
   if (!flags.dryRun && !easWhoamiOk()) {
     logWarn(
       'EAS CLI: `eas whoami` failed (not logged in or invalid EXPO_TOKEN).'
@@ -2081,12 +2197,25 @@ async function phaseExpo(flags, rl, acc, promptInput) {
  * @param {Record<string, string>} acc
  */
 async function phaseGoogle(flags, rl, acc) {
+  logInfo('');
+  logInfo(
+    'Paste the path to your downloaded google-services.json (absolute or relative to repo root).'
+  );
+  logInfo(
+    'Press Enter with blank to skip — you can add GOOGLE_SERVICES_* later in the github phase.'
+  );
+  logInfo('');
   const p = await rlQuestion(
     rl,
-    'Path to google-services.json for CI (optional, Enter to skip): '
+    'Path to google-services.json (optional, Enter to skip): '
   );
   const fp = p.trim();
-  if (!fp) return;
+  if (!fp) {
+    logInfo(
+      'Skipped Google Services import — mobile CI can still run without native Google keys until you add them.'
+    );
+    return;
+  }
   if (flags.dryRun) {
     logInfo(
       `[dry-run] would import GOOGLE_SERVICES_* from ${fp} (skipped; no file read).`
@@ -2261,12 +2390,12 @@ async function phaseGithub(flags, rl, acc, promptInput) {
     }
   }
 
-  const repo = resolveGhRepo();
+  const ghCtx = resolveGhRepoContext(REPO_ROOT, flags.githubRepo);
+  const repo = ghCtx.repo;
   if (!repo) {
-    logWarn('Could not resolve repo (gh repo view).');
+    logWarn('Could not resolve repo (gh repo view / git origin).');
     return;
   }
-  logInfo(`Using repository: ${repo}`);
 
   const localEnv = await readEnvFileIfExists(LOCAL_ENV_PATH);
   const cloudEnv = await readEnvFileIfExists(CLOUD_ENV_PATH);
@@ -2301,6 +2430,20 @@ async function phaseGithub(flags, rl, acc, promptInput) {
   const secrets = collectGithubSecretPayload(acc);
   const variables = collectGithubVariablePayload(acc);
   logMissingRequiredGithubForCi(acc);
+
+  const secretCount = Object.values(secrets).filter(v => v).length;
+  const variableCount = Object.values(variables).filter(v => v).length;
+  logGithubSyncTargetSummary({ logInfo, logWarn }, ghCtx, {
+    secretCount,
+    variableCount,
+  });
+  const proceed = await confirmGithubRepoSyncTarget(
+    rl,
+    { logInfo, logWarn },
+    ghCtx,
+    { dryRun: flags.dryRun, interactive: input.isTTY }
+  );
+  if (!proceed) return;
 
   let ok = 0;
   let fail = 0;
@@ -2454,6 +2597,46 @@ async function main() {
           clearExpoKeysFromAcc(acc);
         }
         continue;
+      }
+
+      if (phase === 'aws') {
+        printAwsPhaseReadinessBriefing(logCtx);
+        if (!flags.dryRun && input.isTTY) {
+          await rlQuestion(
+            rl,
+            'Press Enter when Route53, ACM (us-east-1), and AWS CLI credentials above are ready…'
+          );
+        }
+      }
+
+      if (phase === 'expo') {
+        printExpoPhaseReadinessBriefing(logCtx);
+        if (!flags.dryRun && input.isTTY) {
+          await rlQuestion(
+            rl,
+            'Press Enter when you have an Expo account and know link vs new project (above)…'
+          );
+        }
+      }
+
+      if (phase === 'google') {
+        printGooglePhaseReadinessBriefing(logCtx);
+        if (!flags.dryRun && input.isTTY) {
+          await rlQuestion(
+            rl,
+            'Press Enter to continue (have google-services.json path ready, or skip with blank at next prompt)…'
+          );
+        }
+      }
+
+      if (phase === 'github' && !flags.skipGithub) {
+        printGithubPhaseReadinessBriefing(logCtx);
+        if (!flags.dryRun && input.isTTY) {
+          await rlQuestion(
+            rl,
+            'Press Enter when gh is authenticated and you are ready to sync secrets (or skip this phase with N)…'
+          );
+        }
       }
 
       switch (phase) {

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -749,7 +749,7 @@ async function promptExpoTokenForGithub(rl, promptInput, acc, flags) {
   logInfo('');
   logInfo('Create this token type (on the page that opens next):');
   logInfo(
-    '  • **Access token** — expo.dev → Account settings → Access tokens → Create token'
+    '  • Access token — expo.dev → Account settings → Access tokens → Create token'
   );
   logInfo(
     '  • Use for automation / CI (EAS Update, EAS Build in GitHub Actions)'
@@ -2441,7 +2441,11 @@ async function phaseGithub(flags, rl, acc, promptInput) {
     rl,
     { logInfo, logWarn },
     ghCtx,
-    { dryRun: flags.dryRun, interactive: input.isTTY }
+    {
+      dryRun: flags.dryRun,
+      interactive: input.isTTY,
+      githubRepoOverride: Boolean(flags.githubRepo),
+    }
   );
   if (!proceed) return;
 

--- a/scripts/setup-menu.mjs
+++ b/scripts/setup-menu.mjs
@@ -47,7 +47,7 @@ async function main() {
       choice =
         (
           await rl.question(
-            'Setup: (1) Local — dependencies, Supabase Docker, .env.local [default]  (2) Full cloud — remote resources, GitHub (read README + QUICKSTART first)  (q) Quit: ',
+            'Setup: (1) Local — dependencies, Supabase Docker, .env.local [default]  (2) Full cloud — remote resources, GitHub (read docs/setup-prep-checklist.md first)  (q) Quit: '
           )
         )
           .trim()
@@ -57,20 +57,29 @@ async function main() {
     }
   } else {
     console.log(
-      '[setup] No TTY; running local setup only. For cloud bootstrap run: npm run setup:full',
+      '[setup] No TTY; running local setup only. For cloud bootstrap run: npm run setup:full'
     );
   }
 
-  if (choice === 'q' || choice === 'quit' || choice === 'exit' || choice === 'x') {
+  if (
+    choice === 'q' ||
+    choice === 'quit' ||
+    choice === 'exit' ||
+    choice === 'x'
+  ) {
     logInfo('Goodbye.');
     process.exit(0);
   }
 
   if (choice === '2') {
-    const code = spawnSync(process.execPath, [path.join(__dirname, 'setup-full.mjs'), ...process.argv.slice(2)], {
-      cwd: REPO_ROOT,
-      stdio: 'inherit',
-    });
+    const code = spawnSync(
+      process.execPath,
+      [path.join(__dirname, 'setup-full.mjs'), ...process.argv.slice(2)],
+      {
+        cwd: REPO_ROOT,
+        stdio: 'inherit',
+      }
+    );
     process.exit(code.status ?? 1);
   }
 
@@ -81,7 +90,7 @@ async function main() {
   process.exit(code.status ?? 1);
 }
 
-main().catch((e) => {
+main().catch(e => {
   console.error(e);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

Adds a **pre-flight guide** and **in-wizard readiness briefings** so adopters know what `npm run setup:full` will ask before (and during) each phase—especially for cloud CI and GitHub secret sync.

### Documentation

- **[docs/setup-prep-checklist.md](docs/setup-prep-checklist.md)** — local vs full-cloud tracks; per-phase “have ready / you will be asked”; one-time secrets; post-wizard work (Stripe, OAuth, signed cookies, Lighthouse).
- Wired through **QUICKSTART** (§6.2, github phase pointer), **README**, **docs index**, **setup menu** option (2), and **CONTRIBUTING** (update checklist when changing wizard prompts).
- Phase-specific doc sections: **AWS** ([pr-preview-setup.md](docs/pr-preview-setup.md)), **Expo/Google** ([MOBILE_BUILD_TESTING.md](docs/MOBILE_BUILD_TESTING.md)), **Supabase PAT** ([supabase-staging-production-setup.md](docs/supabase-staging-production-setup.md)).

### Wizard UX (`setup-full`)

- **Full vs brief guide** — default full in-terminal checklist; `--guide=brief` / `--brief-guide` or interactive choice on first run; resume (`--from=`) uses brief banner.
- **Press Enter** readiness briefings after confirming each phase: **AWS**, **Expo**, **Google**, **GitHub** (with expanded Supabase account-PAT explanation in the supabase phase).
- **GitHub sync safety** — shows target repo (`gh repo view` / `git origin`), secret/variable counts, Y/n confirm; **type `owner/repo` to confirm** when target is upstream `Artificer-Innovations/BeakerStack`; skips sync on non-TTY; optional `--github-repo=owner/name`.
- **Expo** — treats `eas init` “Cannot automatically write to dynamic config” as success when project ID is recoverable from CLI output or `.eas/project.json`; patches `app.config.js` accordingly.

## Adopter notes

- **Fork, then sync GitHub secrets** on your fork’s `origin`. Cloning upstream directly will warn before writing to the template repo—use **N** / `--skip-github` on upstream clones.
- Skipped **expo** / **google**? Set `MOBILE_ENABLED=false` at github sync or use `--skip-mobile`.
- Signed cookies and Stripe webhooks remain **post-wizard**; see prep checklist “After the wizard”.

## Test plan

- [ ] Read `docs/setup-prep-checklist.md` against `npm run setup:full -- --help` phase list
- [ ] `npm run setup:full -- --dry-run` — full guide shows external prerequisites; `--brief-guide` shows doc pointers only
- [ ] Confirm phase briefings: `--from=aws`, `--from=expo`, `--from=google`, `--from=github` (Enter gates + github target summary)
- [ ] On upstream clone: github phase shows template warning; cancel without typing repo name
- [ ] On fork clone: github phase shows fork target and Y/n confirm
- [ ] `node --test scripts/__tests__/setup-github-repo.test.mjs`
- [ ] Expo: `eas init` on dynamic `app.config.js` links project without false failure
- [ ] `npm run setup` menu option (2) links prep doc; QUICKSTART §6.2 / §6.4 links resolve