### PR TITLE
chore: remove 18 permanently skipped unit tests (issue #272)

### DIFF
--- a/apps/web/src/pages/__tests__/AuthCallbackPage.test.tsx
+++ b/apps/web/src/pages/__tests__/AuthCallbackPage.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import AuthCallbackPage from '../AuthCallbackPage';
 import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
@@ -90,93 +90,6 @@ describe('AuthCallbackPage', () => {
     expect(
       screen.getByText('Please wait while we complete your authentication...')
     ).toBeInTheDocument();
-  });
-
-  it.skip('displays error message when error is in query params', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (window as any).location;
-    Object.defineProperty(window, 'location', {
-      value: {
-        ...originalLocation,
-        search: '?error=access_denied&error_description=User+cancelled',
-        hash: '',
-      },
-      writable: true,
-      configurable: true,
-    });
-
-    renderWithProviders(<AuthCallbackPage />, [
-      '/auth/callback?error=access_denied',
-    ]);
-
-    await waitFor(() => {
-      expect(screen.getByText(/authentication error/i)).toBeInTheDocument();
-      expect(screen.getByText(/user cancelled/i)).toBeInTheDocument();
-    });
-  });
-
-  it.skip('displays error message when error is in hash params', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (window as any).location;
-    Object.defineProperty(window, 'location', {
-      value: {
-        ...originalLocation,
-        search: '',
-        hash: '#error=access_denied&error_description=User+cancelled',
-      },
-      writable: true,
-      configurable: true,
-    });
-
-    renderWithProviders(<AuthCallbackPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/authentication error/i)).toBeInTheDocument();
-    });
-  });
-
-  it.skip('shows generic error message when error description is missing', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (window as any).location;
-    Object.defineProperty(window, 'location', {
-      value: {
-        ...originalLocation,
-        search: '?error=access_denied',
-        hash: '',
-      },
-      writable: true,
-      configurable: true,
-    });
-
-    renderWithProviders(<AuthCallbackPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/authentication failed/i)).toBeInTheDocument();
-    });
-  });
-
-  it.skip('redirects to login after error timeout', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (window as any).location;
-    Object.defineProperty(window, 'location', {
-      value: {
-        ...originalLocation,
-        search: '?error=access_denied',
-        hash: '',
-      },
-      writable: true,
-      configurable: true,
-    });
-
-    renderWithProviders(<AuthCallbackPage />);
-
-    // Fast-forward time to trigger redirect
-    vi.advanceTimersByTime(3000);
-
-    await waitFor(() => {
-      // The component should show redirecting message
-      expect(screen.getByText(/redirecting to login/i)).toBeInTheDocument();
-    });
   });
 
   it('handles successful OAuth callback with access token in hash', async () => {
@@ -271,42 +184,5 @@ describe('AuthCallbackPage', () => {
 
     // Should show loading state
     expect(screen.getByText('Completing sign in...')).toBeInTheDocument();
-  });
-
-  it.skip('shows error when token is present but user is not authenticated after timeout', async () => {
-    const mockClient = createMockSupabaseClient();
-    mockClient.auth.getSession = vi.fn().mockResolvedValue({
-      data: { session: null },
-      error: null,
-    });
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (window as any).location;
-    Object.defineProperty(window, 'location', {
-      value: {
-        ...originalLocation,
-        search: '',
-        hash: '#access_token=test-token',
-      },
-      writable: true,
-      configurable: true,
-    });
-
-    render(
-      <MemoryRouter initialEntries={['/auth/callback']}>
-        <AuthProvider supabaseClient={mockClient}>
-          <ProfileProvider supabaseClient={mockClient}>
-            <AuthCallbackPage />
-          </ProfileProvider>
-        </AuthProvider>
-      </MemoryRouter>
-    );
-
-    // Fast-forward time
-    vi.advanceTimersByTime(2000);
-
-    await waitFor(() => {
-      expect(screen.getByText(/session not established/i)).toBeInTheDocument();
-    });
   });
 });

