### PR TITLE
feat(setup): auto-provision Stripe webhooks in setup:full

### DIFF
--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -163,7 +163,6 @@ jobs:
       - name: Deploy preview billing edge functions
         id: billing-functions
         continue-on-error: true
-        shell: bash
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_PREVIEW_PROJECT_REF: ${{ secrets.SUPABASE_PREVIEW_PROJECT_REF }}
@@ -174,24 +173,11 @@ jobs:
           PREVIEW_STRIPE_SECRET_KEY: ${{ secrets.PREVIEW_STRIPE_SECRET_KEY }}
           PREVIEW_STRIPE_WEBHOOK_SECRET: ${{ steps.stripe_webhook_preview.outputs.resolved_webhook_secret }}
           PREVIEW_BILLING_ALLOWED_ORIGINS: ${{ secrets.PREVIEW_BILLING_ALLOWED_ORIGINS }}
+          SUPABASE_MAX_RETRIES: 5
         run: |
           set -euo pipefail
-          cd supabase
-          # Path-based previews use this host; empty allowlist breaks checkout redirect validation.
-          BILLING_ORIGINS="${PREVIEW_BILLING_ALLOWED_ORIGINS:-https://deploy.beakerstack.com}"
-          supabase link \
-            --project-ref "${SUPABASE_PREVIEW_PROJECT_REF}" \
-            --password "${SUPABASE_PREVIEW_DB_PASSWORD}" \
-            --yes
-          supabase secrets set \
-            STRIPE_SECRET_KEY="${PREVIEW_STRIPE_SECRET_KEY}" \
-            STRIPE_WEBHOOK_SECRET="${PREVIEW_STRIPE_WEBHOOK_SECRET}" \
-            BILLING_SUPABASE_URL="${PREVIEW_SUPABASE_URL}" \
-            BILLING_SUPABASE_ANON_KEY="${PREVIEW_SUPABASE_ANON_KEY}" \
-            BILLING_SUPABASE_SERVICE_ROLE_KEY="${PR_TESTING_SUPABASE_SERVICE_ROLE_KEY}" \
-            BILLING_ALLOWED_ORIGINS="${BILLING_ORIGINS}"
-          supabase functions deploy stripe-webhook billing-stripe \
-            --project-ref "${SUPABASE_PREVIEW_PROJECT_REF}"
+          chmod +x ./scripts/pr-preview/deploy-preview-billing-functions.sh
+          ./scripts/pr-preview/deploy-preview-billing-functions.sh
 
       - name: Build and deploy web preview
         id: web

