### PR TITLE
fix(web): preserve URL hash when toggling billing cadence

### DIFF
--- a/apps/web/src/components/billing/CadenceToggle.web.tsx
+++ b/apps/web/src/components/billing/CadenceToggle.web.tsx
@@ -1,19 +1,21 @@
 import { usePlanCatalog } from '@beakerstack/billing';
 import type { Plan } from '@beakerstack/billing';
-import { useCallback, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { beakerstackBillingConfig } from '../../billing/beakerstackBillingConfig';
 import {
   cadenceAnnualSavingsFromPlans,
   formatCadenceToggleSavingsBadge,
 } from '@beakerstack/billing/presentation';
+import { useCallback, useMemo } from 'react';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { beakerstackBillingConfig } from '../../billing/beakerstackBillingConfig';
 
 export function getCadenceFromSearch(search: URLSearchParams) {
   return search.get('cadence') === 'annual' ? 'annual' : 'monthly';
 }
 
 function CadenceToggleView({ plans }: { plans: Plan[] }) {
-  const [search, setSearch] = useSearchParams();
+  const [search] = useSearchParams();
+  const navigate = useNavigate();
+  const { hash } = useLocation();
   const savings = useMemo(() => cadenceAnnualSavingsFromPlans(plans), [plans]);
   const annualBadgeText = useMemo(
     () => formatCadenceToggleSavingsBadge(savings),
@@ -26,9 +28,9 @@ function CadenceToggleView({ plans }: { plans: Plan[] }) {
       const n = new URLSearchParams(search);
       if (c === 'monthly') n.delete('cadence');
       else n.set('cadence', 'annual');
-      setSearch(n, { replace: true });
+      navigate({ search: n.toString(), hash }, { replace: true });
     },
-    [search, setSearch]
+    [search, navigate, hash]
   );
 
   return (

--- a/apps/web/src/components/billing/__tests__/CadenceToggle.web.test.tsx
+++ b/apps/web/src/components/billing/__tests__/CadenceToggle.web.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import type { Plan } from '@beakerstack/billing';
 import { CadenceToggle, getCadenceFromSearch } from '../CadenceToggle.web';
 
@@ -99,5 +99,27 @@ describe('CadenceToggle', () => {
     expect(screen.getByRole('button', { name: /Annually/i }).className).toMatch(
       /indigo-600/
     );
+  });
+
+  it('preserves URL hash when toggling cadence (regression: #275)', async () => {
+    const user = userEvent.setup();
+    let capturedHash = '';
+    function HashSpy() {
+      capturedHash = useLocation().hash;
+      return null;
+    }
+    render(
+      <MemoryRouter initialEntries={['/#pricing']}>
+        <CadenceToggle plans={[proPlan]} />
+        <HashSpy />
+      </MemoryRouter>
+    );
+    expect(capturedHash).toBe('#pricing');
+
+    await user.click(screen.getByRole('button', { name: /Annually/i }));
+    expect(capturedHash).toBe('#pricing');
+
+    await user.click(screen.getByRole('button', { name: 'Monthly' }));
+    expect(capturedHash).toBe('#pricing');
   });
 });


### PR DESCRIPTION
## Problem

Toggling Monthly/Annual on the home page pricing section (`/#pricing`) causes the page to scroll to the top. Closes #275.

## Root cause

`setSearchParams` in React Router v6 navigates to `"?" + newParams`, silently dropping the URL hash. On `/#pricing`, clicking the toggle changes the URL from `/#pricing` to `/?cadence=annual` — hash goes from `#pricing` to `""`. `ScrollToTop`'s `useLayoutEffect([pathname, hash])` re-runs and calls `window.scrollTo(0, 0)` because the hash is now empty.

## Fix

In `CadenceToggleView`, replace:
```ts
setSearch(n, { replace: true });
```
with:
```ts
navigate({ search: n.toString(), hash }, { replace: true });
```
using `useLocation()` to read the current hash and pass it through the navigation, so the hash is never dropped.

## Regression test

Adds a test in `CadenceToggle.web.test.tsx` that mounts the toggle inside a `MemoryRouter` with initial entry `/#pricing` and asserts that `location.hash` remains `#pricing` after clicking both Annual and Monthly buttons.

## Test plan
- [ ] Existing `CadenceToggle` tests pass
- [ ] New regression test passes
- [ ] Manually visit `/#pricing` on the home page, toggle cadence — page does not scroll to top