--- a/apps/web/src/pages/__tests__/SignupPage.test.tsx
+++ b/apps/web/src/pages/__tests__/SignupPage.test.tsx
@@ -285,31 +285,6 @@ describe('SignupPage', () => {
     expect(confirmPasswordInput).toHaveValue('password123');
   });
 
-  it.skip('shows loading state when submitting', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<SignupPage />);
-
-    const emailInput = screen.getByPlaceholderText('Email address');
-    const passwordInput = screen.getByPlaceholderText('Password');
-    const confirmPasswordInput =
-      screen.getByPlaceholderText('Confirm password');
-    const form = emailInput.closest('form');
-    const submitButton = form?.querySelector(
-      'button[type="submit"]'
-    ) as HTMLButtonElement;
-
-    await user.type(emailInput, 'test@example.com');
-    await user.type(passwordInput, 'password123');
-    await user.type(confirmPasswordInput, 'password123');
-    if (submitButton) {
-      await user.click(submitButton);
-    }
-
-    await waitFor(() => {
-      expect(screen.getByText('Creating account...')).toBeInTheDocument();
-    });
-  });
-
   it('displays error message on signup failure', async () => {
     const user = userEvent.setup();
     authClientMocks.signUp.mockResolvedValueOnce({
@@ -520,36 +495,5 @@ describe('SignupPage', () => {
   it('does not show plan aside copy on plain /signup', () => {
     renderWithProviders(<SignupPage />);
     expect(screen.queryByText('Your selection')).not.toBeInTheDocument();
-  });
-
-  it.skip('disables form inputs when loading', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<SignupPage />);
-
-    const emailInput = screen.getByPlaceholderText('Email address');
-    const passwordInput = screen.getByPlaceholderText('Password');
-    const confirmPasswordInput =
-      screen.getByPlaceholderText('Confirm password');
-    const form = emailInput.closest('form');
-    const submitButton = form?.querySelector(
-      'button[type="submit"]'
-    ) as HTMLButtonElement;
-
-    await user.type(emailInput, 'test@example.com');
-    await user.type(passwordInput, 'password123');
-    await user.type(confirmPasswordInput, 'password123');
-    if (submitButton) {
-      await user.click(submitButton);
-    }
-
-    // Inputs should be disabled during loading
-    await waitFor(() => {
-      expect(emailInput).toBeDisabled();
-      expect(passwordInput).toBeDisabled();
-      expect(confirmPasswordInput).toBeDisabled();
-      if (submitButton) {
-        expect(submitButton).toBeDisabled();
-      }
-    });
   });
 });

--- a/packages/shared-tests/__tests__/components/auth/ProtectedRoute.native.test.tsx
+++ b/packages/shared-tests/__tests__/components/auth/ProtectedRoute.native.test.tsx
@@ -53,32 +53,6 @@ describe('ProtectedRoute (Native)', () => {
     jest.useRealTimers();
   });
 
-  it.skip('should render children when user is authenticated', async () => {
-    const mockClient = createMockSupabaseClient();
-    mockClient.auth.getSession = jest.fn().mockResolvedValue({
-      data: {
-        session: {
-          user: { id: '1', email: 'test@example.com' },
-          access_token: 'token',
-        },
-      },
-      error: null,
-    });
-
-    renderWithProviders(
-      <ProtectedRoute>
-        <div>Protected Content</div>
-      </ProtectedRoute>
-    );
-
-    await waitFor(
-      () => {
-        expect(screen.getByText('Protected Content')).toBeInTheDocument();
-      },
-      { timeout: 3000 }
-    );
-  });
-
   it('should show loading state while checking authentication', () => {
     const mockClient = createMockSupabaseClient();
     mockClient.auth.getSession = jest.fn().mockImplementation(
@@ -182,10 +156,5 @@ describe('ProtectedRoute (Native)', () => {
     });
 
     consoleWarnSpy.mockRestore();
-  });
-
-  it.skip('should not redirect when navigation is not available', async () => {
-    // This test is complex to mock properly with React Navigation
-    // Skipping for now as the main functionality is covered
   });
 });

--- a/packages/shared-tests/__tests__/components/forms/FormInput.native.test.tsx
+++ b/packages/shared-tests/__tests__/components/forms/FormInput.native.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { FormInput } from '@beakerstack/shared/components/forms/FormInput.native';
 
@@ -23,43 +23,6 @@ describe('FormInput (Native)', () => {
 
     const input = screen.getByDisplayValue('testuser');
     expect(input).toBeInTheDocument();
-  });
-
-  it.skip('calls onChange when input value changes', () => {
-    const mockOnChange = jest.fn();
-    render(
-      <FormInput
-        label='Username'
-        value=''
-        onChange={mockOnChange}
-        placeholder='Enter username'
-      />
-    );
-
-    const input = screen.getByPlaceholderText('Enter username');
-    // react-native-web renders TextInput - fire changeText directly
-    fireEvent(input, 'changeText', 'newvalue');
-
-    expect(mockOnChange).toHaveBeenCalledWith('newvalue');
-  });
-
-  it.skip('calls onBlur when input loses focus', () => {
-    const mockOnChange = jest.fn();
-    const mockOnBlur = jest.fn();
-    render(
-      <FormInput
-        label='Username'
-        value=''
-        onChange={mockOnChange}
-        onBlur={mockOnBlur}
-        placeholder='Enter username'
-      />
-    );
-
-    const input = screen.getByPlaceholderText('Enter username');
-    fireEvent(input, 'blur');
-
-    expect(mockOnBlur).toHaveBeenCalled();
   });
 
   it('displays error message when error prop is provided', () => {
@@ -195,26 +158,5 @@ describe('FormInput (Native)', () => {
 
     // Verify component renders
     expect(screen.getByText('Username')).toBeInTheDocument();
-  });
-
-  it.skip('calls onChange when value changes with error', () => {
-    const mockOnChange = jest.fn();
-    render(
-      <FormInput
-        label='Username'
-        value=''
-        onChange={mockOnChange}
-        error='Error message'
-        placeholder='Enter username'
-      />
-    );
-
-    expect(screen.getByText('Error message')).toBeInTheDocument();
-
-    // Simulate user typing
-    const input = screen.getByPlaceholderText('Enter username');
-    fireEvent(input, 'changeText', 'newvalue');
-
-    expect(mockOnChange).toHaveBeenCalledWith('newvalue');
   });
 });

--- a/packages/shared-tests/__tests__/components/navigation/AppHeader.native.test.tsx
+++ b/packages/shared-tests/__tests__/components/navigation/AppHeader.native.test.tsx
@@ -170,25 +170,4 @@ describe('AppHeader (Native)', () => {
     fireEvent.click(signUpButton);
     expect(mockNavigate).toHaveBeenCalledWith('Signup');
   });
-
-  it.skip('renders UserMenu when user is authenticated', async () => {
-    const mockClient = createMockSupabaseClient(true);
-    mockClient.auth.getSession = jest.fn().mockResolvedValue({
-      data: {
-        session: {
-          user: { id: '1', email: 'test@example.com' },
-          access_token: 'token',
-        },
-      },
-      error: null,
-    });
-
-    renderWithProviders(<AppHeader supabaseClient={mockClient} />);
-
-    // Wait for UserMenu to appear (ProfileProvider needs to load profile first)
-    await screen.findByTestId('user-menu', {}, { timeout: 3000 });
-
-    expect(screen.getByTestId('user-menu')).toBeInTheDocument();
-    expect(screen.queryByText('Sign In')).not.toBeInTheDocument();
-  });
 });

