### PR TITLE
feat(setup): Stripe phase and safer fork rename defaults

### DIFF
--- a/docs/renaming.md
+++ b/docs/renaming.md
@@ -19,6 +19,22 @@ The script derives the following variants from the `--from` and `--to` names and
 
 These cover display copy, route slugs, Supabase identifiers, Expo slugs, bundle identifiers, and other string-based references.
 
+## What rename changes vs preserves
+
+By default the script runs in **preserve upstream** mode so forks can keep merging from [Artificer-Innovations/BeakerStack](https://github.com/Artificer-Innovations/BeakerStack) and installing `@beakerstack/*` packages from npm.
+
+| Target                                                          | Default (`--preserve-upstream`)     | Full rebrand (`--full-rebrand`)  |
+| --------------------------------------------------------------- | ----------------------------------- | -------------------------------- |
+| Display name, UI copy, branding                                 | Renamed                             | Renamed                          |
+| Bundle IDs, slugs (`com.anonymous.beakerstack`, `beaker-stack`) | Renamed                             | Renamed                          |
+| `@beakerstack/*` workspace imports                              | **Preserved**                       | Renamed to your flat-lower scope |
+| `docs/UPGRADING.md`, `docs/VERSIONING.md`, `CONTRIBUTING.md`    | **Skipped**                         | Renamed                          |
+| Template-internal identifiers (`beakerstackBillingConfig`)      | **Preserved** (word-boundary rules) | Renamed in file contents         |
+
+Use **full rebrand** only when you want a fully independent monorepo name with no upstream merge or npm scope story.
+
+`npm run setup` asks whether to fully rebrand; answering **no** (default) passes `--preserve-upstream`.
+
 ## Usage
 
 Run the script from the repository root via the npm helper:
@@ -39,8 +55,10 @@ Use `--no-supabase-check` when stdin is not a TTY and you are certain skipping t
 
 Recommended flags:
 
+- `--preserve-upstream` &mdash; Default. Keeps `@beakerstack` scope and skips upstream upgrade docs.
+- `--full-rebrand` &mdash; Legacy behavior: rename npm scope and all docs (same as `--no-preserve-upstream`).
 - `--dry-run` &mdash; Preview changes without writing to disk.
-- `--strict` &mdash; Exit with a non-zero status if any legacy identifiers remain.
+- `--strict` &mdash; Exit with a non-zero status if any legacy identifiers remain (upstream-skipped paths are not scanned).
 - `--verbose` &mdash; Print each file touched during the rename.
 - `--no-supabase-check` &mdash; Skip the Supabase status guard.
 
@@ -48,6 +66,12 @@ Example dry-run with strict validation:
 
 ```bash
 npm run rename -- --from "Beaker Stack" --to "Acme App" --dry-run --strict --verbose
+```
+
+Full rebrand (previous default behavior):
+
+```bash
+npm run rename -- --from "Beaker Stack" --to "Acme App" --full-rebrand
 ```
 
 > The script skips binary assets and the `ios/` and `android/` directories because those assets are typically regenerated after Expo prebuild. All other text files within `apps/`, `packages/`, `supabase/`, `.github/`, and `docs/` are processed.
@@ -64,7 +88,9 @@ After running the rename (without `--dry-run`):
    - Mobile (Expo managed): `npm run type-check:mobile`, `npm run lint:mobile`, `npm run test:unit:mobile`, then `npm run mobile`
 3. Update store metadata or developer console configuration (Apple/Google) if bundle identifiers changed.
 4. Review Supabase project settings (`project_id`, redirect URLs) and update environment variables or secrets in CI/CD systems.
-5. Commit the rename and document the new project name for your team.
+5. Update `package.json` `repository` / `homepage` to your fork’s GitHub URL if they still point at the template repo.
+6. In preserve mode, optionally rename `beakerstackBillingConfig.ts` / its export manually if you want those identifiers to match your product slug.
+7. Commit the rename and document the new project name for your team.
 
 ## Custom Identifiers
 
@@ -78,4 +104,4 @@ For advanced scenarios (multiple bundle IDs, white-label variants), consider run
 - **CI/CD secrets**: GitHub Actions and EAS may store project names or bundle IDs in repository secrets. Update those values manually after running the script.
 - **Supabase deep links**: Ensure the redirect URLs in Supabase `config.toml` or dashboard match the new scheme (e.g., `acme-app://auth/callback`).
 
-For questions or additional automation requirements, open an issue in your derived repository and tailor the script to your workflow.\*\*\*
+For questions or additional automation requirements, open an issue in your derived repository and tailor the script to your workflow.

--- a/docs/setup-prep-checklist.md
+++ b/docs/setup-prep-checklist.md
@@ -31,30 +31,32 @@ Do not commit filled-in values or `.env*` files with secrets.
 
 ## Track B — Full cloud
 
-**Phases:** `prereqs` → `identity` → `supabase` → `aws` → `expo` → `google` → `write` → `github`  
+**Phases:** `prereqs` → `identity` → `supabase` → `aws` → `expo` → `google` → `stripe` → `write` → `github`  
 **Skip a phase:** answer **N** at `Run "<phase>" now?`  
 **Resume:** `npm run setup:full -- --from=supabase` (etc.)
 
 ### Decide first
 
-| Question                | If **no** / skip                          |
-| ----------------------- | ----------------------------------------- |
-| Mobile (Expo / EAS)?    | `--skip-mobile` → skips `expo` + `google` |
-| Rebrand template?       | `--skip-rename` → skips `identity`        |
-| Push secrets with `gh`? | `--skip-github` → skips `github` sync     |
+| Question                | If **no** / skip                                         |
+| ----------------------- | -------------------------------------------------------- |
+| Mobile (Expo / EAS)?    | `--skip-mobile` → skips `expo` + `google`                |
+| Rebrand template?       | `--skip-rename` → skips `identity`                       |
+| Push secrets with `gh`? | `--skip-github` → skips `github` sync                    |
+| Stripe billing in CI?   | `--skip-stripe` → skips `stripe` + Stripe keys at github |
 
 ### At a glance
 
-| Phase    | One-time secrets?                | Notes                                                  |
-| -------- | -------------------------------- | ------------------------------------------------------ |
-| prereqs  | —                                | CLI checks only                                        |
-| identity | —                                | Optional rename                                        |
-| supabase | **DB passwords**                 | 3 tiers: preview, staging, production                  |
-| aws      | —                                | May ask destructive bucket teardown                    |
-| expo     | **EXPO_TOKEN**                   | Skipped if no mobile                                   |
-| google   | —                                | `google-services.json` path                            |
-| write    | —                                | Merges `.env*` files                                   |
-| github   | Stripe webhooks, etc. if missing | May prompt `CLOUDFRONT_*` if you set up signed cookies |
+| Phase    | One-time secrets?            | Notes                                                  |
+| -------- | ---------------------------- | ------------------------------------------------------ |
+| prereqs  | —                            | CLI checks only                                        |
+| identity | —                            | Optional rename                                        |
+| supabase | **DB passwords**             | 3 tiers: preview, staging, production                  |
+| aws      | —                            | May ask destructive bucket teardown                    |
+| expo     | **EXPO_TOKEN**               | Skipped if no mobile                                   |
+| google   | —                            | `google-services.json` path                            |
+| stripe   | Stripe `sk_*` + `whsec_*` ×3 | Preview/staging test; production live when ready       |
+| write    | —                            | Merges `.env*` files                                   |
+| github   | Anything still missing       | May prompt `CLOUDFRONT_*` if you set up signed cookies |
 
 ---
 
@@ -169,6 +171,29 @@ Do not commit filled-in values or `.env*` files with secrets.
 
 ---
 
+### stripe
+
+**Have ready (before Yes — wizard shows checklist + Enter):**
+
+1. **[Stripe account](https://dashboard.stripe.com)** — **Test mode** for preview + staging; **Live mode** only when production is ready.
+2. **Supabase phase done** — so the wizard can print each tier’s webhook URL (`https://<ref>.supabase.co/functions/v1/stripe-webhook`).
+3. Per tier, from Dashboard → **Developers → API keys** and **Webhooks**:
+   - **Preview:** `PREVIEW_STRIPE_SECRET_KEY` + `PREVIEW_STRIPE_WEBHOOK_SECRET`
+   - **Staging:** `STAGING_STRIPE_SECRET_KEY` + `STAGING_STRIPE_WEBHOOK_SECRET`
+   - **Production:** `PRODUCTION_STRIPE_SECRET_KEY` + `PRODUCTION_STRIPE_WEBHOOK_SECRET`
+
+**You will be asked:**
+
+- **Press Enter** when ready (or **N** to skip / `--skip-stripe` for no billing in CI)
+- For each tier (preview → staging → production): collect now? → masked secret key → masked webhook signing secret
+- **Enter** on a tier skips that tier (github may prompt again later)
+
+**Saved as:** `*_STRIPE_*` in `.env.cloud.generated.local` → GitHub secrets in **github** phase.
+
+**Not in this phase:** `npm run billing:sync-stripe`, `supabase secrets set`, Stripe CLI local forwarding — [stripe-billing-setup.md](stripe-billing-setup.md).
+
+---
+
 ### write
 
 **Have ready:** nothing.
@@ -207,7 +232,7 @@ Not run by `setup-full`. Do these when you need them.
 
 | Task                             | In wizard?                               | What to do                                                     |
 | -------------------------------- | ---------------------------------------- | -------------------------------------------------------------- |
-| **Stripe billing**               | Only if keys missing at `github` sync    | [stripe-billing-setup.md](stripe-billing-setup.md)             |
+| **Stripe billing**               | `stripe` phase + sync/webhooks in doc    | [stripe-billing-setup.md](stripe-billing-setup.md)             |
 | **Google / Apple OAuth**         | No                                       | [OAUTH.md](OAUTH.md)                                           |
 | **Signed-cookie preview access** | **No** — separate script after AWS stack | See below                                                      |
 | **Lighthouse CI**                | No                                       | [lighthouse-ci.md](lighthouse-ci.md) — `LHCI_GITHUB_APP_TOKEN` |

--- a/docs/stripe-billing-setup.md
+++ b/docs/stripe-billing-setup.md
@@ -10,6 +10,25 @@ This guide walks you from **zero** to a working **test-mode** Stripe integration
 
 ---
 
+## Before the Stripe wizard phase
+
+If you use `npm run setup:full`, the **stripe** phase (after **supabase**, before **write** / **github**) collects GitHub Actions keys so you are not surprised by `STAGING_STRIPE_SECRET_KEY` at github sync.
+
+### Checklist
+
+| #   | Requirement                      | Details                                                                                                                                                                  |
+| --- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | **Stripe account**               | [dashboard.stripe.com](https://dashboard.stripe.com) — **Test mode** for preview + staging.                                                                              |
+| 2   | **API secret keys**              | Developers → API keys → `sk_test_…` (preview/staging) and `sk_live_…` (production when ready).                                                                           |
+| 3   | **Webhook per Supabase project** | URL `https://<PROJECT_REF>.supabase.co/functions/v1/stripe-webhook` — one endpoint per preview/staging/production project; **Reveal** signing secret `whsec_…` for each. |
+| 4   | **Supabase URLs from setup**     | Complete the **supabase** phase first so the wizard can print each webhook URL.                                                                                          |
+
+Skip billing in CI: answer **N** at the stripe phase or `npm run setup:full -- --skip-stripe`.
+
+**More:** [setup-prep-checklist.md § stripe](setup-prep-checklist.md#stripe)
+
+---
+
 ## 0. Billing model overview (what you are actually setting up)
 
 Beaker Stack uses Stripe for **commercial billing primitives** and Supabase for **application-side entitlement state**.

--- a/scripts/__tests__/rename-project.test.mjs
+++ b/scripts/__tests__/rename-project.test.mjs
@@ -5,29 +5,35 @@ import {
   tokenizeName,
   buildNameVariants,
   buildReplacementPairs,
-  findRemainingOccurrences
+  findRemainingOccurrences,
+  replaceAll,
+  replaceFlatLowerPreservingScope,
+  annotateReplacementsForPreserveMode,
+  isPreserveUpstreamPath,
+  resolvePreserveUpstream,
+  PRESERVE_UPSTREAM_RELATIVE_PATHS,
 } from '../rename-project.mjs';
 
 const BASE_NAME = 'Beaker Stack';
 
-const normalizeToTokens = (name) =>
+const normalizeToTokens = name =>
   name
     .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
     .replace(/[_-]+/g, ' ')
     .trim()
     .split(/\s+/)
     .filter(Boolean)
-    .map((token) => token.toLowerCase());
+    .map(token => token.toLowerCase());
 
 const tokens = normalizeToTokens(BASE_NAME);
-const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
+const capitalize = word => word.charAt(0).toUpperCase() + word.slice(1);
 const titleCase = tokens.map(capitalize).join(' ');
 const pascalCase = tokens.map(capitalize).join('');
 const camelCase = [tokens[0], ...tokens.slice(1).map(capitalize)].join('');
 const kebabCase = tokens.join('-');
 const snakeCase = tokens.join('_');
-const upperSnakeCase = tokens.map((token) => token.toUpperCase()).join('_');
-const upperFlat = tokens.map((token) => token.toUpperCase()).join('');
+const upperSnakeCase = tokens.map(token => token.toUpperCase()).join('_');
+const upperFlat = tokens.map(token => token.toUpperCase()).join('');
 const flatLower = tokens.join('');
 
 test('tokenizeName splits mixed separators and casing', () => {
@@ -52,7 +58,7 @@ test('buildNameVariants derives consistent casing variants', () => {
 test('buildReplacementPairs maps all primary variants', () => {
   const { replacements } = buildReplacementPairs(BASE_NAME, 'Acme App');
 
-  const map = new Map(replacements.map((pair) => [pair.from, pair.to]));
+  const map = new Map(replacements.map(pair => [pair.from, pair.to]));
 
   assert.equal(map.get(titleCase), 'Acme App');
   assert.equal(map.get(pascalCase), 'AcmeApp');
@@ -74,3 +80,84 @@ test('findRemainingOccurrences detects legacy identifiers', () => {
   assert.deepEqual(matches.slice().sort(), expected);
 });
 
+test('isPreserveUpstreamPath matches upgrade and versioning docs', () => {
+  assert.equal(isPreserveUpstreamPath('docs/UPGRADING.md'), true);
+  assert.equal(isPreserveUpstreamPath('docs/VERSIONING.md'), true);
+  assert.equal(isPreserveUpstreamPath('CONTRIBUTING.md'), true);
+  assert.equal(isPreserveUpstreamPath('docs/renaming.md'), false);
+  assert.ok(PRESERVE_UPSTREAM_RELATIVE_PATHS.has('docs/UPGRADING.md'));
+});
+
+test('resolvePreserveUpstream defaults to preserve unless full rebrand', () => {
+  assert.equal(resolvePreserveUpstream({}), true);
+  assert.equal(resolvePreserveUpstream({ preserveUpstream: true }), true);
+  assert.equal(resolvePreserveUpstream({ fullRebrand: true }), false);
+  assert.equal(resolvePreserveUpstream({ preserveUpstream: false }), false);
+  assert.equal(
+    resolvePreserveUpstream({ preserveUpstream: true, fullRebrand: true }),
+    false
+  );
+});
+
+test('replaceFlatLowerPreservingScope keeps @beakerstack and compound identifiers', () => {
+  const input = [
+    `import x from '@beakerstack/billing';`,
+    `const beakerstackBillingConfig = 1;`,
+    `com.anonymous.beakerstack`,
+    `productId: 'beakerstack'`,
+  ].join('\n');
+
+  const { updated, replacementsMade } = replaceFlatLowerPreservingScope(
+    input,
+    flatLower,
+    'acmeapp'
+  );
+
+  assert.match(updated, /@beakerstack\/billing/);
+  assert.match(updated, /beakerstackBillingConfig/);
+  assert.match(updated, /com\.anonymous\.acmeapp/);
+  assert.match(updated, /productId: 'acmeapp'/);
+  assert.equal(replacementsMade, 2);
+});
+
+test('annotateReplacementsForPreserveMode marks flatlower only', () => {
+  const { replacements } = buildReplacementPairs(BASE_NAME, 'Acme App');
+  const annotated = annotateReplacementsForPreserveMode(replacements, true);
+  const flat = annotated.find(pair => pair.description === 'flatlower');
+  const title = annotated.find(pair => pair.description === 'Title case');
+
+  assert.equal(flat?.preserveScope, true);
+  assert.equal(title?.preserveScope, undefined);
+
+  const passthrough = annotateReplacementsForPreserveMode(replacements, false);
+  assert.equal(
+    passthrough.find(pair => pair.description === 'flatlower')?.preserveScope,
+    undefined
+  );
+});
+
+test('replaceAll preserve mode rebrands display name and bundle id', () => {
+  const { replacements } = buildReplacementPairs(BASE_NAME, 'Acme App');
+  const annotated = annotateReplacementsForPreserveMode(replacements, true);
+  const content = [
+    titleCase,
+    '@beakerstack/shared',
+    'com.anonymous.beakerstack',
+  ].join('\n');
+
+  const { updated } = replaceAll(content, annotated);
+
+  assert.match(updated, /Acme App/);
+  assert.match(updated, /@beakerstack\/shared/);
+  assert.match(updated, /com\.anonymous\.acmeapp/);
+});
+
+test('replaceAll full rebrand rewrites npm scope', () => {
+  const { replacements } = buildReplacementPairs(BASE_NAME, 'Acme App');
+  const content = '@beakerstack/billing and BeakerStack';
+
+  const { updated } = replaceAll(content, replacements);
+
+  assert.match(updated, /@acmeapp\/billing/);
+  assert.match(updated, /AcmeApp/);
+});

--- a/scripts/__tests__/rename-project.test.mjs
+++ b/scripts/__tests__/rename-project.test.mjs
@@ -120,6 +120,16 @@ test('replaceFlatLowerPreservingScope keeps @beakerstack and compound identifier
   assert.equal(replacementsMade, 2);
 });
 
+test('uniquePairs keeps flatlower when camelCase shares the same from token', () => {
+  const { replacements } = buildReplacementPairs('Beaker', 'Acme');
+  const annotated = annotateReplacementsForPreserveMode(replacements, true);
+  const beakerPair = annotated.find(pair => pair.from === 'beaker');
+
+  assert.ok(beakerPair);
+  assert.equal(beakerPair.description, 'flatlower');
+  assert.equal(beakerPair.preserveScope, true);
+});
+
 test('annotateReplacementsForPreserveMode marks flatlower only', () => {
   const { replacements } = buildReplacementPairs(BASE_NAME, 'Acme App');
   const annotated = annotateReplacementsForPreserveMode(replacements, true);

--- a/scripts/__tests__/setup-manifest-github-sync.test.mjs
+++ b/scripts/__tests__/setup-manifest-github-sync.test.mjs
@@ -9,15 +9,29 @@ import {
   resolveSetupFromPhase,
 } from '../lib/setup-manifest.mjs';
 
+test('listMissingRequiredGithubForCi omits Stripe when SETUP_STRIPE_SKIPPED', () => {
+  const missing = listMissingRequiredGithubForCi({
+    SETUP_STRIPE_SKIPPED: 'true',
+    SUPABASE_ACCESS_TOKEN: 'pat',
+    AWS_ACCESS_KEY_ID: 'x',
+    AWS_SECRET_ACCESS_KEY: 'y',
+  });
+  assert.ok(!missing.some(m => m.name.includes('STRIPE')));
+});
+
 test('listMissingRequiredGithubCiDetails includes primaryEnvKey and groups core before aws', () => {
   const details = listMissingRequiredGithubCiDetails({});
   assert.ok(details.length > 0);
-  const coreIdx = details.findIndex((d) => d.group === 'core');
-  const awsIdx = details.findIndex((d) => d.group === 'aws');
+  const coreIdx = details.findIndex(d => d.group === 'core');
+  const awsIdx = details.findIndex(d => d.group === 'aws');
   assert.ok(coreIdx !== -1 && awsIdx !== -1);
   assert.ok(coreIdx < awsIdx);
-  const core = details.find((d) => d.name === 'SUPABASE_ACCESS_TOKEN');
-  assert.ok(core && core.primaryEnvKey === 'SUPABASE_ACCESS_TOKEN' && core.kind === 'secret');
+  const core = details.find(d => d.name === 'SUPABASE_ACCESS_TOKEN');
+  assert.ok(
+    core &&
+      core.primaryEnvKey === 'SUPABASE_ACCESS_TOKEN' &&
+      core.kind === 'secret'
+  );
 });
 
 test('resolveSetupFromPhase maps gh to github', () => {
@@ -31,7 +45,7 @@ test('mergeGithubSyncEnv: later file layers override earlier; session overrides 
     { AWS_ACCESS_KEY_ID: 'from-session', EXPO_TOKEN: 'tok' },
     { AWS_ACCESS_KEY_ID: 'from-local', STAGING_SUPABASE_URL: 'https://local' },
     { AWS_ACCESS_KEY_ID: 'from-cloud', STAGING_SUPABASE_URL: 'https://cloud' },
-    { AWS_ACCESS_KEY_ID: 'from-aws-file' },
+    { AWS_ACCESS_KEY_ID: 'from-aws-file' }
   );
   assert.equal(merged.AWS_ACCESS_KEY_ID, 'from-session');
   assert.equal(merged.STAGING_SUPABASE_URL, 'https://cloud');
@@ -39,7 +53,12 @@ test('mergeGithubSyncEnv: later file layers override earlier; session overrides 
 });
 
 test('mergeGithubSyncEnv: disk-only keys appear when session omits them', () => {
-  const merged = mergeGithubSyncEnv({}, {}, { AWS_SECRET_ACCESS_KEY: 'sec', SUPABASE_ACCESS_TOKEN: 'pat' }, {});
+  const merged = mergeGithubSyncEnv(
+    {},
+    {},
+    { AWS_SECRET_ACCESS_KEY: 'sec', SUPABASE_ACCESS_TOKEN: 'pat' },
+    {}
+  );
   assert.equal(merged.AWS_SECRET_ACCESS_KEY, 'sec');
   assert.equal(merged.SUPABASE_ACCESS_TOKEN, 'pat');
 });
@@ -58,7 +77,8 @@ test('collectGithubSecretPayload picks up values supplied only via merged disk-s
       STAGING_SUPABASE_DB_PASSWORD: 'pw',
       STAGING_STRIPE_SECRET_KEY: 'sk_test_staging',
       STAGING_STRIPE_WEBHOOK_SECRET: 'whsec_staging',
-      STAGING_BILLING_ALLOWED_ORIGINS: 'https://staging.app.example,https://app.example',
+      STAGING_BILLING_ALLOWED_ORIGINS:
+        'https://staging.app.example,https://app.example',
       PRODUCTION_SUPABASE_URL: 'https://prd.supabase.co',
       PRODUCTION_SUPABASE_ANON_KEY: 'anon2',
       PRODUCTION_SUPABASE_PROJECT_REF: 'ref2',
@@ -75,7 +95,7 @@ test('collectGithubSecretPayload picks up values supplied only via merged disk-s
       PR_PREVIEW_CERTIFICATE_ARN: 'arn:aws:acm:…',
       EXPO_PROJECT_ID: 'uuid',
     },
-    {},
+    {}
   );
   const payload = collectGithubSecretPayload(env);
   assert.equal(payload.AWS_ACCESS_KEY_ID, 'AKIA');
@@ -91,8 +111,12 @@ test('collectGithubSecretPayload picks up values supplied only via merged disk-s
 test('listMissingRequiredGithubForCi: empty env lists all required manifest entries', () => {
   const missing = listMissingRequiredGithubForCi({});
   assert.ok(missing.length > 5);
-  assert.ok(missing.some((m) => m.name === 'AWS_ACCESS_KEY_ID' && m.kind === 'secret'));
-  assert.ok(missing.some((m) => m.name === 'PR_PREVIEW_DOMAIN' && m.kind === 'variable'));
+  assert.ok(
+    missing.some(m => m.name === 'AWS_ACCESS_KEY_ID' && m.kind === 'secret')
+  );
+  assert.ok(
+    missing.some(m => m.name === 'PR_PREVIEW_DOMAIN' && m.kind === 'variable')
+  );
 });
 
 test('listMissingRequiredGithubForCi: satisfied required entries are omitted', () => {
@@ -126,7 +150,7 @@ test('listMissingRequiredGithubForCi: satisfied required entries are omitted', (
       EXPO_TOKEN: 'et',
       EXPO_PROJECT_ID: 'ep',
     },
-    {},
+    {}
   );
   Object.assign(env, {
     PR_PREVIEW_DOMAIN: 'd.example',
@@ -173,7 +197,7 @@ test('listMissingRequiredGithubForCi: optional google block not required', () =>
       PR_PREVIEW_STACK_NAME: 's',
       EXPO_ACCOUNT: 'acct',
     },
-    {},
+    {}
   );
   const missing = listMissingRequiredGithubForCi(env);
   assert.equal(missing.length, 0);

--- a/scripts/__tests__/setup-manifest-github-sync.test.mjs
+++ b/scripts/__tests__/setup-manifest-github-sync.test.mjs
@@ -9,6 +9,13 @@ import {
   resolveSetupFromPhase,
 } from '../lib/setup-manifest.mjs';
 
+test('listMissingRequiredGithubCiDetails includes def for github-phase filtering', () => {
+  const details = listMissingRequiredGithubCiDetails({});
+  const stripe = details.find(d => d.name === 'STAGING_STRIPE_SECRET_KEY');
+  assert.ok(stripe?.def);
+  assert.equal(stripe.primaryEnvKey, 'STAGING_STRIPE_SECRET_KEY');
+});
+
 test('listMissingRequiredGithubForCi omits Stripe when SETUP_STRIPE_SKIPPED', () => {
   const missing = listMissingRequiredGithubForCi({
     SETUP_STRIPE_SKIPPED: 'true',

--- a/scripts/__tests__/setup-stripe.test.mjs
+++ b/scripts/__tests__/setup-stripe.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  supabaseStripeWebhookUrl,
+  tierStripeKeysPresent,
+  STRIPE_SETUP_TIERS,
+} from '../lib/setup-stripe.mjs';
+
+test('supabaseStripeWebhookUrl', () => {
+  assert.equal(
+    supabaseStripeWebhookUrl('https://abcd1234.supabase.co'),
+    'https://abcd1234.supabase.co/functions/v1/stripe-webhook'
+  );
+  assert.equal(supabaseStripeWebhookUrl('http://localhost:54321'), '');
+});
+
+test('tierStripeKeysPresent', () => {
+  const tier = STRIPE_SETUP_TIERS.find(t => t.id === 'staging');
+  assert.ok(tier);
+  assert.ok(
+    !tierStripeKeysPresent({ STAGING_STRIPE_SECRET_KEY: 'sk_test_x' }, tier)
+  );
+  assert.ok(
+    tierStripeKeysPresent(
+      {
+        STAGING_STRIPE_SECRET_KEY: 'sk_test_x',
+        STAGING_STRIPE_WEBHOOK_SECRET: 'whsec_x',
+      },
+      tier
+    )
+  );
+});

--- a/scripts/__tests__/setup-stripe.test.mjs
+++ b/scripts/__tests__/setup-stripe.test.mjs
@@ -2,6 +2,9 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  isStripeGithubSecretDef,
+  resolveSupabaseUrlForStripeTier,
+  setupStripeKeysDeferred,
   supabaseStripeWebhookUrl,
   tierStripeKeysPresent,
   STRIPE_SETUP_TIERS,
@@ -13,6 +16,13 @@ test('supabaseStripeWebhookUrl', () => {
     'https://abcd1234.supabase.co/functions/v1/stripe-webhook'
   );
   assert.equal(supabaseStripeWebhookUrl('http://localhost:54321'), '');
+});
+
+test('supabaseStripeWebhookUrl strips trailing slash', () => {
+  assert.equal(
+    supabaseStripeWebhookUrl('https://abcd1234.supabase.co/'),
+    'https://abcd1234.supabase.co/functions/v1/stripe-webhook'
+  );
 });
 
 test('tierStripeKeysPresent', () => {
@@ -30,4 +40,39 @@ test('tierStripeKeysPresent', () => {
       tier
     )
   );
+});
+
+test('isStripeGithubSecretDef matches STRIPE keys', () => {
+  assert.ok(isStripeGithubSecretDef({ name: 'STAGING_STRIPE_SECRET_KEY' }));
+  assert.ok(
+    isStripeGithubSecretDef({ name: 'PRODUCTION_STRIPE_WEBHOOK_SECRET' })
+  );
+  assert.ok(!isStripeGithubSecretDef({ name: 'AWS_ACCESS_KEY_ID' }));
+  assert.ok(!isStripeGithubSecretDef({}));
+});
+
+test('setupStripeKeysDeferred', () => {
+  assert.ok(setupStripeKeysDeferred({ SETUP_STRIPE_SKIPPED: 'true' }));
+  assert.ok(!setupStripeKeysDeferred({ SETUP_STRIPE_SKIPPED: 'false' }));
+  assert.ok(!setupStripeKeysDeferred({}));
+});
+
+test('resolveSupabaseUrlForStripeTier uses first non-empty key', () => {
+  const tier = STRIPE_SETUP_TIERS.find(t => t.id === 'preview');
+  assert.ok(tier);
+  assert.equal(
+    resolveSupabaseUrlForStripeTier(
+      { PREVIEW_SUPABASE_URL: 'https://a.supabase.co' },
+      tier
+    ),
+    'https://a.supabase.co'
+  );
+  assert.equal(
+    resolveSupabaseUrlForStripeTier(
+      { PR_TESTING_SUPABASE_URL: 'https://b.supabase.co' },
+      tier
+    ),
+    'https://b.supabase.co'
+  );
+  assert.equal(resolveSupabaseUrlForStripeTier({}, tier), '');
 });

--- a/scripts/__tests__/setup-stripe.test.mjs
+++ b/scripts/__tests__/setup-stripe.test.mjs
@@ -15,13 +15,24 @@ test('supabaseStripeWebhookUrl', () => {
     supabaseStripeWebhookUrl('https://abcd1234.supabase.co'),
     'https://abcd1234.supabase.co/functions/v1/stripe-webhook'
   );
-  assert.equal(supabaseStripeWebhookUrl('http://localhost:54321'), '');
+  assert.equal(supabaseStripeWebhookUrl('not-a-url'), '');
 });
 
 test('supabaseStripeWebhookUrl strips trailing slash', () => {
   assert.equal(
     supabaseStripeWebhookUrl('https://abcd1234.supabase.co/'),
     'https://abcd1234.supabase.co/functions/v1/stripe-webhook'
+  );
+});
+
+test('supabaseStripeWebhookUrl supports local and custom base URLs', () => {
+  assert.equal(
+    supabaseStripeWebhookUrl('http://127.0.0.1:54321'),
+    'http://127.0.0.1:54321/functions/v1/stripe-webhook'
+  );
+  assert.equal(
+    supabaseStripeWebhookUrl('https://api.example.com/custom/path/'),
+    'https://api.example.com/custom/path/functions/v1/stripe-webhook'
   );
 });
 

--- a/scripts/lib/setup-manifest.mjs
+++ b/scripts/lib/setup-manifest.mjs
@@ -1,3 +1,8 @@
+import {
+  isStripeGithubSecretDef,
+  setupStripeKeysDeferred,
+} from './setup-stripe.mjs';
+
 /**
  * Maps local .env keys to GitHub Actions secrets/variables used by workflows.
  * Values are never logged by the setup orchestrator.
@@ -134,7 +139,10 @@ export const GITHUB_SECRETS = [
   {
     type: 'secret',
     name: 'SUPABASE_PREVIEW_PROJECT_REF',
-    envKeys: ['SUPABASE_PREVIEW_PROJECT_REF', 'PR_TESTING_SUPABASE_PROJECT_REF'],
+    envKeys: [
+      'SUPABASE_PREVIEW_PROJECT_REF',
+      'PR_TESTING_SUPABASE_PROJECT_REF',
+    ],
     group: 'preview',
   },
   {
@@ -438,17 +446,28 @@ export function listMissingRequiredGithubForCi(env) {
   /** @type {{ kind: 'secret' | 'variable'; name: string; group: string }[]} */
   const missing = [];
   const mobileDisabled = env.MOBILE_ENABLED === 'false';
+  const stripeDeferred = setupStripeKeysDeferred(env);
   for (const def of GITHUB_SECRETS) {
     if (def.optional) continue;
     if (mobileDisabled && MOBILE_GROUPS.has(def.group)) continue;
+    if (stripeDeferred && isStripeGithubSecretDef(def)) continue;
     if (resolveValueForGithub(env, def)) continue;
-    missing.push({ kind: 'secret', name: def.name, group: def.group || 'unknown' });
+    missing.push({
+      kind: 'secret',
+      name: def.name,
+      group: def.group || 'unknown',
+    });
   }
   for (const def of GITHUB_VARIABLES) {
     if (def.optional) continue;
     if (mobileDisabled && MOBILE_GROUPS.has(def.group)) continue;
+    if (stripeDeferred && isStripeGithubSecretDef(def)) continue;
     if (resolveValueForGithub(env, def)) continue;
-    missing.push({ kind: 'variable', name: def.name, group: def.group || 'unknown' });
+    missing.push({
+      kind: 'variable',
+      name: def.name,
+      group: def.group || 'unknown',
+    });
   }
   return missing;
 }
@@ -476,7 +495,9 @@ export function listMissingRequiredGithubCiDetails(env) {
   for (const m of missing) {
     /** @type {GhSecretDef | GhVariableDef | undefined} */
     const def =
-      m.kind === 'secret' ? GITHUB_SECRETS.find((d) => d.name === m.name) : GITHUB_VARIABLES.find((d) => d.name === m.name);
+      m.kind === 'secret'
+        ? GITHUB_SECRETS.find(d => d.name === m.name)
+        : GITHUB_VARIABLES.find(d => d.name === m.name);
     if (!def || !def.envKeys.length) continue;
     out.push({
       kind: m.kind,

--- a/scripts/lib/setup-manual-instructions.mjs
+++ b/scripts/lib/setup-manual-instructions.mjs
@@ -511,7 +511,7 @@ export function printStripePhaseReadinessBriefing(ctx) {
   logInfo('');
   logInfo('4) Complete supabase phase first');
   logInfo(
-    '   • The wizard prints each webhook URL when STAGING_/PREVIEW_/PRODUCTION_SUPABASE_URL is already in acc.'
+    '   • The wizard prints each webhook URL when STAGING_/PREVIEW_/PRODUCTION_SUPABASE_URL is already set from the supabase phase.'
   );
   logInfo('');
   logInfo('5) Not run in this phase (do later)');
@@ -594,7 +594,7 @@ export function printGithubPhaseReadinessBriefing(ctx) {
     '   • Skipped **AWS** or **Supabase**? Add secrets manually later or re-run `--from=aws` / `--from=supabase`.'
   );
   logInfo(
-    '   • Skipped **stripe**? Re-run `--from=stripe` or enter keys here; use `--skip-stripe` to omit Stripe from CI sync.'
+    '   • Skipped **stripe** (menu **N** or `--skip-stripe`)? Stripe keys are omitted from github prompts; re-run `--from=stripe` without `--skip-stripe` to collect them.'
   );
   logInfo('');
   logInfo('5) During this phase');

--- a/scripts/lib/setup-manual-instructions.mjs
+++ b/scripts/lib/setup-manual-instructions.mjs
@@ -250,6 +250,13 @@ const PHASE_INTROS = {
       'If you choose Yes, a prerequisites checklist prints next — optional; press Enter to skip.',
     ],
   },
+  stripe: {
+    title: 'Stripe billing (CI keys)',
+    body: [
+      'Collects PREVIEW_*, STAGING_*, and PRODUCTION_* Stripe secret + webhook signing keys for GitHub Actions.',
+      'If you choose Yes, a prerequisites checklist prints next — Stripe Dashboard test/live mode, webhook URLs per Supabase project.',
+    ],
+  },
   write: {
     title: 'Write env files',
     body: [
@@ -465,6 +472,64 @@ export function printGooglePhaseReadinessBriefing(ctx) {
 }
 
 /**
+ * Prerequisites checklist shown after you confirm the Stripe phase.
+ * @param {LogCtx} ctx
+ */
+export function printStripePhaseReadinessBriefing(ctx) {
+  const { logInfo } = ctx;
+  const doc = 'docs/stripe-billing-setup.md#before-the-stripe-wizard-phase';
+  logInfo('');
+  logInfo('── Before Stripe billing keys ──');
+  logInfo('');
+  logInfo(
+    'BeakerStack billing needs Stripe API keys and webhook signing secrets for each Supabase tier you deploy to CI.'
+  );
+  logInfo('');
+  logInfo('1) Stripe account');
+  logInfo(
+    '   • https://dashboard.stripe.com — use Test mode until you intentionally go live.'
+  );
+  logInfo('');
+  logInfo(
+    '2) Three tiers (same Stripe account is fine; separate webhook endpoints)'
+  );
+  logInfo(
+    '   • Preview + Staging → sk_test_… and whsec_… per Supabase project'
+  );
+  logInfo(
+    '   • Production → sk_live_… and whsec_… (only after you are ready for live charges)'
+  );
+  logInfo('');
+  logInfo('3) Per tier you will paste');
+  logInfo('   • Secret key — Dashboard → Developers → API keys');
+  logInfo(
+    '   • Webhook signing secret — Dashboard → Developers → Webhooks → your endpoint → Reveal'
+  );
+  logInfo(
+    '   • One webhook URL per Supabase project: https://<PROJECT_REF>.supabase.co/functions/v1/stripe-webhook'
+  );
+  logInfo('');
+  logInfo('4) Complete supabase phase first');
+  logInfo(
+    '   • The wizard prints each webhook URL when STAGING_/PREVIEW_/PRODUCTION_SUPABASE_URL is already in acc.'
+  );
+  logInfo('');
+  logInfo('5) Not run in this phase (do later)');
+  logInfo(
+    '   • npm run billing:sync-stripe — creates Products/Prices in Stripe + billing_plans rows'
+  );
+  logInfo('   • supabase secrets set STRIPE_* on each hosted project');
+  logInfo('   • Local dev: Stripe CLI forward (see docs §8)');
+  logInfo('');
+  logInfo(
+    'Skip billing entirely: answer N at Run stripe now, or use --skip-stripe (github will not require Stripe keys).'
+  );
+  logInfo('');
+  logInfo(`Full guide: ${doc}`);
+  logInfo('');
+}
+
+/**
  * Prerequisites checklist shown after you confirm the GitHub sync phase.
  * @param {LogCtx} ctx
  */
@@ -527,6 +592,9 @@ export function printGithubPhaseReadinessBriefing(ctx) {
   logInfo('     or re-run setup with `--skip-mobile`.');
   logInfo(
     '   • Skipped **AWS** or **Supabase**? Add secrets manually later or re-run `--from=aws` / `--from=supabase`.'
+  );
+  logInfo(
+    '   • Skipped **stripe**? Re-run `--from=stripe` or enter keys here; use `--skip-stripe` to omit Stripe from CI sync.'
   );
   logInfo('');
   logInfo('5) During this phase');
@@ -665,6 +733,16 @@ export function printManualInstructions(ctx, phaseId) {
       logInfo(
         '4. See docs/MOBILE_BUILD_TESTING.md#before-the-google-wizard-phase'
       );
+      break;
+    case 'stripe':
+      logInfo(
+        '1. Stripe Dashboard → Developers → API keys (test vs live per tier)'
+      );
+      logInfo(
+        '2. Webhooks → one endpoint per Supabase project URL (whsec_… each)'
+      );
+      logInfo('3. Or re-run: npm run setup:full -- --from=stripe');
+      logInfo('4. See docs/stripe-billing-setup.md');
       break;
     case 'github':
       logInfo('1. gh auth login with admin on the repository');

--- a/scripts/lib/setup-stripe.mjs
+++ b/scripts/lib/setup-stripe.mjs
@@ -1,0 +1,174 @@
+/**
+ * Stripe billing keys for setup-full (GitHub Actions + .env.cloud.generated.local).
+ */
+
+/** @typedef {{ id: string; label: string; secretKey: string; webhookSecretKey: string; supabaseUrlKeys: string[]; stripeMode: 'test' | 'live' }} StripeSetupTier */
+
+/** @type {StripeSetupTier[]} */
+export const STRIPE_SETUP_TIERS = [
+  {
+    id: 'preview',
+    label: 'Preview (PR testing)',
+    secretKey: 'PREVIEW_STRIPE_SECRET_KEY',
+    webhookSecretKey: 'PREVIEW_STRIPE_WEBHOOK_SECRET',
+    supabaseUrlKeys: ['PREVIEW_SUPABASE_URL', 'PR_TESTING_SUPABASE_URL'],
+    stripeMode: 'test',
+  },
+  {
+    id: 'staging',
+    label: 'Staging',
+    secretKey: 'STAGING_STRIPE_SECRET_KEY',
+    webhookSecretKey: 'STAGING_STRIPE_WEBHOOK_SECRET',
+    supabaseUrlKeys: ['STAGING_SUPABASE_URL'],
+    stripeMode: 'test',
+  },
+  {
+    id: 'production',
+    label: 'Production',
+    secretKey: 'PRODUCTION_STRIPE_SECRET_KEY',
+    webhookSecretKey: 'PRODUCTION_STRIPE_WEBHOOK_SECRET',
+    supabaseUrlKeys: ['PRODUCTION_SUPABASE_URL'],
+    stripeMode: 'live',
+  },
+];
+
+/** Env flag: stripe keys may be omitted from GitHub required list and github-phase prompts. */
+export const SETUP_STRIPE_SKIPPED_ENV = 'SETUP_STRIPE_SKIPPED';
+
+/**
+ * @param {{ name?: string }} def
+ */
+export function isStripeGithubSecretDef(def) {
+  return /_STRIPE_/.test(String(def?.name || ''));
+}
+
+/**
+ * @param {Record<string, string>} env
+ */
+export function setupStripeKeysDeferred(env) {
+  return env[SETUP_STRIPE_SKIPPED_ENV] === 'true';
+}
+
+/**
+ * @param {Record<string, string>} acc
+ * @param {StripeSetupTier} tier
+ */
+export function resolveSupabaseUrlForStripeTier(acc, tier) {
+  for (const key of tier.supabaseUrlKeys) {
+    const v = (acc[key] || '').trim();
+    if (v) return v;
+  }
+  return '';
+}
+
+/**
+ * @param {string} supabaseUrl
+ * @returns {string}
+ */
+export function supabaseStripeWebhookUrl(supabaseUrl) {
+  const raw = String(supabaseUrl || '')
+    .trim()
+    .replace(/\/+$/, '');
+  const m = raw.match(/^https:\/\/([a-z0-9-]+)\.supabase\.co/i);
+  if (!m) return '';
+  return `https://${m[1]}.supabase.co/functions/v1/stripe-webhook`;
+}
+
+/**
+ * @param {Record<string, string>} acc
+ * @param {StripeSetupTier} tier
+ */
+export function tierStripeKeysPresent(acc, tier) {
+  return Boolean(
+    (acc[tier.secretKey] || '').trim() &&
+    (acc[tier.webhookSecretKey] || '').trim()
+  );
+}
+
+/**
+ * @param {{
+ *   acc: Record<string, string>;
+ *   flags: { dryRun: boolean; plainSecretPrompts: boolean };
+ *   logInfo: (s: string) => void;
+ *   logWarn: (s: string) => void;
+ *   question: (prompt: string) => Promise<string>;
+ *   readSecret: (prompt: string) => Promise<string>;
+ *   applySecret: (raw: string, primaryKey: string) => Promise<void>;
+ * }} ctx
+ */
+export async function collectStripeEnvKeys(ctx) {
+  const { acc, flags, logInfo, logWarn, question, readSecret, applySecret } =
+    ctx;
+
+  if (flags.dryRun) {
+    logInfo(
+      '[dry-run] would walk preview / staging / production Stripe keys (sk_test + whsec per tier).'
+    );
+    return;
+  }
+
+  for (const tier of STRIPE_SETUP_TIERS) {
+    if (tierStripeKeysPresent(acc, tier)) {
+      logInfo(
+        `${tier.label}: ${tier.secretKey} and ${tier.webhookSecretKey} already set (values not printed).`
+      );
+      continue;
+    }
+
+    const supabaseUrl = resolveSupabaseUrlForStripeTier(acc, tier);
+    const webhookUrl = supabaseStripeWebhookUrl(supabaseUrl);
+
+    logInfo('');
+    logInfo(`── Stripe: ${tier.label} ──`);
+    logInfo(
+      `  Use Stripe ${tier.stripeMode === 'live' ? 'Live' : 'Test'} mode keys (Dashboard toggle in header).`
+    );
+    if (webhookUrl) {
+      logInfo(`  Webhook endpoint URL for this Supabase project:`);
+      logInfo(`    ${webhookUrl}`);
+      logInfo(
+        '  Dashboard → Developers → Webhooks → Add endpoint → paste URL → select subscription events → Reveal signing secret (whsec_…).'
+      );
+    } else {
+      logWarn(
+        `  No Supabase URL in acc yet (${tier.supabaseUrlKeys.join(' / ')}) — complete supabase phase first, or paste keys from docs/stripe-billing-setup.md.`
+      );
+    }
+    logInfo(
+      `  Secret key → ${tier.secretKey}  |  Signing secret → ${tier.webhookSecretKey}`
+    );
+    logInfo(
+      '  (Enter to skip this tier — github phase will ask again if still empty.)'
+    );
+    logInfo('');
+
+    const skipTier = (
+      await question(`Collect Stripe keys for ${tier.label} now? (Y/n): `)
+    )
+      .trim()
+      .toLowerCase();
+    if (skipTier === 'n' || skipTier === 'no') {
+      logInfo(`Skipped ${tier.label} Stripe keys for now.`);
+      continue;
+    }
+
+    if (!(acc[tier.secretKey] || '').trim()) {
+      const sk = await readSecret(
+        `${tier.secretKey} (sk_${tier.stripeMode === 'live' ? 'live' : 'test'}_…, Enter to skip): `
+      );
+      if (sk) await applySecret(sk, tier.secretKey);
+    }
+
+    if (!(acc[tier.webhookSecretKey] || '').trim()) {
+      const wh = await readSecret(
+        `${tier.webhookSecretKey} (whsec_… for webhook above, Enter to skip): `
+      );
+      if (wh) await applySecret(wh, tier.webhookSecretKey);
+    }
+  }
+
+  logInfo('');
+  logInfo(
+    'Optional next steps (not run by this wizard): npm run billing:sync-stripe per project; supabase secrets set; see docs/stripe-billing-setup.md §7–8.'
+  );
+}

--- a/scripts/lib/setup-stripe.mjs
+++ b/scripts/lib/setup-stripe.mjs
@@ -66,12 +66,27 @@ export function resolveSupabaseUrlForStripeTier(acc, tier) {
  * @returns {string}
  */
 export function supabaseStripeWebhookUrl(supabaseUrl) {
-  const raw = String(supabaseUrl || '')
-    .trim()
-    .replace(/\/+$/, '');
-  const m = raw.match(/^https:\/\/([a-z0-9-]+)\.supabase\.co/i);
-  if (!m) return '';
-  return `https://${m[1]}.supabase.co/functions/v1/stripe-webhook`;
+  const raw = String(supabaseUrl || '').trim();
+  if (!raw) return '';
+  const webhookPath = '/functions/v1/stripe-webhook';
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== 'https:' && u.protocol !== 'http:') return '';
+    const hostMatch = u.hostname.match(/^([a-z0-9-]+)\.supabase\.co$/i);
+    if (hostMatch) {
+      return `https://${hostMatch[1]}.supabase.co${webhookPath}`;
+    }
+    const path = u.pathname.replace(/\/+$/, '') || '';
+    if (path.endsWith(webhookPath)) {
+      return `${u.origin}${path}`;
+    }
+    if (path && path !== '/') {
+      return `${u.origin}${path}${webhookPath}`;
+    }
+    return `${u.origin}${webhookPath}`;
+  } catch {
+    return '';
+  }
 }
 
 /**
@@ -138,7 +153,7 @@ export async function collectStripeEnvKeys(ctx) {
       `  Secret key → ${tier.secretKey}  |  Signing secret → ${tier.webhookSecretKey}`
     );
     logInfo(
-      '  (Enter to skip this tier — github phase will ask again if still empty.)'
+      '  (Next prompt: Enter or y = collect this tier; n = skip — github may prompt again if still empty.)'
     );
     logInfo('');
 

--- a/scripts/lib/setup-stripe.mjs
+++ b/scripts/lib/setup-stripe.mjs
@@ -131,7 +131,7 @@ export async function collectStripeEnvKeys(ctx) {
       );
     } else {
       logWarn(
-        `  No Supabase URL in acc yet (${tier.supabaseUrlKeys.join(' / ')}) — complete supabase phase first, or paste keys from docs/stripe-billing-setup.md.`
+        `  No Supabase URL set yet (${tier.supabaseUrlKeys.join(' / ')}) — complete supabase phase first, or paste keys from docs/stripe-billing-setup.md.`
       );
     }
     logInfo(

--- a/scripts/rename-project.mjs
+++ b/scripts/rename-project.mjs
@@ -12,7 +12,10 @@ const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 
 // Match ANSI escape sequences (ESC = U+001B) without control chars in the regex literal (eslint no-control-regex).
-const ANSI_PATTERN = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*[A-Za-z]`, 'g');
+const ANSI_PATTERN = new RegExp(
+  `${String.fromCharCode(0x1b)}\\[[0-9;]*[A-Za-z]`,
+  'g'
+);
 
 function stripAnsi(value) {
   if (!value) {
@@ -34,7 +37,7 @@ const DEFAULT_IGNORE_DIRS = new Set([
   'ios',
   'dist',
   'build',
-  'coverage'
+  'coverage',
 ]);
 
 const DEFAULT_IGNORE_FILES = new Set([
@@ -42,7 +45,14 @@ const DEFAULT_IGNORE_FILES = new Set([
   'pnpm-lock.yaml',
   'yarn.lock',
   'Podfile.lock',
-  'Gemfile.lock'
+  'Gemfile.lock',
+]);
+
+/** Relative paths skipped entirely when --preserve-upstream is active (default). */
+export const PRESERVE_UPSTREAM_RELATIVE_PATHS = new Set([
+  'docs/UPGRADING.md',
+  'docs/VERSIONING.md',
+  'CONTRIBUTING.md',
 ]);
 
 const BINARY_EXTENSIONS = new Set([
@@ -63,7 +73,7 @@ const BINARY_EXTENSIONS = new Set([
   '.db',
   '.sqlite',
   '.mp3',
-  '.mp4'
+  '.mp4',
 ]);
 
 export function tokenizeName(name) {
@@ -78,7 +88,7 @@ export function tokenizeName(name) {
     .trim()
     .split(' ')
     .filter(Boolean)
-    .map((token) => token.toLowerCase());
+    .map(token => token.toLowerCase());
 }
 
 export function capitalize(word) {
@@ -101,8 +111,8 @@ export function buildNameVariants(name) {
   const camelCase = [tokens[0], ...tokens.slice(1).map(capitalize)].join('');
   const kebabCase = tokens.join('-');
   const snakeCase = tokens.join('_');
-  const upperSnakeCase = tokens.map((token) => token.toUpperCase()).join('_');
-  const upperFlat = tokens.map((token) => token.toUpperCase()).join('');
+  const upperSnakeCase = tokens.map(token => token.toUpperCase()).join('_');
+  const upperFlat = tokens.map(token => token.toUpperCase()).join('');
   const flatLower = tokens.join('');
 
   return {
@@ -115,7 +125,7 @@ export function buildNameVariants(name) {
     snakeCase,
     upperSnakeCase,
     upperFlat,
-    flatLower
+    flatLower,
   };
 }
 
@@ -140,21 +150,118 @@ export function buildReplacementPairs(fromName, toName) {
   const toVariants = buildNameVariants(toName);
 
   const pairs = [
-    { from: fromVariants.original, to: toVariants.original, description: 'Original casing' },
-    { from: fromVariants.titleCase, to: toVariants.titleCase, description: 'Title case' },
-    { from: fromVariants.pascalCase, to: toVariants.pascalCase, description: 'PascalCase' },
-    { from: fromVariants.camelCase, to: toVariants.camelCase, description: 'camelCase' },
-    { from: fromVariants.kebabCase, to: toVariants.kebabCase, description: 'kebab-case' },
-    { from: fromVariants.snakeCase, to: toVariants.snakeCase, description: 'snake_case' },
-    { from: fromVariants.upperSnakeCase, to: toVariants.upperSnakeCase, description: 'SCREAMING_SNAKE_CASE' },
-    { from: fromVariants.upperFlat, to: toVariants.upperFlat, description: 'UPPERFLAT' },
-    { from: fromVariants.flatLower, to: toVariants.flatLower, description: 'flatlower' }
+    {
+      from: fromVariants.original,
+      to: toVariants.original,
+      description: 'Original casing',
+    },
+    {
+      from: fromVariants.titleCase,
+      to: toVariants.titleCase,
+      description: 'Title case',
+    },
+    {
+      from: fromVariants.pascalCase,
+      to: toVariants.pascalCase,
+      description: 'PascalCase',
+    },
+    {
+      from: fromVariants.camelCase,
+      to: toVariants.camelCase,
+      description: 'camelCase',
+    },
+    {
+      from: fromVariants.kebabCase,
+      to: toVariants.kebabCase,
+      description: 'kebab-case',
+    },
+    {
+      from: fromVariants.snakeCase,
+      to: toVariants.snakeCase,
+      description: 'snake_case',
+    },
+    {
+      from: fromVariants.upperSnakeCase,
+      to: toVariants.upperSnakeCase,
+      description: 'SCREAMING_SNAKE_CASE',
+    },
+    {
+      from: fromVariants.upperFlat,
+      to: toVariants.upperFlat,
+      description: 'UPPERFLAT',
+    },
+    {
+      from: fromVariants.flatLower,
+      to: toVariants.flatLower,
+      description: 'flatlower',
+    },
   ];
 
   return {
     variants: { from: fromVariants, to: toVariants },
-    replacements: uniquePairs(pairs)
+    replacements: uniquePairs(pairs),
   };
+}
+
+/**
+ * @param {string} relativePath POSIX-style path relative to repo root
+ * @returns {boolean}
+ */
+export function isPreserveUpstreamPath(relativePath) {
+  return PRESERVE_UPSTREAM_RELATIVE_PATHS.has(relativePath.replace(/\\/g, '/'));
+}
+
+/**
+ * @param {{ preserveUpstream?: boolean; fullRebrand?: boolean }} flags
+ * @returns {boolean}
+ */
+export function resolvePreserveUpstream(flags) {
+  if (flags.fullRebrand) {
+    return false;
+  }
+  return flags.preserveUpstream !== false;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Replace flatlower only at word boundaries and not inside @scope/package names.
+ * @param {string} content
+ * @param {string} from
+ * @param {string} to
+ */
+export function replaceFlatLowerPreservingScope(content, from, to) {
+  if (!from || from === to) {
+    return { updated: content, replacementsMade: 0 };
+  }
+
+  const pattern = new RegExp(`(?<!@)\\b${escapeRegExp(from)}\\b`, 'g');
+  let replacementsMade = 0;
+  const updated = content.replace(pattern, () => {
+    replacementsMade += 1;
+    return to;
+  });
+
+  return { updated, replacementsMade };
+}
+
+/**
+ * @param {ReturnType<typeof buildReplacementPairs>['replacements']} replacements
+ * @param {boolean} preserveUpstream
+ */
+export function annotateReplacementsForPreserveMode(
+  replacements,
+  preserveUpstream
+) {
+  if (!preserveUpstream) {
+    return replacements;
+  }
+
+  return replacements.map(pair =>
+    pair.description === 'flatlower' ? { ...pair, preserveScope: true } : pair
+  );
 }
 
 function parseArgs(argv) {
@@ -163,6 +270,8 @@ function parseArgs(argv) {
     verbose: false,
     strict: false,
     skipSupabaseCheck: false,
+    preserveUpstream: true,
+    fullRebrand: false,
     from: undefined,
     to: undefined,
     fromLegal: undefined,
@@ -189,6 +298,21 @@ function parseArgs(argv) {
 
     if (value === '--no-supabase-check') {
       args.skipSupabaseCheck = true;
+      continue;
+    }
+
+    if (value === '--preserve-upstream') {
+      args.preserveUpstream = true;
+      continue;
+    }
+
+    if (value === '--no-preserve-upstream') {
+      args.preserveUpstream = false;
+      continue;
+    }
+
+    if (value === '--full-rebrand') {
+      args.fullRebrand = true;
       continue;
     }
 
@@ -290,12 +414,20 @@ async function readTextFile(filePath) {
   return buffer.toString('utf8');
 }
 
-function replaceAll(content, replacements) {
+export function replaceAll(content, replacements) {
   let updated = content;
   let replacementsMade = 0;
 
-  for (const { from, to } of replacements) {
+  for (const pair of replacements) {
+    const { from, to, preserveScope } = pair;
     if (!from) {
+      continue;
+    }
+
+    if (preserveScope) {
+      const result = replaceFlatLowerPreservingScope(updated, from, to);
+      updated = result.updated;
+      replacementsMade += result.replacementsMade;
       continue;
     }
 
@@ -366,22 +498,48 @@ async function collectRemainingMatches(files, patterns) {
 function logUsage() {
   const relativeScript = path.relative(repoRoot, __filename);
   console.log(
-    `Usage: npm run rename -- --from "Old Name" --to "New Name" [--from-legal "…"] [--to-legal "…"] [--dry-run] [--strict] [--verbose]`,
+    `Usage: npm run rename -- --from "Old Name" --to "New Name" [--from-legal "…"] [--to-legal "…"] [--dry-run] [--strict] [--verbose]`
   );
   console.log('');
   console.log('Options:');
   console.log('  --from "Old Name"     Existing project name (display form).');
-  console.log('  --to "New Name"       Replacement project name (display form).');
-  console.log('  --from-legal "…"      Optional exact string to replace (e.g. legal entity in package.json).');
-  console.log('  --to-legal "…"        Replacement for --from-legal (both required if either set).');
-  console.log('  --dry-run             Show files that would change without writing.');
-  console.log('  --strict              Exit with failure if any legacy names remain.');
-  console.log('  --no-supabase-check   Skip the running Supabase instance guard (required in CI / no TTY).');
+  console.log(
+    '  --to "New Name"       Replacement project name (display form).'
+  );
+  console.log(
+    '  --from-legal "…"      Optional exact string to replace (e.g. legal entity in package.json).'
+  );
+  console.log(
+    '  --to-legal "…"        Replacement for --from-legal (both required if either set).'
+  );
+  console.log(
+    '  --dry-run             Show files that would change without writing.'
+  );
+  console.log(
+    '  --strict              Exit with failure if any legacy names remain.'
+  );
+  console.log(
+    '  --no-supabase-check   Skip the running Supabase instance guard (required in CI / no TTY).'
+  );
+  console.log(
+    '  --preserve-upstream   Keep @beakerstack scope and upgrade docs unchanged (default).'
+  );
+  console.log(
+    '  --no-preserve-upstream  Same as --full-rebrand for upstream preservation.'
+  );
+  console.log(
+    '  --full-rebrand        Rename npm scope and upgrade docs (legacy behavior).'
+  );
   console.log('  --verbose             Print detailed progress information.');
   console.log('');
-  console.log(`Example: npm run rename -- --from "Beaker Stack" --to "Acme App"`);
   console.log(
-    `Example: npm run rename -- --from "Beaker Stack" --to "Acme App" --from-legal "Artificer Innovations, LLC" --to-legal "Acme Corp"`,
+    `Example: npm run rename -- --from "Beaker Stack" --to "Acme App"`
+  );
+  console.log(
+    `Example: npm run rename -- --from "Beaker Stack" --to "Acme App" --full-rebrand`
+  );
+  console.log(
+    `Example: npm run rename -- --from "Beaker Stack" --to "Acme App" --from-legal "Artificer Innovations, LLC" --to-legal "Acme Corp"`
   );
   console.log(`Script: ${relativeScript}`);
 }
@@ -393,7 +551,7 @@ function logUsage() {
 export function checkSupabaseStatus(opts = {}) {
   const verbose = Boolean(opts.verbose);
   const cwd = opts.cwd ?? process.cwd();
-  const logVerbose = (message) => {
+  const logVerbose = message => {
     if (verbose) {
       console.log(`[supabase-check] ${message}`);
     }
@@ -405,10 +563,12 @@ export function checkSupabaseStatus(opts = {}) {
       jsonResult = spawnSync('supabase', ['status', '--output', 'json'], {
         cwd,
         encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'pipe']
+        stdio: ['ignore', 'pipe', 'pipe'],
       });
     } catch (error) {
-      logVerbose(`Supabase CLI not available: ${error instanceof Error ? error.message : error}`);
+      logVerbose(
+        `Supabase CLI not available: ${error instanceof Error ? error.message : error}`
+      );
     }
 
     if (jsonResult && jsonResult.status === 0 && jsonResult.stdout.trim()) {
@@ -416,12 +576,13 @@ export function checkSupabaseStatus(opts = {}) {
         const data = JSON.parse(jsonResult.stdout);
         const services = Object.values(data.services ?? {});
         const running = services.filter(
-          (service) => String(service.state || '').toUpperCase() === 'RUNNING'
+          service => String(service.state || '').toUpperCase() === 'RUNNING'
         );
         if (running.length > 0) {
           return {
-            projectId: data.project_id ?? data.projectId ?? data.projectRef ?? null,
-            running
+            projectId:
+              data.project_id ?? data.projectId ?? data.projectRef ?? null,
+            running,
           };
         }
       } catch (error) {
@@ -429,18 +590,24 @@ export function checkSupabaseStatus(opts = {}) {
           `Failed to parse Supabase status JSON: ${error instanceof Error ? error.message : error}`
         );
       }
-    } else if (jsonResult && jsonResult.status !== 0 && jsonResult.stderr.trim()) {
+    } else if (
+      jsonResult &&
+      jsonResult.status !== 0 &&
+      jsonResult.stderr.trim()
+    ) {
       logVerbose(`Supabase status command failed: ${jsonResult.stderr.trim()}`);
     }
 
     const textResult = spawnSync('supabase', ['status'], {
       cwd,
       encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe']
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
 
     if (textResult.error) {
-      logVerbose(`Supabase CLI not available (fallback): ${textResult.error.message}`);
+      logVerbose(
+        `Supabase CLI not available (fallback): ${textResult.error.message}`
+      );
       return null;
     }
 
@@ -449,7 +616,8 @@ export function checkSupabaseStatus(opts = {}) {
       return null;
     }
 
-    const stdoutRaw = (textResult.stdout || '') + '\n' + (textResult.stderr || '');
+    const stdoutRaw =
+      (textResult.stdout || '') + '\n' + (textResult.stderr || '');
     const stdout = stripAnsi(stdoutRaw);
     const normalized = stdout.toLowerCase();
 
@@ -460,14 +628,14 @@ export function checkSupabaseStatus(opts = {}) {
 
       return {
         projectId: projectMatch ? projectMatch[1] : null,
-        running: [{ name: 'Supabase local development stack' }]
+        running: [{ name: 'Supabase local development stack' }],
       };
     }
 
     const running = stdout
       .split('\n')
-      .map((line) => line.trim())
-      .filter((line) => /\bRUNNING\b/i.test(line));
+      .map(line => line.trim())
+      .filter(line => /\bRUNNING\b/i.test(line));
 
     if (running.length === 0) {
       return { projectId: null, running: [] };
@@ -475,10 +643,12 @@ export function checkSupabaseStatus(opts = {}) {
 
     return {
       projectId: null,
-      running: running.map((line) => ({ name: line }))
+      running: running.map(line => ({ name: line })),
     };
   } catch (error) {
-    logVerbose(`Supabase status check failed: ${error instanceof Error ? error.message : error}`);
+    logVerbose(
+      `Supabase status check failed: ${error instanceof Error ? error.message : error}`
+    );
     return null;
   }
 }
@@ -493,33 +663,39 @@ async function resolveSupabaseForRename(ctx) {
     return 'ok';
   }
 
-  const projectIdText = status.projectId ? ` (project ID: ${status.projectId})` : '';
+  const projectIdText = status.projectId
+    ? ` (project ID: ${status.projectId})`
+    : '';
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     console.error(`Supabase services appear to be running${projectIdText}.`);
     console.error(
-      'Stop them before renaming (for example `supabase stop`), or pass --no-supabase-check when stdin is not a TTY (e.g. CI).',
+      'Stop them before renaming (for example `supabase stop`), or pass --no-supabase-check when stdin is not a TTY (e.g. CI).'
     );
     return 'abort';
   }
 
   console.error('');
   console.error(
-    `A local Supabase instance appears to be running${projectIdText}. Clones often share the same supabase/config.toml project_id,`,
+    `A local Supabase instance appears to be running${projectIdText}. Clones often share the same supabase/config.toml project_id,`
   );
-  console.error('so this can refer to a stack started from another directory on this machine.');
+  console.error(
+    'so this can refer to a stack started from another directory on this machine.'
+  );
   console.error('');
   console.error(
-    'If you are renaming this checkout and the running stack belongs to this tree, stop it before continuing.',
+    'If you are renaming this checkout and the running stack belongs to this tree, stop it before continuing.'
   );
   console.error(
-    'If you are rebranding a new template in this directory and the stack is only from elsewhere, you may proceed without stopping.',
+    'If you are rebranding a new template in this directory and the stack is only from elsewhere, you may proceed without stopping.'
   );
   console.error('');
 
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   try {
     for (;;) {
-      const raw = await rl.question('(S)top local Supabase now / (P)roceed anyway / (Q)uit [S]: ');
+      const raw = await rl.question(
+        '(S)top local Supabase now / (P)roceed anyway / (Q)uit [S]: '
+      );
       const line = raw.trim().toLowerCase();
       const key = line === '' ? 's' : line[0];
       if (key === 'q') {
@@ -531,7 +707,11 @@ async function resolveSupabaseForRename(ctx) {
       if (key === 's') {
         const pid = status.projectId;
         const stopArgs = pid ? ['stop', '--project-id', String(pid)] : ['stop'];
-        spawnSync('supabase', stopArgs, { cwd: ctx.cwd, stdio: 'inherit', encoding: 'utf8' });
+        spawnSync('supabase', stopArgs, {
+          cwd: ctx.cwd,
+          stdio: 'inherit',
+          encoding: 'utf8',
+        });
         status = checkSupabaseStatus({ verbose: ctx.verbose, cwd: ctx.cwd });
         if (!status?.running?.length) {
           return 'ok';
@@ -551,7 +731,11 @@ async function resolveSupabaseForRename(ctx) {
 function mergeLegalAndNameReplacements(fromLegal, toLegal, nameReplacements) {
   const list = [];
   if (fromLegal && toLegal && fromLegal !== toLegal) {
-    list.push({ from: fromLegal, to: toLegal, description: 'Legal entity (literal)' });
+    list.push({
+      from: fromLegal,
+      to: toLegal,
+      description: 'Legal entity (literal)',
+    });
   }
   list.push(...nameReplacements);
   return uniquePairs(list);
@@ -568,53 +752,117 @@ async function main() {
   }
 
   if ((args.fromLegal || args.toLegal) && (!args.fromLegal || !args.toLegal)) {
-    console.error('Error: both --from-legal and --to-legal are required when renaming a legal string.');
+    console.error(
+      'Error: both --from-legal and --to-legal are required when renaming a legal string.'
+    );
     logUsage();
     process.exitCode = 1;
     return;
   }
 
   if (!args.skipSupabaseCheck) {
-    const gate = await resolveSupabaseForRename({ verbose: args.verbose, cwd: repoRoot });
+    const gate = await resolveSupabaseForRename({
+      verbose: args.verbose,
+      cwd: repoRoot,
+    });
     if (gate === 'abort') {
       process.exitCode = 1;
       return;
     }
   }
 
-  const { replacements: nameReplacements } = buildReplacementPairs(args.from, args.to);
-  const replacements = mergeLegalAndNameReplacements(args.fromLegal, args.toLegal, nameReplacements);
+  const preserveUpstream = resolvePreserveUpstream(args);
+  if (
+    args.fullRebrand &&
+    args.preserveUpstream === true &&
+    process.argv.includes('--preserve-upstream')
+  ) {
+    console.warn(
+      'Warning: --full-rebrand takes precedence over --preserve-upstream.'
+    );
+  }
+
+  const { replacements: nameReplacements } = buildReplacementPairs(
+    args.from,
+    args.to
+  );
+  const annotated = annotateReplacementsForPreserveMode(
+    nameReplacements,
+    preserveUpstream
+  );
+  const replacements = mergeLegalAndNameReplacements(
+    args.fromLegal,
+    args.toLegal,
+    annotated
+  );
   const files = await walkDirectory(repoRoot);
 
   const stats = {
     filesChanged: 0,
     replacements: 0,
-    examined: files.length
+    examined: files.length,
+    skippedPreservePaths: 0,
   };
 
   const changedFiles = [];
 
   for (const file of files) {
-    const { changed, replacements: count } = await processFile(file, replacements, args);
+    const relativePath = path.relative(repoRoot, file).replace(/\\/g, '/');
+    if (preserveUpstream && isPreserveUpstreamPath(relativePath)) {
+      stats.skippedPreservePaths += 1;
+      if (args.verbose) {
+        console.log(`[skip-upstream] ${relativePath}`);
+      }
+      continue;
+    }
+
+    const { changed, replacements: count } = await processFile(
+      file,
+      replacements,
+      args
+    );
     if (changed) {
       stats.filesChanged += 1;
       stats.replacements += count;
       changedFiles.push({ file, count });
 
       if (args.verbose) {
-        console.log(`${args.dryRun ? '[dry-run]' : '[update]'} ${path.relative(repoRoot, file)} (${count} replacements)`);
+        console.log(
+          `${args.dryRun ? '[dry-run]' : '[update]'} ${path.relative(repoRoot, file)} (${count} replacements)`
+        );
       }
     }
   }
 
-  const searchPatterns = replacements.map((item) => item.from);
-  const remaining = await collectRemainingMatches(files, searchPatterns);
+  const searchPatterns = replacements.map(item => item.from);
+  const filesForRemaining = preserveUpstream
+    ? files.filter(
+        file =>
+          !isPreserveUpstreamPath(
+            path.relative(repoRoot, file).replace(/\\/g, '/')
+          )
+      )
+    : files;
+  const remaining = await collectRemainingMatches(
+    filesForRemaining,
+    searchPatterns
+  );
 
   console.log('');
   console.log('Rename Summary');
   console.log('--------------');
+  console.log(
+    `Mode:               ${preserveUpstream ? 'preserve upstream (default)' : 'full rebrand'}`
+  );
   console.log(`Files scanned:      ${stats.examined}`);
-  console.log(`Files ${args.dryRun ? 'to update' : 'updated'}: ${stats.filesChanged}`);
+  if (preserveUpstream && stats.skippedPreservePaths > 0) {
+    console.log(
+      `Paths skipped:      ${stats.skippedPreservePaths} (upstream docs)`
+    );
+  }
+  console.log(
+    `Files ${args.dryRun ? 'to update' : 'updated'}: ${stats.filesChanged}`
+  );
   console.log(`Total replacements: ${stats.replacements}`);
 
   if (remaining.length > 0) {
@@ -626,24 +874,27 @@ async function main() {
     }
 
     if (args.strict) {
-      console.error('\nRename failed due to remaining legacy identifiers (strict mode).');
+      console.error(
+        '\nRename failed due to remaining legacy identifiers (strict mode).'
+      );
       process.exitCode = 1;
       return;
     }
   }
 
   if (args.dryRun) {
-    console.log('\nDry-run complete. Re-run without --dry-run to apply changes.');
+    console.log(
+      '\nDry-run complete. Re-run without --dry-run to apply changes.'
+    );
   } else {
     console.log('\nRename complete.');
   }
 }
 
 if (import.meta.url === url.pathToFileURL(process.argv[1] || '').href) {
-  main().catch((error) => {
+  main().catch(error => {
     console.error('Rename script failed.');
     console.error(error instanceof Error ? error.stack : error);
     process.exitCode = 1;
   });
 }
-

--- a/scripts/rename-project.mjs
+++ b/scripts/rename-project.mjs
@@ -137,8 +137,17 @@ function uniquePairs(pairs) {
       continue;
     }
 
-    if (!map.has(key)) {
+    const existing = map.get(key);
+    if (!existing) {
       map.set(key, pair);
+      continue;
+    }
+    // camelCase and flatlower often share the same `from` (e.g. single-token names);
+    // keep flatlower so preserve-upstream mode can mark preserveScope.
+    if (pair.description === 'flatlower') {
+      map.set(key, pair);
+    } else if (existing.description !== 'flatlower') {
+      map.set(key, existing);
     }
   }
 

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -52,6 +52,7 @@ import {
   printAwsPhaseReadinessBriefing,
   printExpoPhaseReadinessBriefing,
   printGooglePhaseReadinessBriefing,
+  printStripePhaseReadinessBriefing,
   printGithubPhaseReadinessBriefing,
   confirmRunPhase,
   printManualInstructions,
@@ -67,6 +68,11 @@ import {
   logGithubSyncTargetSummary,
   resolveGhRepoContext,
 } from './lib/setup-github-repo.mjs';
+import {
+  SETUP_STRIPE_SKIPPED_ENV,
+  collectStripeEnvKeys,
+  isStripeGithubSecretDef,
+} from './lib/setup-stripe.mjs';
 import {
   formatSupabaseProjectChoiceLine,
   parseApiKeysJson,
@@ -104,6 +110,7 @@ const PHASE_ORDER = [
   'aws',
   'expo',
   'google',
+  'stripe',
   'write',
   'github',
 ];
@@ -111,7 +118,7 @@ const PHASE_ORDER = [
 /** Merged from dotenv-style secret files / pastes (allowlisted keys only). */
 const MERGEABLE_SETUP_ENV_KEYS = mergeableSetupEnvKeys();
 
-/** @typedef {{ dryRun: boolean; fromPhase: string; skipRename: boolean; awsProfile: string; skipGithub: boolean; githubRepo: string; mobileEnabled: boolean; plainSecretPrompts: boolean; guide: 'full' | 'brief'; guideFromCli: boolean }} CliFlags */
+/** @typedef {{ dryRun: boolean; fromPhase: string; skipRename: boolean; awsProfile: string; skipGithub: boolean; skipStripe: boolean; githubRepo: string; mobileEnabled: boolean; plainSecretPrompts: boolean; guide: 'full' | 'brief'; guideFromCli: boolean }} CliFlags */
 
 function printHelp() {
   console.log(`Usage: node scripts/setup-full.mjs [options]
@@ -120,10 +127,11 @@ Options:
   --dry-run              No env/state file writes; no PAT/EXPO env merge; no Supabase api-keys fetch;
                          no AWS bootstrap run; no google-services import; GitHub sync skips gh but still
                          reads .env*.local to log what would be synced
-  --from=PHASE           Resume at prereqs|identity|supabase|aws|expo|google|write|github (alias: gh=github;
+  --from=PHASE           Resume at prereqs|identity|supabase|aws|expo|google|stripe|write|github (alias: gh=github;
                          merges existing .env*.local first when resuming)
   --skip-rename          Skip the identity / rename phase entirely
   --skip-github          Skip GitHub Actions secret/variable sync
+  --skip-stripe          Skip Stripe key collection; Stripe secrets not required at github sync
   --github-repo=OWNER/NAME  Override repo for gh secret/variable sync (default: gh repo view in cwd)
   --skip-mobile          Skip Expo, EAS, and Google Services setup (web-only repos)
   --aws-profile=NAME     Pass through to bootstrap-aws-stack.sh
@@ -166,6 +174,7 @@ function parseArgv(argv) {
     skipRename: false,
     awsProfile: '',
     skipGithub: false,
+    skipStripe: false,
     githubRepo: '',
     mobileEnabled: true,
     plainSecretPrompts: false,
@@ -176,6 +185,7 @@ function parseArgv(argv) {
     if (a === '--dry-run') flags.dryRun = true;
     else if (a === '--skip-rename') flags.skipRename = true;
     else if (a === '--skip-github') flags.skipGithub = true;
+    else if (a === '--skip-stripe') flags.skipStripe = true;
     else if (a.startsWith('--github-repo='))
       flags.githubRepo = a.slice('--github-repo='.length).trim();
     else if (a === '--skip-mobile') flags.mobileEnabled = false;
@@ -2196,6 +2206,41 @@ async function phaseExpo(flags, rl, acc, promptInput) {
  * @param {import('node:readline/promises').ReadLine} rl
  * @param {Record<string, string>} acc
  */
+/**
+ * @param {CliFlags} flags
+ * @param {import('node:readline/promises').ReadLine} rl
+ * @param {import('stream').Readable & { isTTY?: boolean; setRawMode?: (flag: boolean) => void }} promptInput
+ * @param {Record<string, string>} acc
+ */
+async function phaseStripe(flags, rl, promptInput, acc) {
+  if (flags.skipStripe) {
+    acc[SETUP_STRIPE_SKIPPED_ENV] = 'true';
+    logInfo('Skipping Stripe key collection (--skip-stripe).');
+    return;
+  }
+  acc[SETUP_STRIPE_SKIPPED_ENV] = 'false';
+  await collectStripeEnvKeys({
+    acc,
+    flags,
+    logInfo,
+    logWarn,
+    question: q => rlQuestion(rl, q),
+    readSecret: prompt =>
+      readSecretLineMaskedOrVisible(rl, promptInput, flags, prompt),
+    applySecret: async (raw, primaryKey) => {
+      checkSecretInputQuit(raw);
+      if (!raw) return;
+      const resolved = await resolveSecretInputForSetup(raw, primaryKey);
+      applySecretResolutionToAcc(acc, resolved, primaryKey);
+    },
+  });
+}
+
+/**
+ * @param {CliFlags} flags
+ * @param {import('node:readline/promises').ReadLine} rl
+ * @param {Record<string, string>} acc
+ */
 async function phaseGoogle(flags, rl, acc) {
   logInfo('');
   logInfo(
@@ -2298,6 +2343,13 @@ async function collectMissingGithubCiEnvIntoAcc(flags, rl, promptInput, acc) {
 
   let details = listMissingRequiredGithubCiDetails(acc);
   if (!details.length) return 'none';
+
+  const stripeMissing = details.filter(d => isStripeGithubSecretDef(d.def));
+  if (stripeMissing.length) {
+    logInfo(
+      `${stripeMissing.length} Stripe key(s) still missing — run \`npm run setup:full -- --from=stripe\` for guided collection, or enter below.`
+    );
+  }
 
   if (!input.isTTY) {
     logWarn(
@@ -2580,6 +2632,11 @@ async function main() {
         logInfo('Skipping identity/rename (--skip-rename).');
         continue;
       }
+      if (phase === 'stripe' && flags.skipStripe) {
+        logInfo('Skipping Stripe phase (--skip-stripe).');
+        acc[SETUP_STRIPE_SKIPPED_ENV] = 'true';
+        continue;
+      }
       if (phase === 'github' && flags.skipGithub) {
         logInfo('Skipping GitHub sync (--skip-github).');
         continue;
@@ -2599,6 +2656,9 @@ async function main() {
         printManualInstructions(logCtx, phase);
         if (phase === 'expo') {
           clearExpoKeysFromAcc(acc);
+        }
+        if (phase === 'stripe') {
+          acc[SETUP_STRIPE_SKIPPED_ENV] = 'true';
         }
         continue;
       }
@@ -2633,6 +2693,16 @@ async function main() {
         }
       }
 
+      if (phase === 'stripe' && !flags.skipStripe) {
+        printStripePhaseReadinessBriefing(logCtx);
+        if (!flags.dryRun && input.isTTY) {
+          await rlQuestion(
+            rl,
+            'Press Enter when you have Stripe test keys (and live keys for production if needed)…'
+          );
+        }
+      }
+
       if (phase === 'github' && !flags.skipGithub) {
         printGithubPhaseReadinessBriefing(logCtx);
         if (!flags.dryRun && input.isTTY) {
@@ -2658,6 +2728,9 @@ async function main() {
           break;
         case 'google':
           await phaseGoogle(flags, rl, acc);
+          break;
+        case 'stripe':
+          await phaseStripe(flags, rl, promptInput, acc);
           break;
         case 'github':
           await phaseGithub(flags, rl, acc, promptInput);

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -1426,13 +1426,21 @@ async function phaseIdentity(flags, rl) {
     }
   }
 
+  const doFullRebrand = await rlQuestion(
+    rl,
+    'Fully rebrand npm scope (@beakerstack) and upgrade docs? (y/N): '
+  );
+  const preserveArgs = /^y(es)?$/i.test(doFullRebrand.trim())
+    ? ['--full-rebrand']
+    : ['--preserve-upstream'];
+
   const dry = flags.dryRun ? ['--dry-run'] : [];
   const legalArgs =
     toLegal && fromLegal && fromLegal !== toLegal
       ? ['--from-legal', fromLegal, '--to-legal', toLegal]
       : [];
   logInfo(
-    `Running rename: display "${fromName}" -> "${toName}"${legalArgs.length ? ' + legal entity' : ''}`
+    `Running rename: display "${fromName}" -> "${toName}"${legalArgs.length ? ' + legal entity' : ''} (${preserveArgs.includes('--full-rebrand') ? 'full rebrand' : 'preserve upstream'})`
   );
   const code = runInteractiveWithRl(
     rl,
@@ -1445,6 +1453,7 @@ async function phaseIdentity(flags, rl) {
       fromName,
       '--to',
       toName,
+      ...preserveArgs,
       ...legalArgs,
       ...dry,
     ],

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -2213,20 +2213,10 @@ async function phaseExpo(flags, rl, acc, promptInput) {
 /**
  * @param {CliFlags} flags
  * @param {import('node:readline/promises').ReadLine} rl
- * @param {Record<string, string>} acc
- */
-/**
- * @param {CliFlags} flags
- * @param {import('node:readline/promises').ReadLine} rl
  * @param {import('stream').Readable & { isTTY?: boolean; setRawMode?: (flag: boolean) => void }} promptInput
  * @param {Record<string, string>} acc
  */
 async function phaseStripe(flags, rl, promptInput, acc) {
-  if (flags.skipStripe) {
-    acc[SETUP_STRIPE_SKIPPED_ENV] = 'true';
-    logInfo('Skipping Stripe key collection (--skip-stripe).');
-    return;
-  }
   acc[SETUP_STRIPE_SKIPPED_ENV] = 'false';
   await collectStripeEnvKeys({
     acc,
@@ -2587,6 +2577,10 @@ async function main() {
       acc = mergeRecords(acc, await readEnvFileIfExists(CLOUD_ENV_PATH));
       acc = mergeRecords(acc, await readEnvFileIfExists(AWS_ENV_PATH));
     }
+  }
+
+  if (flags.skipStripe) {
+    acc[SETUP_STRIPE_SKIPPED_ENV] = 'true';
   }
 
   if (!flags.mobileEnabled) {


### PR DESCRIPTION
## Summary

### Stripe billing phase (`setup:full`)

- Adds a dedicated **`stripe`** phase (after `google`, before `write` / `github`) so adopters collect billing keys with context instead of hitting `STAGING_STRIPE_SECRET_KEY` cold at GitHub sync.
- **Preflight briefing** — test vs live mode, one webhook per Supabase project, and what stays manual (`billing:sync-stripe`, `supabase secrets set`, Stripe CLI).
- **Per-tier prompts** (preview → staging → production): prints webhook URL when `*_SUPABASE_URL` exists, then masked `sk_*` and `whsec_*` keys.
- **`--skip-stripe`** — skips the phase and omits Stripe secrets from required GitHub sync.

### Fork-safe rename defaults (`rename-project` + identity phase)

- **Default rename mode is now `--preserve-upstream`**: display name, slugs, and bundle IDs change; **`@beakerstack/*` npm scope**, `docs/UPGRADING.md`, `docs/VERSIONING.md`, and related upstream merge docs are **left unchanged** so forks can keep merging from Artificer-Innovations/BeakerStack and consuming published packages.
- **`--full-rebrand`** restores legacy behavior (rename scope + all docs).
- **`setup:full` identity phase** asks: “Fully rebrand npm scope and upgrade docs? (y/N)” — default **no** passes `--preserve-upstream`.
- Expanded tests and [docs/renaming.md](docs/renaming.md) table explaining default vs full rebrand.

## Docs

- [docs/setup-prep-checklist.md](docs/setup-prep-checklist.md) — `stripe` phase
- [docs/stripe-billing-setup.md](docs/stripe-billing-setup.md) — Before the Stripe wizard phase
- [docs/renaming.md](docs/renaming.md) — preserve upstream vs full rebrand

## Test plan

**Stripe**

- [ ] `npm run setup:full -- --dry-run --from=stripe` — briefing + dry-run collection message
- [ ] `npm run setup:full -- --from=stripe` — staging keys land in `.env.cloud.generated.local` after `write`
- [ ] `npm run setup:full -- --skip-stripe --from=github` — Stripe keys not in missing-required list
- [ ] `node --test scripts/__tests__/setup-stripe.test.mjs scripts/__tests__/setup-manifest-github-sync.test.mjs`

**Rename**

- [ ] `npm run rename -- --from "Beaker Stack" --to "Acme App" --dry-run` — skips `@beakerstack`, UPGRADING, VERSIONING
- [ ] Same with `--full-rebrand` — scope and upgrade docs renamed
- [ ] `node --test scripts/__tests__/rename-project.test.mjs`
- [ ] `setup:full` identity: answer **N** to full rebrand → log shows `preserve upstream`