--- a/docs/setup-prep-checklist.md
+++ b/docs/setup-prep-checklist.md
@@ -176,16 +176,18 @@ Do not commit filled-in values or `.env*` files with secrets.
 **Have ready (before Yes — wizard shows checklist + Enter):**
 
 1. **[Stripe account](https://dashboard.stripe.com)** — **Test mode** for preview + staging; **Live mode** only when production is ready.
-2. **Supabase phase done** — so the wizard can print each tier’s webhook URL (`https://<ref>.supabase.co/functions/v1/stripe-webhook`).
-3. Per tier, from Dashboard → **Developers → API keys** and **Webhooks**:
-   - **Preview:** `PREVIEW_STRIPE_SECRET_KEY` + `PREVIEW_STRIPE_WEBHOOK_SECRET`
-   - **Staging:** `STAGING_STRIPE_SECRET_KEY` + `STAGING_STRIPE_WEBHOOK_SECRET`
-   - **Production:** `PRODUCTION_STRIPE_SECRET_KEY` + `PRODUCTION_STRIPE_WEBHOOK_SECRET`
+2. **Supabase phase done** — so the wizard knows each tier’s hosted webhook URL (`https://<ref>.supabase.co/functions/v1/stripe-webhook`).
+3. Per tier, **API secret key** from Dashboard → **Developers → API keys**:
+   - **Preview:** `PREVIEW_STRIPE_SECRET_KEY` (`sk_test_…`)
+   - **Staging:** `STAGING_STRIPE_SECRET_KEY` (`sk_test_…`)
+   - **Production:** `PRODUCTION_STRIPE_SECRET_KEY` (`sk_live_…` when ready)
+
+For **hosted** Supabase URLs, the wizard **creates or updates** the matching Stripe webhook and fills `*_STRIPE_WEBHOOK_SECRET` automatically when Stripe returns a new signing secret. You only need to paste `whsec_…` manually if that endpoint **already existed** and the secret was never saved (Dashboard → Webhooks → **Reveal**).
 
 **You will be asked:**
 
 - **Press Enter** when ready (or **N** to skip / `--skip-stripe` for no billing in CI)
-- For each tier (preview → staging → production): collect now? → masked secret key → masked webhook signing secret
+- For each tier (preview → staging → production): collect now? → masked secret key → auto-ensure webhook when possible → optional `whsec` prompt if Stripe already had the endpoint without a stored secret
 - **Enter** on a tier skips that tier (github may prompt again later)
 
 **Saved as:** `*_STRIPE_*` in `.env.cloud.generated.local` → GitHub secrets in **github** phase.

--- a/docs/stripe-billing-setup.md
+++ b/docs/stripe-billing-setup.md
@@ -163,7 +163,7 @@ When **Stripe’s servers** must call your project (staging/production, or a sta
    `https://<PROJECT_REF>.supabase.co/functions/v1/stripe-webhook`
    - `PROJECT_REF` is in the Supabase project URL (Dashboard → Project Settings → API → Project URL).
 
-3. **Events to send** — at minimum select the types the template handler implements (you can also use “Receive all events” while testing):
+3. **Events to send** — select the same types as [`STRIPE_WEBHOOK_ENABLED_EVENTS`](../scripts/lib/ensure-stripe-webhook.mjs) (auto-ensure and CI use this list; you can also use “Receive all events” while testing):
    - `checkout.session.completed`
    - `customer.subscription.updated`
    - `customer.subscription.deleted`
@@ -171,6 +171,9 @@ When **Stripe’s servers** must call your project (staging/production, or a sta
    - `invoice.payment_failed`
    - `invoice.paid`
    - `invoice.payment_succeeded`
+   - `invoice.created`
+   - `invoice.finalized`
+   - `invoice.voided`
 
 4. After saving, open the webhook details and **Reveal** the **Signing secret** (`whsec_…`). That value is **`STRIPE_WEBHOOK_SECRET`** for the **same** Stripe mode (test vs live) as your API keys.
 

--- a/docs/stripe-billing-setup.md
+++ b/docs/stripe-billing-setup.md
@@ -12,16 +12,16 @@ This guide walks you from **zero** to a working **test-mode** Stripe integration
 
 ## Before the Stripe wizard phase
 
-If you use `npm run setup:full`, the **stripe** phase (after **supabase**, before **write** / **github**) collects GitHub Actions keys so you are not surprised by `STAGING_STRIPE_SECRET_KEY` at github sync.
+If you use `npm run setup:full`, the **stripe** phase (after **supabase**, before **write** / **github**) collects GitHub Actions keys so you are not surprised by `STAGING_STRIPE_SECRET_KEY` at github sync. For each **hosted** Supabase project (`https://<ref>.supabase.co`), the wizard uses the same logic as CI ([`scripts/lib/ensure-stripe-webhook.mjs`](../scripts/lib/ensure-stripe-webhook.mjs)) to create or update the Stripe webhook and store `*_STRIPE_WEBHOOK_SECRET` when Stripe returns a new signing secret.
 
 ### Checklist
 
-| #   | Requirement                      | Details                                                                                                                                                                  |
-| --- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1   | **Stripe account**               | [dashboard.stripe.com](https://dashboard.stripe.com) — **Test mode** for preview + staging.                                                                              |
-| 2   | **API secret keys**              | Developers → API keys → `sk_test_…` (preview/staging) and `sk_live_…` (production when ready).                                                                           |
-| 3   | **Webhook per Supabase project** | URL `https://<PROJECT_REF>.supabase.co/functions/v1/stripe-webhook` — one endpoint per preview/staging/production project; **Reveal** signing secret `whsec_…` for each. |
-| 4   | **Supabase URLs from setup**     | Complete the **supabase** phase first so the wizard can print each webhook URL.                                                                                          |
+| #   | Requirement                      | Details                                                                                                                                                                                                                                                                 |
+| --- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Stripe account**               | [dashboard.stripe.com](https://dashboard.stripe.com) — **Test mode** for preview + staging.                                                                                                                                                                             |
+| 2   | **API secret keys**              | Developers → API keys → `sk_test_…` (preview/staging) and `sk_live_…` (production when ready).                                                                                                                                                                          |
+| 3   | **Webhook per Supabase project** | One endpoint per preview/staging/production at `https://<PROJECT_REF>.supabase.co/functions/v1/stripe-webhook`. **Greenfield:** wizard/CI create it from `sk_*` only. **Existing endpoint:** paste `whsec_…` from Dashboard → **Reveal** if the secret was never saved. |
+| 4   | **Supabase URLs from setup**     | Complete the **supabase** phase first so the wizard can ensure webhooks against the correct URL.                                                                                                                                                                        |
 
 Skip billing in CI: answer **N** at the stripe phase or `npm run setup:full -- --skip-stripe`.
 
@@ -155,7 +155,7 @@ Seed data (when using repo `supabase/seed.sql`) includes the template product **
 
 ## 5. Stripe Dashboard — webhook endpoint (hosted Supabase)
 
-When **Stripe’s servers** must call your project (staging/production, or a stable tunnel), register the webhook in Stripe:
+When **Stripe’s servers** must call your project (staging/production, or a stable tunnel), register the webhook in Stripe. **`npm run setup:full`** (stripe phase) and deploy CI (`npm run stripe:ensure-webhook`) can create or update this endpoint for `https://<ref>.supabase.co` projects automatically; use the manual steps below if you prefer the Dashboard or need to **Reveal** an existing signing secret.
 
 1. **Developers → Webhooks → Add endpoint**.
 2. **Endpoint URL** (replace placeholders):

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "test:coverage:shared": "cd packages/shared-tests && npm run test:coverage",
     "test:coverage:billing": "cd packages/billing && npm run test:coverage",
     "test:coverage:merge": "node scripts/merge-coverage.js",
-    "test:unit:scripts": "node --test scripts/__tests__/rename-project.test.mjs scripts/__tests__/detect-repo-identity.test.mjs scripts/__tests__/setup-aws-discover.test.mjs scripts/__tests__/setup-dotenv.test.mjs scripts/__tests__/setup-manifest-github-sync.test.mjs scripts/__tests__/setup-secret-input.test.mjs scripts/__tests__/setup-supabase-pick-recommend.test.mjs scripts/__tests__/billing-webhook-guards.test.mjs && ./scripts/pr-preview/check-preview-deploy-needed.sh --self-test",
+    "test:unit:scripts": "node --test scripts/__tests__/rename-project.test.mjs scripts/__tests__/detect-repo-identity.test.mjs scripts/__tests__/setup-aws-discover.test.mjs scripts/__tests__/setup-dotenv.test.mjs scripts/__tests__/setup-manifest-github-sync.test.mjs scripts/__tests__/setup-secret-input.test.mjs scripts/__tests__/setup-supabase-pick-recommend.test.mjs scripts/__tests__/billing-webhook-guards.test.mjs scripts/__tests__/setup-stripe.test.mjs scripts/__tests__/ensure-stripe-webhook.test.mjs && ./scripts/pr-preview/check-preview-deploy-needed.sh --self-test",
     "lint": "npm run lint:mobile; npm run lint:web; npm run lint:shared; npm run lint:billing; npm run lint:repo",
     "lint:mobile": "eslint apps/mobile/src --ext ts,tsx --report-unused-disable-directives",
     "lint:web": "eslint apps/web/src --ext ts,tsx --report-unused-disable-directives",

--- a/scripts/__tests__/ensure-stripe-webhook.test.mjs
+++ b/scripts/__tests__/ensure-stripe-webhook.test.mjs
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  ensureStripeWebhook,
+  isAutoEnsureStripeWebhookUrl,
+  MissingWebhookSecretError,
+  normalizeStripeWebhookUrl,
+  stripeSecretKeyMatchesMode,
+  STRIPE_WEBHOOK_ENABLED_EVENTS,
+} from '../lib/ensure-stripe-webhook.mjs';
+
+test('normalizeStripeWebhookUrl trims trailing slash', () => {
+  assert.equal(
+    normalizeStripeWebhookUrl(
+      'https://abcd.supabase.co/functions/v1/stripe-webhook/'
+    ),
+    'https://abcd.supabase.co/functions/v1/stripe-webhook'
+  );
+});
+
+test('isAutoEnsureStripeWebhookUrl accepts hosted supabase https webhook', () => {
+  assert.ok(
+    isAutoEnsureStripeWebhookUrl(
+      'https://abcd1234.supabase.co/functions/v1/stripe-webhook'
+    )
+  );
+});
+
+test('isAutoEnsureStripeWebhookUrl rejects local docker', () => {
+  assert.ok(
+    !isAutoEnsureStripeWebhookUrl(
+      'http://127.0.0.1:54321/functions/v1/stripe-webhook'
+    )
+  );
+});
+
+test('isAutoEnsureStripeWebhookUrl rejects custom hosts', () => {
+  assert.ok(
+    !isAutoEnsureStripeWebhookUrl(
+      'https://api.example.com/functions/v1/stripe-webhook'
+    )
+  );
+});
+
+test('stripeSecretKeyMatchesMode', () => {
+  assert.ok(stripeSecretKeyMatchesMode('sk_test_abc', 'test'));
+  assert.ok(stripeSecretKeyMatchesMode('sk_live_abc', 'live'));
+  assert.ok(!stripeSecretKeyMatchesMode('sk_live_abc', 'test'));
+});
+
+test('ensureStripeWebhook creates endpoint when missing', async () => {
+  const calls = [];
+  const mockStripe = {
+    webhookEndpoints: {
+      list: async () => ({ data: [] }),
+      create: async params => {
+        calls.push(['create', params]);
+        return { id: 'we_123', secret: 'whsec_new' };
+      },
+      update: async () => {
+        throw new Error('should not update');
+      },
+    },
+  };
+
+  const result = await ensureStripeWebhook({
+    secretKey: 'sk_test_x',
+    webhookUrl: 'https://proj.supabase.co/functions/v1/stripe-webhook',
+    description: 'test',
+    stripe: mockStripe,
+  });
+
+  assert.equal(result.signingSecret, 'whsec_new');
+  assert.equal(result.created, true);
+  assert.equal(result.endpointId, 'we_123');
+  assert.deepEqual(calls[0][1].enabled_events, STRIPE_WEBHOOK_ENABLED_EVENTS);
+});
+
+test('ensureStripeWebhook reuses existing secret', async () => {
+  const url = 'https://proj.supabase.co/functions/v1/stripe-webhook';
+  const mockStripe = {
+    webhookEndpoints: {
+      list: async () => ({
+        data: [
+          {
+            id: 'we_existing',
+            url,
+            enabled_events: [...STRIPE_WEBHOOK_ENABLED_EVENTS],
+          },
+        ],
+      }),
+      create: async () => {
+        throw new Error('should not create');
+      },
+      update: async () => {
+        throw new Error('should not update');
+      },
+    },
+  };
+
+  const result = await ensureStripeWebhook({
+    secretKey: 'sk_test_x',
+    webhookUrl: url,
+    existingWebhookSecret: 'whsec_saved',
+    stripe: mockStripe,
+  });
+
+  assert.equal(result.signingSecret, 'whsec_saved');
+  assert.equal(result.created, false);
+});
+
+test('ensureStripeWebhook throws MissingWebhookSecretError when endpoint exists without secret', async () => {
+  const url = 'https://proj.supabase.co/functions/v1/stripe-webhook';
+  const mockStripe = {
+    webhookEndpoints: {
+      list: async () => ({
+        data: [
+          {
+            id: 'we_existing',
+            url,
+            enabled_events: ['checkout.session.completed'],
+          },
+        ],
+      }),
+      update: async () => ({ id: 'we_existing' }),
+      create: async () => {
+        throw new Error('should not create');
+      },
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      ensureStripeWebhook({
+        secretKey: 'sk_test_x',
+        webhookUrl: url,
+        stripe: mockStripe,
+      }),
+    MissingWebhookSecretError
+  );
+});

--- a/scripts/__tests__/ensure-stripe-webhook.test.mjs
+++ b/scripts/__tests__/ensure-stripe-webhook.test.mjs
@@ -139,6 +139,45 @@ test('ensureStripeWebhook reuses existing secret', async () => {
 
   assert.equal(result.signingSecret, 'whsec_saved');
   assert.equal(result.created, false);
+  assert.equal(result.reenabled, false);
+});
+
+test('ensureStripeWebhook re-enables disabled endpoint', async () => {
+  const url = 'https://proj.supabase.co/functions/v1/stripe-webhook';
+  const updateCalls = [];
+  const mockStripe = {
+    webhookEndpoints: {
+      list: async () => ({
+        data: [
+          {
+            id: 'we_disabled',
+            url,
+            status: 'disabled',
+            enabled_events: [...STRIPE_WEBHOOK_ENABLED_EVENTS],
+          },
+        ],
+      }),
+      update: async (id, params) => {
+        updateCalls.push([id, params]);
+        return { id };
+      },
+      create: async () => {
+        throw new Error('should not create');
+      },
+    },
+  };
+
+  const result = await ensureStripeWebhook({
+    secretKey: 'sk_test_x',
+    webhookUrl: url,
+    existingWebhookSecret: 'whsec_saved',
+    stripe: mockStripe,
+  });
+
+  assert.equal(result.reenabled, true);
+  assert.equal(result.eventsUpdated, false);
+  assert.equal(updateCalls.length, 1);
+  assert.equal(updateCalls[0][1].disabled, false);
 });
 
 test('ensureStripeWebhook updates events and returns eventsUpdated: true', async () => {

--- a/scripts/__tests__/ensure-stripe-webhook.test.mjs
+++ b/scripts/__tests__/ensure-stripe-webhook.test.mjs
@@ -141,6 +141,42 @@ test('ensureStripeWebhook reuses existing secret', async () => {
   assert.equal(result.created, false);
 });
 
+test('ensureStripeWebhook updates events and returns eventsUpdated: true', async () => {
+  const url = 'https://proj.supabase.co/functions/v1/stripe-webhook';
+  const updateCalls = [];
+  const mockStripe = {
+    webhookEndpoints: {
+      list: async () => ({
+        data: [
+          {
+            id: 'we_existing',
+            url,
+            enabled_events: ['checkout.session.completed'],
+          },
+        ],
+      }),
+      update: async (id, params) => {
+        updateCalls.push([id, params]);
+        return { id };
+      },
+      create: async () => {
+        throw new Error('should not create');
+      },
+    },
+  };
+
+  const result = await ensureStripeWebhook({
+    secretKey: 'sk_test_x',
+    webhookUrl: url,
+    existingWebhookSecret: 'whsec_saved',
+    stripe: mockStripe,
+  });
+
+  assert.equal(result.eventsUpdated, true);
+  assert.equal(result.signingSecret, 'whsec_saved');
+  assert.equal(updateCalls.length, 1);
+});
+
 test('ensureStripeWebhook throws MissingWebhookSecretError when endpoint exists without secret', async () => {
   const url = 'https://proj.supabase.co/functions/v1/stripe-webhook';
   const mockStripe = {

--- a/scripts/__tests__/ensure-stripe-webhook.test.mjs
+++ b/scripts/__tests__/ensure-stripe-webhook.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   ensureStripeWebhook,
+  findStripeWebhookEndpointByUrl,
   isAutoEnsureStripeWebhookUrl,
   MissingWebhookSecretError,
   normalizeStripeWebhookUrl,
@@ -47,6 +48,36 @@ test('stripeSecretKeyMatchesMode', () => {
   assert.ok(stripeSecretKeyMatchesMode('sk_test_abc', 'test'));
   assert.ok(stripeSecretKeyMatchesMode('sk_live_abc', 'live'));
   assert.ok(!stripeSecretKeyMatchesMode('sk_live_abc', 'test'));
+});
+
+test('findStripeWebhookEndpointByUrl paginates past first page', async () => {
+  const target = 'https://proj.supabase.co/functions/v1/stripe-webhook';
+  const other = 'https://other.supabase.co/functions/v1/stripe-webhook';
+  let call = 0;
+  const mockStripe = {
+    webhookEndpoints: {
+      list: async ({ starting_after: after } = {}) => {
+        call += 1;
+        if (!after) {
+          return {
+            data: Array.from({ length: 100 }, (_, i) => ({
+              id: `we_fill_${i}`,
+              url: other,
+            })),
+            has_more: true,
+          };
+        }
+        return {
+          data: [{ id: 'we_target', url: target }],
+          has_more: false,
+        };
+      },
+    },
+  };
+
+  const found = await findStripeWebhookEndpointByUrl(mockStripe, target);
+  assert.equal(found?.id, 'we_target');
+  assert.equal(call, 2);
 });
 
 test('ensureStripeWebhook creates endpoint when missing', async () => {

--- a/scripts/__tests__/setup-stripe.test.mjs
+++ b/scripts/__tests__/setup-stripe.test.mjs
@@ -5,10 +5,12 @@ import {
   isStripeGithubSecretDef,
   resolveSupabaseUrlForStripeTier,
   setupStripeKeysDeferred,
+  stripeWebhookDescriptionForTier,
   supabaseStripeWebhookUrl,
   tierStripeKeysPresent,
   STRIPE_SETUP_TIERS,
 } from '../lib/setup-stripe.mjs';
+import { isAutoEnsureStripeWebhookUrl } from '../lib/ensure-stripe-webhook.mjs';
 
 test('supabaseStripeWebhookUrl', () => {
   assert.equal(
@@ -66,6 +68,27 @@ test('setupStripeKeysDeferred', () => {
   assert.ok(setupStripeKeysDeferred({ SETUP_STRIPE_SKIPPED: 'true' }));
   assert.ok(!setupStripeKeysDeferred({ SETUP_STRIPE_SKIPPED: 'false' }));
   assert.ok(!setupStripeKeysDeferred({}));
+});
+
+test('hosted supabase webhook URL is eligible for auto-ensure', () => {
+  const url = supabaseStripeWebhookUrl('https://abcd1234.supabase.co');
+  assert.ok(isAutoEnsureStripeWebhookUrl(url));
+});
+
+test('local supabase webhook URL is not auto-ensured', () => {
+  const url = supabaseStripeWebhookUrl('http://127.0.0.1:54321');
+  assert.ok(!isAutoEnsureStripeWebhookUrl(url));
+});
+
+test('stripeWebhookDescriptionForTier includes tier id', () => {
+  const tier = STRIPE_SETUP_TIERS.find(t => t.id === 'staging');
+  assert.ok(tier);
+  const desc = stripeWebhookDescriptionForTier(
+    tier,
+    'https://myproj.supabase.co/functions/v1/stripe-webhook'
+  );
+  assert.match(desc, /staging/);
+  assert.match(desc, /myproj/);
 });
 
 test('resolveSupabaseUrlForStripeTier uses first non-empty key', () => {

--- a/scripts/__tests__/setup-stripe.test.mjs
+++ b/scripts/__tests__/setup-stripe.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  ensureTierStripeWebhookSecret,
   isStripeGithubSecretDef,
   resolveSupabaseUrlForStripeTier,
   setupStripeKeysDeferred,
@@ -10,7 +11,24 @@ import {
   tierStripeKeysPresent,
   STRIPE_SETUP_TIERS,
 } from '../lib/setup-stripe.mjs';
-import { isAutoEnsureStripeWebhookUrl } from '../lib/ensure-stripe-webhook.mjs';
+import {
+  isAutoEnsureStripeWebhookUrl,
+  MissingWebhookSecretError,
+} from '../lib/ensure-stripe-webhook.mjs';
+
+function makeEnsureTierCtx(overrides = {}) {
+  const tier = STRIPE_SETUP_TIERS.find(t => t.id === 'preview');
+  assert.ok(tier);
+  return {
+    acc: { PREVIEW_STRIPE_SECRET_KEY: 'sk_test_abc' },
+    tier,
+    webhookUrl: 'https://proj.supabase.co/functions/v1/stripe-webhook',
+    logInfo: () => {},
+    logWarn: () => {},
+    applySecret: async () => {},
+    ...overrides,
+  };
+}
 
 test('supabaseStripeWebhookUrl', () => {
   assert.equal(
@@ -89,6 +107,70 @@ test('stripeWebhookDescriptionForTier includes tier id', () => {
   );
   assert.match(desc, /staging/);
   assert.match(desc, /myproj/);
+});
+
+test('ensureTierStripeWebhookSecret returns true when webhook secret already set', async () => {
+  const tier = STRIPE_SETUP_TIERS.find(t => t.id === 'preview');
+  assert.ok(tier);
+  const ctx = makeEnsureTierCtx({
+    acc: {
+      PREVIEW_STRIPE_SECRET_KEY: 'sk_test_abc',
+      PREVIEW_STRIPE_WEBHOOK_SECRET: 'whsec_existing',
+    },
+  });
+  const result = await ensureTierStripeWebhookSecret(ctx);
+  assert.equal(result, true);
+});
+
+test('ensureTierStripeWebhookSecret wrong Stripe mode returns false', async () => {
+  const warned = [];
+  const ctx = makeEnsureTierCtx({
+    acc: { PREVIEW_STRIPE_SECRET_KEY: 'sk_live_bad' },
+    logWarn: s => warned.push(s),
+  });
+  const result = await ensureTierStripeWebhookSecret(ctx);
+  assert.equal(result, false);
+  assert.ok(warned.some(w => /sk_test/.test(w)));
+});
+
+test('ensureTierStripeWebhookSecret non-auto-ensure URL returns false', async () => {
+  const ctx = makeEnsureTierCtx({
+    webhookUrl: 'http://127.0.0.1:54321/functions/v1/stripe-webhook',
+  });
+  const result = await ensureTierStripeWebhookSecret(ctx);
+  assert.equal(result, false);
+});
+
+test('ensureTierStripeWebhookSecret MissingWebhookSecretError falls back to false', async () => {
+  const url = 'https://proj.supabase.co/functions/v1/stripe-webhook';
+  const warned = [];
+  const ctx = makeEnsureTierCtx({
+    logWarn: s => warned.push(s),
+    ensureStripeWebhook: async () => {
+      throw new MissingWebhookSecretError(url);
+    },
+  });
+  const result = await ensureTierStripeWebhookSecret(ctx);
+  assert.equal(result, false);
+  assert.ok(warned.some(w => /signing secret is unknown/.test(w)));
+});
+
+test('ensureTierStripeWebhookSecret happy path calls applySecret', async () => {
+  const applied = [];
+  const ctx = makeEnsureTierCtx({
+    applySecret: async (raw, key) => {
+      applied.push([raw, key]);
+    },
+    ensureStripeWebhook: async () => ({
+      signingSecret: 'whsec_new',
+      created: true,
+      endpointId: 'we_123',
+      eventsUpdated: false,
+    }),
+  });
+  const result = await ensureTierStripeWebhookSecret(ctx);
+  assert.equal(result, true);
+  assert.deepEqual(applied, [['whsec_new', 'PREVIEW_STRIPE_WEBHOOK_SECRET']]);
 });
 
 test('resolveSupabaseUrlForStripeTier uses first non-empty key', () => {

--- a/scripts/__tests__/setup-stripe.test.mjs
+++ b/scripts/__tests__/setup-stripe.test.mjs
@@ -166,6 +166,7 @@ test('ensureTierStripeWebhookSecret happy path calls applySecret', async () => {
       created: true,
       endpointId: 'we_123',
       eventsUpdated: false,
+      reenabled: false,
     }),
   });
   const result = await ensureTierStripeWebhookSecret(ctx);

--- a/scripts/ensure-stripe-webhook-endpoint.mjs
+++ b/scripts/ensure-stripe-webhook-endpoint.mjs
@@ -55,6 +55,14 @@ async function main() {
       console.log(
         'Save this signing secret as your GitHub STRIPE_WEBHOOK_* secret for future CI runs (Dashboard can also reveal it).'
       );
+    } else if (result.reenabled && result.eventsUpdated) {
+      console.log(
+        `Re-enabled Stripe webhook endpoint ${result.endpointId} and updated enabled_events (${url.replace(/\/+$/, '')})`
+      );
+    } else if (result.reenabled) {
+      console.log(
+        `Re-enabled Stripe webhook endpoint ${result.endpointId} (${url.replace(/\/+$/, '')})`
+      );
     } else if (result.eventsUpdated) {
       console.log(
         `Updated Stripe webhook endpoint ${result.endpointId} enabled_events (${url.replace(/\/+$/, '')})`

--- a/scripts/ensure-stripe-webhook-endpoint.mjs
+++ b/scripts/ensure-stripe-webhook-endpoint.mjs
@@ -3,12 +3,6 @@
  * Ensures a Stripe webhook endpoint exists for the Supabase `stripe-webhook` URL and
  * exposes the signing secret for CI (GITHUB_OUTPUT) or the next `supabase secrets set`.
  *
- * - If no endpoint matches STRIPE_WEBHOOK_URL, creates one with the events used by
- *   `supabase/functions/stripe-webhook/index.ts`.
- * - If it already exists, updates `enabled_events` to match; the signing secret is only
- *   returned at create time, so STRIPE_WEBHOOK_SECRET must be set (e.g. GitHub secret
- *   from Dashboard → Reveal) on subsequent runs.
- *
  * Env:
  *   STRIPE_SECRET_KEY (required)
  *   STRIPE_WEBHOOK_URL (required) — full URL, e.g. https://<ref>.supabase.co/functions/v1/stripe-webhook
@@ -17,21 +11,11 @@
  */
 import fs from 'node:fs';
 import process from 'node:process';
-import Stripe from 'stripe';
 
-/** Keep in sync with `processStripeEvent` switch in stripe-webhook/index.ts */
-const ENABLED_EVENTS = [
-  'checkout.session.completed',
-  'customer.subscription.updated',
-  'customer.subscription.deleted',
-  'customer.subscription.trial_will_end',
-  'invoice.payment_failed',
-  'invoice.paid',
-  'invoice.payment_succeeded',
-  'invoice.created',
-  'invoice.finalized',
-  'invoice.voided',
-];
+import {
+  ensureStripeWebhook,
+  MissingWebhookSecretError,
+} from './lib/ensure-stripe-webhook.mjs';
 
 function emitResolvedSecret(secret) {
   const outPath = process.env.GITHUB_OUTPUT;
@@ -45,7 +29,7 @@ function emitResolvedSecret(secret) {
 
 async function main() {
   const sk = process.env.STRIPE_SECRET_KEY;
-  const url = process.env.STRIPE_WEBHOOK_URL?.replace(/\/+$/, '');
+  const url = process.env.STRIPE_WEBHOOK_URL;
   if (!sk || !url) {
     console.error(
       'Missing STRIPE_SECRET_KEY or STRIPE_WEBHOOK_URL (full …/functions/v1/stripe-webhook URL)'
@@ -53,71 +37,45 @@ async function main() {
     process.exit(1);
   }
 
-  const stripe = new Stripe(sk, { apiVersion: '2023-10-16' });
   const description =
     process.env.WEBHOOK_DESCRIPTION || 'BeakerStack CI (stripe-webhook)';
 
-  const list = await stripe.webhookEndpoints.list({ limit: 100 });
-  const found = list.data.find((e) => e.url.replace(/\/+$/, '') === url);
+  try {
+    const result = await ensureStripeWebhook({
+      secretKey: sk,
+      webhookUrl: url,
+      existingWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+      description,
+    });
 
-  let signingSecret = process.env.STRIPE_WEBHOOK_SECRET?.trim() || '';
-
-  if (found) {
-    const sorted = [...ENABLED_EVENTS].sort();
-    const current = [...(found.enabled_events || [])].sort();
-    const needsUpdate =
-      sorted.length !== current.length ||
-      sorted.some((ev, i) => ev !== current[i]);
-
-    if (needsUpdate) {
-      await stripe.webhookEndpoints.update(found.id, {
-        enabled_events: ENABLED_EVENTS,
-        description,
-      });
+    if (result.created) {
       console.log(
-        `Updated Stripe webhook endpoint ${found.id} enabled_events (${url})`
+        `Created Stripe webhook endpoint ${result.endpointId} (${url.replace(/\/+$/, '')})`
+      );
+      console.log(
+        'Save this signing secret as your GitHub STRIPE_WEBHOOK_* secret for future CI runs (Dashboard can also reveal it).'
+      );
+    } else if (result.eventsUpdated) {
+      console.log(
+        `Updated Stripe webhook endpoint ${result.endpointId} enabled_events (${url.replace(/\/+$/, '')})`
       );
     } else {
-      console.log(`Stripe webhook endpoint already configured (${url})`);
+      console.log(
+        `Stripe webhook endpoint already configured (${url.replace(/\/+$/, '')})`
+      );
     }
 
-    if (!signingSecret) {
-      console.error(
-        [
-          'This Stripe account already has a webhook for this URL, but STRIPE_WEBHOOK_SECRET is not set.',
-          'In Stripe Dashboard → Developers → Webhooks → select this endpoint → Reveal signing secret,',
-          'then add it as the matching GitHub repository secret (e.g. PREVIEW_STRIPE_WEBHOOK_SECRET).',
-        ].join('\n')
-      );
+    emitResolvedSecret(result.signingSecret);
+  } catch (e) {
+    if (e instanceof MissingWebhookSecretError) {
+      console.error(e.message);
       process.exit(1);
     }
-
-    emitResolvedSecret(signingSecret);
-    return;
+    throw e;
   }
-
-  const created = await stripe.webhookEndpoints.create({
-    url,
-    enabled_events: ENABLED_EVENTS,
-    description,
-    api_version: '2023-10-16',
-  });
-
-  signingSecret = created.secret;
-  if (!signingSecret) {
-    console.error('Stripe did not return a signing secret for the new webhook endpoint.');
-    process.exit(1);
-  }
-
-  console.log(`Created Stripe webhook endpoint ${created.id} (${url})`);
-  console.log(
-    'Save this signing secret as your GitHub STRIPE_WEBHOOK_* secret for future CI runs (Dashboard can also reveal it).'
-  );
-
-  emitResolvedSecret(signingSecret);
 }
 
-main().catch((e) => {
+main().catch(e => {
   console.error(e);
   process.exit(1);
 });

--- a/scripts/lib/ensure-stripe-webhook.mjs
+++ b/scripts/lib/ensure-stripe-webhook.mjs
@@ -114,6 +114,7 @@ export async function findStripeWebhookEndpointByUrl(stripe, webhookUrl) {
  *   created: boolean;
  *   endpointId: string;
  *   eventsUpdated: boolean;
+ *   reenabled: boolean;
  * }>}
  */
 export async function ensureStripeWebhook(opts) {
@@ -135,17 +136,21 @@ export async function ensureStripeWebhook(opts) {
   if (found) {
     const sorted = [...STRIPE_WEBHOOK_ENABLED_EVENTS].sort();
     const current = [...(found.enabled_events || [])].sort();
-    const needsUpdate =
+    const needsEventUpdate =
       sorted.length !== current.length ||
       sorted.some((ev, i) => ev !== current[i]);
+    const needsReenable = found.status === 'disabled';
 
     let eventsUpdated = false;
-    if (needsUpdate) {
+    let reenabled = false;
+    if (needsEventUpdate || needsReenable) {
       await stripe.webhookEndpoints.update(found.id, {
         enabled_events: STRIPE_WEBHOOK_ENABLED_EVENTS,
         description,
+        ...(needsReenable ? { disabled: false } : {}),
       });
-      eventsUpdated = true;
+      eventsUpdated = needsEventUpdate;
+      reenabled = needsReenable;
     }
 
     if (!signingSecret) {
@@ -157,6 +162,7 @@ export async function ensureStripeWebhook(opts) {
       created: false,
       endpointId: found.id,
       eventsUpdated,
+      reenabled,
     };
   }
 
@@ -179,5 +185,6 @@ export async function ensureStripeWebhook(opts) {
     created: true,
     endpointId: created.id,
     eventsUpdated: false,
+    reenabled: false,
   };
 }

--- a/scripts/lib/ensure-stripe-webhook.mjs
+++ b/scripts/lib/ensure-stripe-webhook.mjs
@@ -1,0 +1,159 @@
+/**
+ * Ensure a Stripe webhook endpoint exists for a Supabase `stripe-webhook` URL.
+ * Shared by CI (`ensure-stripe-webhook-endpoint.mjs`) and setup:full stripe phase.
+ */
+
+import Stripe from 'stripe';
+
+/** Keep in sync with `processStripeEvent` switch in stripe-webhook/index.ts */
+export const STRIPE_WEBHOOK_ENABLED_EVENTS = [
+  'checkout.session.completed',
+  'customer.subscription.updated',
+  'customer.subscription.deleted',
+  'customer.subscription.trial_will_end',
+  'invoice.payment_failed',
+  'invoice.paid',
+  'invoice.payment_succeeded',
+  'invoice.created',
+  'invoice.finalized',
+  'invoice.voided',
+];
+
+export class MissingWebhookSecretError extends Error {
+  /** @param {string} webhookUrl */
+  constructor(webhookUrl) {
+    super(
+      [
+        'This Stripe account already has a webhook for this URL, but no signing secret was provided.',
+        'In Stripe Dashboard → Developers → Webhooks → select this endpoint → Reveal signing secret,',
+        'then add it as the matching repository secret (e.g. PREVIEW_STRIPE_WEBHOOK_SECRET).',
+        `URL: ${webhookUrl}`,
+      ].join('\n')
+    );
+    this.name = 'MissingWebhookSecretError';
+    this.webhookUrl = webhookUrl;
+  }
+}
+
+/**
+ * @param {string} url
+ * @returns {string}
+ */
+export function normalizeStripeWebhookUrl(url) {
+  return String(url || '')
+    .trim()
+    .replace(/\/+$/, '');
+}
+
+/**
+ * Hosted Supabase projects can receive Stripe Dashboard webhooks; local/docker cannot.
+ * @param {string} webhookUrl
+ * @returns {boolean}
+ */
+export function isAutoEnsureStripeWebhookUrl(webhookUrl) {
+  const normalized = normalizeStripeWebhookUrl(webhookUrl);
+  if (!normalized) return false;
+  try {
+    const u = new URL(normalized);
+    return (
+      u.protocol === 'https:' &&
+      /\.supabase\.co$/i.test(u.hostname) &&
+      u.pathname === '/functions/v1/stripe-webhook'
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {string} secretKey
+ * @param {'test' | 'live'} expectedMode
+ * @returns {boolean}
+ */
+export function stripeSecretKeyMatchesMode(secretKey, expectedMode) {
+  const sk = String(secretKey || '').trim();
+  if (expectedMode === 'live') return sk.startsWith('sk_live_');
+  return sk.startsWith('sk_test_');
+}
+
+/**
+ * @param {{
+ *   secretKey: string;
+ *   webhookUrl: string;
+ *   existingWebhookSecret?: string;
+ *   description?: string;
+ *   stripe?: import('stripe').Stripe;
+ * }} opts
+ * @returns {Promise<{
+ *   signingSecret: string;
+ *   created: boolean;
+ *   endpointId: string;
+ *   eventsUpdated: boolean;
+ * }>}
+ */
+export async function ensureStripeWebhook(opts) {
+  const secretKey = String(opts.secretKey || '').trim();
+  const url = normalizeStripeWebhookUrl(opts.webhookUrl);
+  if (!secretKey || !url) {
+    throw new Error('ensureStripeWebhook requires secretKey and webhookUrl');
+  }
+
+  const stripe =
+    opts.stripe ?? new Stripe(secretKey, { apiVersion: '2023-10-16' });
+  const description =
+    opts.description?.trim() || 'BeakerStack (stripe-webhook)';
+
+  const list = await stripe.webhookEndpoints.list({ limit: 100 });
+  const found = list.data.find(e => normalizeStripeWebhookUrl(e.url) === url);
+
+  let signingSecret = String(opts.existingWebhookSecret || '').trim();
+
+  if (found) {
+    const sorted = [...STRIPE_WEBHOOK_ENABLED_EVENTS].sort();
+    const current = [...(found.enabled_events || [])].sort();
+    const needsUpdate =
+      sorted.length !== current.length ||
+      sorted.some((ev, i) => ev !== current[i]);
+
+    let eventsUpdated = false;
+    if (needsUpdate) {
+      await stripe.webhookEndpoints.update(found.id, {
+        enabled_events: STRIPE_WEBHOOK_ENABLED_EVENTS,
+        description,
+      });
+      eventsUpdated = true;
+    }
+
+    if (!signingSecret) {
+      throw new MissingWebhookSecretError(url);
+    }
+
+    return {
+      signingSecret,
+      created: false,
+      endpointId: found.id,
+      eventsUpdated,
+    };
+  }
+
+  const created = await stripe.webhookEndpoints.create({
+    url,
+    enabled_events: STRIPE_WEBHOOK_ENABLED_EVENTS,
+    description,
+    api_version: '2023-10-16',
+  });
+
+  signingSecret = created.secret || '';
+  if (!signingSecret) {
+    throw new Error(
+      'Stripe did not return a signing secret for the new webhook endpoint.'
+    );
+  }
+
+  return {
+    signingSecret,
+    created: true,
+    endpointId: created.id,
+    eventsUpdated: false,
+  };
+}

--- a/scripts/lib/ensure-stripe-webhook.mjs
+++ b/scripts/lib/ensure-stripe-webhook.mjs
@@ -77,6 +77,31 @@ export function stripeSecretKeyMatchesMode(secretKey, expectedMode) {
 }
 
 /**
+ * @param {import('stripe').Stripe} stripe
+ * @param {string} webhookUrl
+ * @returns {Promise<import('stripe').Stripe.WebhookEndpoint | null>}
+ */
+export async function findStripeWebhookEndpointByUrl(stripe, webhookUrl) {
+  const normalized = normalizeStripeWebhookUrl(webhookUrl);
+  if (!normalized) return null;
+
+  let startingAfter;
+  for (;;) {
+    const list = await stripe.webhookEndpoints.list({
+      limit: 100,
+      ...(startingAfter ? { starting_after: startingAfter } : {}),
+    });
+    const found = list.data.find(
+      e => normalizeStripeWebhookUrl(e.url) === normalized
+    );
+    if (found) return found;
+    if (!list.has_more || list.data.length === 0) break;
+    startingAfter = list.data[list.data.length - 1].id;
+  }
+  return null;
+}
+
+/**
  * @param {{
  *   secretKey: string;
  *   webhookUrl: string;
@@ -103,8 +128,7 @@ export async function ensureStripeWebhook(opts) {
   const description =
     opts.description?.trim() || 'BeakerStack (stripe-webhook)';
 
-  const list = await stripe.webhookEndpoints.list({ limit: 100 });
-  const found = list.data.find(e => normalizeStripeWebhookUrl(e.url) === url);
+  const found = await findStripeWebhookEndpointByUrl(stripe, url);
 
   let signingSecret = String(opts.existingWebhookSecret || '').trim();
 

--- a/scripts/lib/setup-stripe.mjs
+++ b/scripts/lib/setup-stripe.mjs
@@ -131,7 +131,6 @@ export function stripeWebhookDescriptionForTier(tier, webhookUrl) {
  *   logInfo: (s: string) => void;
  *   logWarn: (s: string) => void;
  *   applySecret: (raw: string, primaryKey: string) => Promise<void>;
- *   readSecret: (prompt: string) => Promise<string>;
  * }} ctx
  * @returns {Promise<boolean>} true if webhook secret is set when done
  */
@@ -294,7 +293,6 @@ export async function collectStripeEnvKeys(ctx) {
         logInfo,
         logWarn,
         applySecret,
-        readSecret,
       });
       if (!ensured && !(acc[tier.webhookSecretKey] || '').trim()) {
         const wh = await readSecret(

--- a/scripts/lib/setup-stripe.mjs
+++ b/scripts/lib/setup-stripe.mjs
@@ -2,6 +2,13 @@
  * Stripe billing keys for setup-full (GitHub Actions + .env.cloud.generated.local).
  */
 
+import {
+  ensureStripeWebhook,
+  isAutoEnsureStripeWebhookUrl,
+  MissingWebhookSecretError,
+  stripeSecretKeyMatchesMode,
+} from './ensure-stripe-webhook.mjs';
+
 /** @typedef {{ id: string; label: string; secretKey: string; webhookSecretKey: string; supabaseUrlKeys: string[]; stripeMode: 'test' | 'live' }} StripeSetupTier */
 
 /** @type {StripeSetupTier[]} */
@@ -101,6 +108,94 @@ export function tierStripeKeysPresent(acc, tier) {
 }
 
 /**
+ * @param {StripeSetupTier} tier
+ * @param {string} webhookUrl
+ * @returns {string}
+ */
+export function stripeWebhookDescriptionForTier(tier, webhookUrl) {
+  let ref = '';
+  try {
+    ref = new URL(webhookUrl).hostname.split('.')[0] || '';
+  } catch {
+    /* ignore */
+  }
+  const suffix = ref ? ` (${ref})` : '';
+  return `BeakerStack ${tier.id}${suffix}`;
+}
+
+/**
+ * @param {{
+ *   acc: Record<string, string>;
+ *   tier: StripeSetupTier;
+ *   webhookUrl: string;
+ *   logInfo: (s: string) => void;
+ *   logWarn: (s: string) => void;
+ *   applySecret: (raw: string, primaryKey: string) => Promise<void>;
+ *   readSecret: (prompt: string) => Promise<string>;
+ * }} ctx
+ * @returns {Promise<boolean>} true if webhook secret is set when done
+ */
+export async function ensureTierStripeWebhookSecret(ctx) {
+  const { acc, tier, webhookUrl, logInfo, logWarn, applySecret } = ctx;
+
+  if ((acc[tier.webhookSecretKey] || '').trim()) {
+    return true;
+  }
+
+  const secretKey = (acc[tier.secretKey] || '').trim();
+  if (!secretKey) {
+    return false;
+  }
+
+  if (!isAutoEnsureStripeWebhookUrl(webhookUrl)) {
+    return false;
+  }
+
+  if (!stripeSecretKeyMatchesMode(secretKey, tier.stripeMode)) {
+    logWarn(
+      `  ${tier.secretKey} does not look like sk_${tier.stripeMode === 'live' ? 'live' : 'test'}_ — fix the key or Stripe mode before ensuring webhooks.`
+    );
+    return false;
+  }
+
+  try {
+    const result = await ensureStripeWebhook({
+      secretKey,
+      webhookUrl,
+      existingWebhookSecret: acc[tier.webhookSecretKey],
+      description: stripeWebhookDescriptionForTier(tier, webhookUrl),
+    });
+    await applySecret(result.signingSecret, tier.webhookSecretKey);
+    if (result.created) {
+      logInfo(
+        `  Created Stripe webhook endpoint ${result.endpointId} and saved ${tier.webhookSecretKey}.`
+      );
+    } else if (result.eventsUpdated) {
+      logInfo(
+        `  Updated webhook ${result.endpointId} events; reused ${tier.webhookSecretKey}.`
+      );
+    } else {
+      logInfo(
+        `  Reused existing Stripe webhook; saved ${tier.webhookSecretKey}.`
+      );
+    }
+    return true;
+  } catch (e) {
+    if (e instanceof MissingWebhookSecretError) {
+      logWarn(
+        '  Stripe already has a webhook for this URL but the signing secret is unknown.'
+      );
+      logInfo(
+        '  Dashboard → Developers → Webhooks → this endpoint → Reveal signing secret (whsec_…).'
+      );
+      return false;
+    }
+    logWarn(`  Could not ensure Stripe webhook: ${e.message}`);
+    return false;
+  }
+}
+
+/**
  * @param {{
  *   acc: Record<string, string>;
  *   flags: { dryRun: boolean; plainSecretPrompts: boolean };
@@ -117,8 +212,17 @@ export async function collectStripeEnvKeys(ctx) {
 
   if (flags.dryRun) {
     logInfo(
-      '[dry-run] would walk preview / staging / production Stripe keys (sk_test + whsec per tier).'
+      '[dry-run] would walk preview / staging / production Stripe keys (sk_*; auto-ensure hosted webhooks when Supabase URL is set).'
     );
+    for (const tier of STRIPE_SETUP_TIERS) {
+      const supabaseUrl = resolveSupabaseUrlForStripeTier(acc, tier);
+      const webhookUrl = supabaseStripeWebhookUrl(supabaseUrl);
+      if (webhookUrl && isAutoEnsureStripeWebhookUrl(webhookUrl)) {
+        logInfo(
+          `[dry-run] would ensure Stripe webhook at ${webhookUrl} → ${tier.webhookSecretKey}`
+        );
+      }
+    }
     return;
   }
 
@@ -132,6 +236,8 @@ export async function collectStripeEnvKeys(ctx) {
 
     const supabaseUrl = resolveSupabaseUrlForStripeTier(acc, tier);
     const webhookUrl = supabaseStripeWebhookUrl(supabaseUrl);
+    const canAutoEnsure =
+      Boolean(webhookUrl) && isAutoEnsureStripeWebhookUrl(webhookUrl);
 
     logInfo('');
     logInfo(`── Stripe: ${tier.label} ──`);
@@ -141,9 +247,15 @@ export async function collectStripeEnvKeys(ctx) {
     if (webhookUrl) {
       logInfo(`  Webhook endpoint URL for this Supabase project:`);
       logInfo(`    ${webhookUrl}`);
-      logInfo(
-        '  Dashboard → Developers → Webhooks → Add endpoint → paste URL → select subscription events → Reveal signing secret (whsec_…).'
-      );
+      if (canAutoEnsure) {
+        logInfo(
+          `  With ${tier.secretKey} only, the wizard can create or update this webhook in Stripe and set ${tier.webhookSecretKey} automatically.`
+        );
+      } else {
+        logInfo(
+          '  Local/custom URLs: use Stripe CLI (stripe listen) for webhooks; see docs/stripe-billing-setup.md §8.'
+        );
+      }
     } else {
       logWarn(
         `  No Supabase URL set yet (${tier.supabaseUrlKeys.join(' / ')}) — complete supabase phase first, or paste keys from docs/stripe-billing-setup.md.`
@@ -174,7 +286,23 @@ export async function collectStripeEnvKeys(ctx) {
       if (sk) await applySecret(sk, tier.secretKey);
     }
 
-    if (!(acc[tier.webhookSecretKey] || '').trim()) {
+    if (webhookUrl && !(acc[tier.webhookSecretKey] || '').trim()) {
+      const ensured = await ensureTierStripeWebhookSecret({
+        acc,
+        tier,
+        webhookUrl,
+        logInfo,
+        logWarn,
+        applySecret,
+        readSecret,
+      });
+      if (!ensured && !(acc[tier.webhookSecretKey] || '').trim()) {
+        const wh = await readSecret(
+          `${tier.webhookSecretKey} (whsec_… — paste from Dashboard Reveal if webhook already exists, Enter to skip): `
+        );
+        if (wh) await applySecret(wh, tier.webhookSecretKey);
+      }
+    } else if (!(acc[tier.webhookSecretKey] || '').trim()) {
       const wh = await readSecret(
         `${tier.webhookSecretKey} (whsec_… for webhook above, Enter to skip): `
       );

--- a/scripts/lib/setup-stripe.mjs
+++ b/scripts/lib/setup-stripe.mjs
@@ -131,11 +131,20 @@ export function stripeWebhookDescriptionForTier(tier, webhookUrl) {
  *   logInfo: (s: string) => void;
  *   logWarn: (s: string) => void;
  *   applySecret: (raw: string, primaryKey: string) => Promise<void>;
+ *   ensureStripeWebhook?: typeof import('./ensure-stripe-webhook.mjs').ensureStripeWebhook;
  * }} ctx
  * @returns {Promise<boolean>} true if webhook secret is set when done
  */
 export async function ensureTierStripeWebhookSecret(ctx) {
-  const { acc, tier, webhookUrl, logInfo, logWarn, applySecret } = ctx;
+  const {
+    acc,
+    tier,
+    webhookUrl,
+    logInfo,
+    logWarn,
+    applySecret,
+    ensureStripeWebhook: ensureFn = ensureStripeWebhook,
+  } = ctx;
 
   if ((acc[tier.webhookSecretKey] || '').trim()) {
     return true;
@@ -158,7 +167,7 @@ export async function ensureTierStripeWebhookSecret(ctx) {
   }
 
   try {
-    const result = await ensureStripeWebhook({
+    const result = await ensureFn({
       secretKey,
       webhookUrl,
       existingWebhookSecret: acc[tier.webhookSecretKey],
@@ -189,7 +198,11 @@ export async function ensureTierStripeWebhookSecret(ctx) {
       );
       return false;
     }
-    logWarn(`  Could not ensure Stripe webhook: ${e.message}`);
+    const msg = e instanceof Error ? e.message : String(e);
+    logWarn(`  Could not ensure Stripe webhook: ${msg}`);
+    if (e instanceof Error && e.stack) {
+      logWarn(`  ${e.stack}`);
+    }
     return false;
   }
 }

--- a/scripts/lib/setup-stripe.mjs
+++ b/scripts/lib/setup-stripe.mjs
@@ -178,6 +178,14 @@ export async function ensureTierStripeWebhookSecret(ctx) {
       logInfo(
         `  Created Stripe webhook endpoint ${result.endpointId} and saved ${tier.webhookSecretKey}.`
       );
+    } else if (result.reenabled && result.eventsUpdated) {
+      logInfo(
+        `  Re-enabled webhook ${result.endpointId} and updated events; reused ${tier.webhookSecretKey}.`
+      );
+    } else if (result.reenabled) {
+      logInfo(
+        `  Re-enabled webhook ${result.endpointId}; reused ${tier.webhookSecretKey}.`
+      );
     } else if (result.eventsUpdated) {
       logInfo(
         `  Updated webhook ${result.endpointId} events; reused ${tier.webhookSecretKey}.`

--- a/scripts/pr-preview/deploy-preview-billing-functions.sh
+++ b/scripts/pr-preview/deploy-preview-billing-functions.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Link preview Supabase, set billing Edge secrets, deploy stripe-webhook + billing-stripe.
+# Retries transient Supabase API failures (e.g. 504 on project status).
+#
+# Required environment:
+#   SUPABASE_PREVIEW_PROJECT_REF (or SUPABASE_PROJECT_REF)
+#   SUPABASE_PREVIEW_DB_PASSWORD (or SUPABASE_DB_PASSWORD)
+#   PREVIEW_STRIPE_SECRET_KEY (or STRIPE_SECRET_KEY)
+#   PREVIEW_STRIPE_WEBHOOK_SECRET (or STRIPE_WEBHOOK_SECRET)
+#   PREVIEW_SUPABASE_URL (or BILLING_SUPABASE_URL)
+#   PREVIEW_SUPABASE_ANON_KEY (or BILLING_SUPABASE_ANON_KEY)
+#   PR_TESTING_SUPABASE_SERVICE_ROLE_KEY (or BILLING_SUPABASE_SERVICE_ROLE_KEY)
+# Optional:
+#   PREVIEW_BILLING_ALLOWED_ORIGINS (default https://deploy.beakerstack.com)
+#   SUPABASE_MAX_RETRIES (default 5)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/supabase-retry.sh
+source "${SCRIPT_DIR}/lib/supabase-retry.sh"
+
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+PROJECT_REF="${SUPABASE_PREVIEW_PROJECT_REF:-${SUPABASE_PROJECT_REF:-}}"
+DB_PASSWORD="${SUPABASE_PREVIEW_DB_PASSWORD:-${SUPABASE_DB_PASSWORD:-}}"
+STRIPE_SK="${PREVIEW_STRIPE_SECRET_KEY:-${STRIPE_SECRET_KEY:-}}"
+STRIPE_WHSEC="${PREVIEW_STRIPE_WEBHOOK_SECRET:-${STRIPE_WEBHOOK_SECRET:-}}"
+BILLING_URL="${PREVIEW_SUPABASE_URL:-${BILLING_SUPABASE_URL:-}}"
+BILLING_ANON="${PREVIEW_SUPABASE_ANON_KEY:-${BILLING_SUPABASE_ANON_KEY:-}}"
+BILLING_SERVICE="${PR_TESTING_SUPABASE_SERVICE_ROLE_KEY:-${BILLING_SUPABASE_SERVICE_ROLE_KEY:-}}"
+BILLING_ORIGINS="${PREVIEW_BILLING_ALLOWED_ORIGINS:-${BILLING_ALLOWED_ORIGINS:-https://deploy.beakerstack.com}}"
+
+missing=()
+[[ -n "${PROJECT_REF}" ]] || missing+=("SUPABASE_PREVIEW_PROJECT_REF")
+[[ -n "${DB_PASSWORD}" ]] || missing+=("SUPABASE_PREVIEW_DB_PASSWORD")
+[[ -n "${STRIPE_SK}" ]] || missing+=("PREVIEW_STRIPE_SECRET_KEY")
+[[ -n "${STRIPE_WHSEC}" ]] || missing+=("PREVIEW_STRIPE_WEBHOOK_SECRET")
+[[ -n "${BILLING_URL}" ]] || missing+=("PREVIEW_SUPABASE_URL")
+[[ -n "${BILLING_ANON}" ]] || missing+=("PREVIEW_SUPABASE_ANON_KEY")
+[[ -n "${BILLING_SERVICE}" ]] || missing+=("PR_TESTING_SUPABASE_SERVICE_ROLE_KEY")
+
+if ((${#missing[@]} > 0)); then
+  log "ERROR" "Missing required env: ${missing[*]}"
+  exit 1
+fi
+
+cd "${REPO_ROOT}/supabase"
+
+supabase_run "Link preview Supabase project" \
+  supabase link \
+  --project-ref "${PROJECT_REF}" \
+  --password "${DB_PASSWORD}" \
+  --yes
+
+supabase_run "Set preview billing Edge secrets" \
+  supabase secrets set \
+  STRIPE_SECRET_KEY="${STRIPE_SK}" \
+  STRIPE_WEBHOOK_SECRET="${STRIPE_WHSEC}" \
+  BILLING_SUPABASE_URL="${BILLING_URL}" \
+  BILLING_SUPABASE_ANON_KEY="${BILLING_ANON}" \
+  BILLING_SUPABASE_SERVICE_ROLE_KEY="${BILLING_SERVICE}" \
+  BILLING_ALLOWED_ORIGINS="${BILLING_ORIGINS}"
+
+supabase_run "Deploy preview billing edge functions" \
+  supabase functions deploy stripe-webhook billing-stripe \
+  --project-ref "${PROJECT_REF}"
+
+log "INFO" "Preview billing edge functions deployed for project ${PROJECT_REF}"

--- a/scripts/pr-preview/lib/supabase-retry.sh
+++ b/scripts/pr-preview/lib/supabase-retry.sh
@@ -1,0 +1,81 @@
+# Shared retry helper for Supabase CLI calls in CI (transient 504s, network blips).
+# shellcheck shell=bash
+#
+# Usage:
+#   source "$(dirname "$0")/lib/supabase-retry.sh"
+#   supabase_run "description" supabase link ...
+
+if ! declare -f log >/dev/null 2>&1; then
+  log() {
+    local level="$1"
+    shift
+    printf '[%-5s] %s\n' "${level}" "$*"
+  }
+fi
+
+# Run a command with exponential backoff. Fails after SUPABASE_MAX_RETRIES (default 5).
+# Pass --allow-fail as first arg to return 0 after exhausting retries.
+supabase_run() {
+  local allow_fail=0
+  if [[ "${1:-}" == "--allow-fail" ]]; then
+    allow_fail=1
+    shift
+  fi
+
+  local description="$1"
+  shift
+
+  if [[ "${DRY_RUN:-false}" == true ]]; then
+    log "DRY" "${description}"
+    return 0
+  fi
+
+  local max_attempts="${SUPABASE_MAX_RETRIES:-5}"
+  local attempt=1
+  local delay=5
+
+  local tmp
+  tmp="$(mktemp)"
+
+  while true; do
+    local status
+    if "$@" >"${tmp}" 2>&1; then
+      status=0
+    else
+      status=$?
+    fi
+
+    # Treat common Supabase CLI / API errors as failures even if exit code is zero.
+    if grep -qiE \
+      'failed to connect|cannot find project ref|Error:|error code: 504|\b504\b|gateway timeout|unexpected error retrieving remote project status' \
+      "${tmp}"; then
+      status=${status:-1}
+      if [[ "${status}" -eq 0 ]]; then
+        status=1
+      fi
+    fi
+
+    cat "${tmp}"
+
+    if (( status == 0 )); then
+      rm -f "${tmp}"
+      return 0
+    fi
+
+    if (( attempt >= max_attempts )); then
+      rm -f "${tmp}"
+      if (( allow_fail )); then
+        log "WARN" "${description} failed after ${attempt} attempt(s); continuing. (exit ${status})"
+        return 0
+      fi
+      log "ERROR" "${description} failed after ${attempt} attempt(s). (exit ${status})"
+      return "${status}"
+    fi
+
+    log "WARN" "${description} failed (attempt ${attempt}/${max_attempts}); retrying in ${delay}s..."
+    sleep "${delay}"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+    : >"${tmp}"
+  done
+}

--- a/scripts/pr-preview/reset-preview-database.sh
+++ b/scripts/pr-preview/reset-preview-database.sh
@@ -4,67 +4,9 @@
 # However, we'll make database operations non-blocking so the workflow can continue
 set -euo pipefail
 
-supabase_run() {
-  local allow_fail=0
-  if [[ "${1:-}" == "--allow-fail" ]]; then
-    allow_fail=1
-    shift
-  fi
-
-  local description="$1"
-  shift
-
-  if [[ "${DRY_RUN}" == true ]]; then
-    log "DRY" "${description}"
-    return 0
-  fi
-
-  local max_attempts="${SUPABASE_MAX_RETRIES:-3}"
-  local attempt=1
-  local delay=5
-
-  local tmp
-  tmp="$(mktemp)"
-
-  while true; do
-    local status
-    if "$@" >"${tmp}" 2>&1; then
-      status=0
-    else
-      status=$?
-    fi
-
-    # Treat common Supabase CLI error messages as failures even if exit code is zero.
-    if grep -qiE "failed to connect|cannot find project ref|Error:" "${tmp}"; then
-      status=${status:-1}
-    fi
-
-    cat "${tmp}"
-
-    if (( status == 0 )); then
-      rm -f "${tmp}"
-      return 0
-    fi
-
-    if (( attempt >= max_attempts )); then
-      rm -f "${tmp}"
-      if (( allow_fail )); then
-        log "WARN" "${description} failed after ${attempt} attempt(s); continuing. (exit ${status})"
-        return 0
-      fi
-      log "ERROR" "${description} failed after ${attempt} attempt(s). (exit ${status})"
-      return ${status}
-    fi
-
-    log "WARN" "${description} failed (attempt ${attempt}/${max_attempts}); retrying in ${delay}s..."
-    sleep "${delay}"
-    attempt=$((attempt + 1))
-    delay=$((delay * 2))
-    : >"${tmp}"
-  done
-}
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/supabase-retry.sh
+source "${SCRIPT_DIR}/lib/supabase-retry.sh"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 DEFAULT_PROJECT_REF="${SUPABASE_PREVIEW_PROJECT_REF:-}"


### PR DESCRIPTION
## Summary

- Extract `ensureStripeWebhook()` into `scripts/lib/ensure-stripe-webhook.mjs` for shared use by CI (`stripe:ensure-webhook`) and `setup:full`.
- In the stripe wizard phase, after collecting `sk_*` for a hosted Supabase tier, automatically create or update the Stripe webhook and store `*_STRIPE_WEBHOOK_SECRET` when Stripe returns a new signing secret.
- Fall back to a single masked `whsec` prompt when the endpoint already exists and the secret was never saved (Dashboard Reveal).
- Update setup prep checklist and stripe billing docs; add unit tests for the ensure lib and auto-ensure eligibility.

## Test plan

- [x] `node --test scripts/__tests__/ensure-stripe-webhook.test.mjs scripts/__tests__/setup-stripe.test.mjs`
- [ ] Run `npm run setup:full -- --from=stripe` against a fork with hosted Supabase URLs and verify webhook + `whsec` are filled for a greenfield tier
- [ ] Re-run on an existing Stripe webhook without stored `whsec` and confirm the Reveal fallback prompt appears
- [ ] Confirm CI `stripe:ensure-webhook` behavior unchanged on staging/preview deploy