--- a/packages/shared-tests/__tests__/components/navigation/AppHeader.test.tsx
+++ b/packages/shared-tests/__tests__/components/navigation/AppHeader.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
@@ -83,63 +83,6 @@ describe('AppHeader (Web)', () => {
     await screen.findByText('Sign In');
     expect(screen.getByText('Sign In')).toBeInTheDocument();
     expect(screen.getByText('Sign Up')).toBeInTheDocument();
-  });
-
-  it.skip('should show UserMenu when user is authenticated', async () => {
-    const mockClient = createMockSupabaseClient();
-    const mockUser = {
-      id: '1',
-      email: 'test@example.com',
-      app_metadata: {},
-      user_metadata: {},
-      aud: 'authenticated',
-      created_at: new Date().toISOString(),
-    };
-
-    mockClient.auth.getSession = jest.fn().mockResolvedValue({
-      data: {
-        session: {
-          user: mockUser,
-          access_token: 'token',
-        },
-      },
-      error: null,
-    });
-
-    // Mock ProfileProvider to return a profile
-    mockClient.from = jest.fn(() => ({
-      select: jest.fn().mockReturnValue({
-        eq: jest.fn().mockReturnValue({
-          single: jest.fn().mockResolvedValue({
-            data: null,
-            error: { code: 'PGRST116', message: 'No rows returned' },
-          }),
-        }),
-      }),
-    })) as any;
-
-    render(
-      <BrowserRouter>
-        <AuthProvider supabaseClient={mockClient}>
-          <ProfileProvider supabaseClient={mockClient}>
-            <AppHeader supabaseClient={mockClient} />
-          </ProfileProvider>
-        </AuthProvider>
-      </BrowserRouter>
-    );
-
-    // Wait for auth to initialize - UserMenu should appear
-    await waitFor(
-      () => {
-        // Either UserMenu appears or Sign In/Sign Up are hidden
-        const signInLinks = screen.queryAllByText('Sign In');
-        const signUpLinks = screen.queryAllByText('Sign Up');
-        // If user is authenticated, these should not be in the header
-        expect(signInLinks.length).toBeLessThanOrEqual(1); // May appear in main content
-        expect(signUpLinks.length).toBeLessThanOrEqual(1);
-      },
-      { timeout: 3000 }
-    );
   });
 
   it('should have correct link to home page', () => {

--- a/packages/shared-tests/__tests__/components/navigation/UserMenu.test.tsx
+++ b/packages/shared-tests/__tests__/components/navigation/UserMenu.test.tsx
@@ -211,33 +211,6 @@ describe('UserMenu (Web)', () => {
     });
   });
 
-  it.skip('should close menu when clicking on menu item', async () => {
-    renderWithProviders(<UserMenu user={mockUser} profile={mockProfile} />);
-    await waitFor(() => {
-      expect(screen.getByLabelText('User menu')).toBeInTheDocument();
-    });
-
-    const menuButton = screen.getByLabelText('User menu');
-    fireEvent.click(menuButton);
-
-    await waitFor(() => {
-      expect(screen.getByText('Profile')).toBeInTheDocument();
-    });
-
-    const profileLink = screen.getByText('Profile');
-    fireEvent.click(profileLink);
-
-    // Menu should close after clicking link - check that aria-expanded is false
-    await waitFor(
-      () => {
-        const menuButtonAfter = screen.getByLabelText('User menu');
-        const ariaExpanded = menuButtonAfter.getAttribute('aria-expanded');
-        expect(ariaExpanded).toBe('false');
-      },
-      { timeout: 1000 }
-    );
-  });
-
   it('should have correct links to Profile and Dashboard', async () => {
     renderWithProviders(<UserMenu user={mockUser} profile={mockProfile} />);
     await waitFor(() => {

--- a/packages/shared-tests/__tests__/components/profile/AvatarUpload.native.test.tsx
+++ b/packages/shared-tests/__tests__/components/profile/AvatarUpload.native.test.tsx
@@ -640,59 +640,6 @@ describe('AvatarUpload (Native)', () => {
     global.__DEV__ = false;
   });
 
-  it.skip('handles image load error', () => {
-    const { Logger } = require('@beakerstack/shared/utils/logger');
-    const warnSpy = jest.spyOn(Logger, 'warn');
-
-    render(
-      <AvatarUpload
-        currentAvatarUrl='https://example.com/invalid.jpg'
-        onUploadComplete={mockOnUploadComplete}
-        onRemove={mockOnRemove}
-        userId='user-id-1'
-        supabaseClient={mockClient}
-      />
-    );
-
-    const images = screen.queryAllByRole('img');
-    if (images.length > 0) {
-      fireEvent(images[0], 'error', {
-        nativeEvent: { error: 'Load failed' },
-      });
-
-      // Error handler should be called (though may not trigger in test environment)
-      // Just verify the component renders
-      expect(images[0]).toBeInTheDocument();
-    }
-
-    warnSpy.mockRestore();
-  });
-
-  it.skip('handles image load success', () => {
-    const { Logger } = require('@beakerstack/shared/utils/logger');
-    const debugSpy = jest.spyOn(Logger, 'debug');
-
-    render(
-      <AvatarUpload
-        currentAvatarUrl='https://example.com/avatar.jpg'
-        onUploadComplete={mockOnUploadComplete}
-        onRemove={mockOnRemove}
-        userId='user-id-1'
-        supabaseClient={mockClient}
-      />
-    );
-
-    const images = screen.queryAllByRole('img');
-    if (images.length > 0) {
-      fireEvent(images[0], 'load');
-
-      // Load handler should be called
-      expect(images[0]).toBeInTheDocument();
-    }
-
-    debugSpy.mockRestore();
-  });
-
   it('handles remove avatar error', async () => {
     mockRemoveAvatar.mockRejectedValueOnce(new Error('Remove failed'));
 

--- a/packages/shared-tests/__tests__/hooks/useAuth.test.ts
+++ b/packages/shared-tests/__tests__/hooks/useAuth.test.ts
@@ -358,50 +358,6 @@ describe('useAuth', () => {
     expect(result.current.loading).toBe(false);
   });
 
-  it.skip('should handle signInWithGoogle with PR preview path', async () => {
-    const { mockClient } = createMockSupabaseClient();
-
-    // Mock window.location using Object.defineProperty on window
-    const originalLocation = window.location;
-    const mockLocation = {
-      ...originalLocation,
-      origin: 'http://localhost',
-      pathname: '/pr-9/login',
-    };
-
-    // Use Object.defineProperty to replace window.location
-    Object.defineProperty(window, 'location', {
-      value: mockLocation,
-      writable: true,
-      configurable: true,
-    });
-
-    const { result } = renderHook(() => useAuth(mockClient));
-
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false);
-    });
-
-    await act(async () => {
-      await result.current.signInWithGoogle();
-    });
-
-    // Should call signInWithOAuth with redirectTo including base path
-    expect(mockClient.auth.signInWithOAuth).toHaveBeenCalledWith({
-      provider: 'google',
-      options: {
-        redirectTo: 'http://localhost/pr-9/auth/callback',
-      },
-    });
-
-    // Restore window.location
-    Object.defineProperty(window, 'location', {
-      value: originalLocation,
-      writable: true,
-      configurable: true,
-    });
-  });
-
   it('should throw error during Google sign in when OAuth fails', async () => {
     const { mockClient } = createMockSupabaseClient();
     const errorMessage = 'OAuth error';


### PR DESCRIPTION
## Summary

- Deletes all 18 `it.skip` cases across 9 files — none provide coverage not already in the passing suite
- Three imports left unused by the removals are cleaned up (`waitFor` ×2, `fireEvent` ×1)
- `rg '.skip\(' --glob "**/*.{test,spec}.{ts,tsx}"` is clean after this change
- Pre-existing `shared-tests` collection failures (missing package imports, unrelated to this PR) unchanged

## Test plan

- [x] `apps/web` vitest suite: 415 tests, 69 files — all pass
- [x] No `.skip(` in test files (grep clean)
- [x] Type-check passes (pre-commit hook)

Closes #272
