### PR TITLE
feat(auth): forgot password / account recovery flow (#271)

### DIFF
--- a/apps/mobile/__tests__/App.test.tsx
+++ b/apps/mobile/__tests__/App.test.tsx
@@ -81,6 +81,8 @@ jest.mock('@beakerstack/shared/contexts/AuthContext', () => ({
     signUp: jest.fn(),
     signOut: jest.fn(),
     signInWithGoogle: jest.fn(),
+    requestPasswordReset: jest.fn(),
+    updatePassword: jest.fn(),
   }),
 }));
 
@@ -119,6 +121,7 @@ jest.mock('@react-navigation/native-stack', () => {
             navigate: jest.fn(),
             replace: jest.fn(),
             goBack: jest.fn(),
+            reset: jest.fn(),
           };
           return <Component navigation={mockNavigation} {...props} />;
         }
@@ -184,6 +187,42 @@ jest.mock('../src/screens/DashboardScreen', () => {
     default: () => (
       <View testID='dashboard-screen'>
         <Text>Dashboard</Text>
+      </View>
+    ),
+  };
+});
+
+jest.mock('../src/screens/ForgotPasswordScreen', () => {
+  const { View, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: () => (
+      <View testID='forgot-password-screen'>
+        <Text>Forgot Password</Text>
+      </View>
+    ),
+  };
+});
+
+jest.mock('../src/screens/AuthCallbackScreen', () => {
+  const { View, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: () => (
+      <View testID='auth-callback-screen'>
+        <Text>Auth Callback</Text>
+      </View>
+    ),
+  };
+});
+
+jest.mock('../src/screens/ResetPasswordScreen', () => {
+  const { View, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: () => (
+      <View testID='reset-password-screen'>
+        <Text>Reset Password</Text>
       </View>
     ),
   };

--- a/apps/mobile/__tests__/navigation/AppNavigator.test.tsx
+++ b/apps/mobile/__tests__/navigation/AppNavigator.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react-native';
+import { render, waitFor } from '@testing-library/react-native';
 import { AppNavigator } from '../../src/navigation/AppNavigator';
 import { useFeatureFlags } from '../../src/config/featureFlags';
 
@@ -65,6 +65,42 @@ jest.mock('../../src/navigation/BillingNavigator', () => {
   };
 });
 
+jest.mock('../../src/screens/ForgotPasswordScreen', () => {
+  const { View, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: () => (
+      <View testID='forgot-password-screen'>
+        <Text>Forgot Password Screen</Text>
+      </View>
+    ),
+  };
+});
+
+jest.mock('../../src/screens/AuthCallbackScreen', () => {
+  const { View, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: () => (
+      <View testID='auth-callback-screen'>
+        <Text>Auth Callback Screen</Text>
+      </View>
+    ),
+  };
+});
+
+jest.mock('../../src/screens/ResetPasswordScreen', () => {
+  const { View, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: () => (
+      <View testID='reset-password-screen'>
+        <Text>Reset Password Screen</Text>
+      </View>
+    ),
+  };
+});
+
 describe('AppNavigator', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -73,18 +109,18 @@ describe('AppNavigator', () => {
     });
   });
 
-  it('renders navigation container', () => {
+  it('renders navigation container', async () => {
     const { getByTestId } = render(<AppNavigator />);
-    expect(getByTestId('home-screen')).toBeTruthy();
+    await waitFor(() => expect(getByTestId('home-screen')).toBeTruthy());
   });
 
-  it('configures navigation with feature flags', () => {
+  it('configures navigation with feature flags', async () => {
     (useFeatureFlags as jest.Mock).mockReturnValue({
       showNativeHeader: true,
     });
 
     const { getByTestId } = render(<AppNavigator />);
-    expect(getByTestId('home-screen')).toBeTruthy();
+    await waitFor(() => expect(getByTestId('home-screen')).toBeTruthy());
   });
 
   it('exposes navigation ref in dev mode', () => {

--- a/apps/mobile/__tests__/screens/AuthCallbackScreen.test.tsx
+++ b/apps/mobile/__tests__/screens/AuthCallbackScreen.test.tsx
@@ -26,7 +26,6 @@ jest.mock('../../src/lib/supabase', () => ({
   },
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const mockOnAuthStateChange = (require('../../src/lib/supabase') as {
   supabase: { auth: { onAuthStateChange: jest.Mock } };
 }).supabase.auth.onAuthStateChange;

--- a/apps/mobile/__tests__/screens/AuthCallbackScreen.test.tsx
+++ b/apps/mobile/__tests__/screens/AuthCallbackScreen.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render, waitFor, act } from '@testing-library/react-native';
+import AuthCallbackScreen from '../../src/screens/AuthCallbackScreen';
+
+jest.mock('expo-constants', () => ({
+  default: {
+    expoConfig: {
+      extra: {
+        supabaseUrl: 'http://localhost:54321',
+        supabaseAnonKey: 'test-anon-key',
+        googleWebClientId: 'test-web-client-id',
+        googleIosClientId: 'test-ios-client-id',
+        googleAndroidClientId: 'test-android-client-id',
+      },
+    },
+  },
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      onAuthStateChange: jest.fn(() => ({
+        data: { subscription: { unsubscribe: jest.fn() } },
+      })),
+    },
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const mockOnAuthStateChange = (require('../../src/lib/supabase') as {
+  supabase: { auth: { onAuthStateChange: jest.Mock } };
+}).supabase.auth.onAuthStateChange;
+
+const mockReset = jest.fn();
+const mockNavigation = { reset: mockReset, navigate: jest.fn() } as any;
+
+describe('AuthCallbackScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockOnAuthStateChange.mockImplementation(() => ({
+      data: { subscription: { unsubscribe: jest.fn() } },
+    }));
+  });
+
+  it('shows loading spinner', () => {
+    const { getByText } = render(<AuthCallbackScreen navigation={mockNavigation} />);
+    expect(getByText('Completing authentication...')).toBeTruthy();
+  });
+
+  it('resets to ResetPassword on PASSWORD_RECOVERY event', async () => {
+    mockOnAuthStateChange.mockImplementation((cb: (event: string) => void) => {
+      cb('PASSWORD_RECOVERY');
+      return { data: { subscription: { unsubscribe: jest.fn() } } };
+    });
+
+    render(<AuthCallbackScreen navigation={mockNavigation} />);
+
+    await waitFor(() => {
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: 'ResetPassword' }],
+      });
+    });
+    expect(mockReset).not.toHaveBeenCalledWith(
+      expect.objectContaining({ routes: [{ name: 'Dashboard' }] })
+    );
+  });
+
+  it('resets to Dashboard on SIGNED_IN event', async () => {
+    mockOnAuthStateChange.mockImplementation((cb: (event: string) => void) => {
+      cb('SIGNED_IN');
+      return { data: { subscription: { unsubscribe: jest.fn() } } };
+    });
+
+    render(<AuthCallbackScreen navigation={mockNavigation} />);
+
+    await waitFor(() => {
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: 'Dashboard' }],
+      });
+    });
+    expect(mockReset).not.toHaveBeenCalledWith(
+      expect.objectContaining({ routes: [{ name: 'ResetPassword' }] })
+    );
+  });
+
+  it('resets to Login after 5s timeout if no auth event fires', () => {
+    jest.useFakeTimers();
+
+    render(<AuthCallbackScreen navigation={mockNavigation} />);
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(mockReset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: 'Login' }],
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('does not reset after timeout if auth event already handled', () => {
+    jest.useFakeTimers();
+
+    mockOnAuthStateChange.mockImplementation((cb: (event: string) => void) => {
+      cb('SIGNED_IN');
+      return { data: { subscription: { unsubscribe: jest.fn() } } };
+    });
+
+    render(<AuthCallbackScreen navigation={mockNavigation} />);
+
+    // SIGNED_IN fires synchronously, then timeout fires — should only navigate once
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    const dashboardCalls = mockReset.mock.calls.filter(
+      (c) => c[0]?.routes?.[0]?.name === 'Dashboard'
+    );
+    const loginCalls = mockReset.mock.calls.filter(
+      (c) => c[0]?.routes?.[0]?.name === 'Login'
+    );
+    expect(dashboardCalls).toHaveLength(1);
+    expect(loginCalls).toHaveLength(0);
+
+    jest.useRealTimers();
+  });
+});

--- a/apps/mobile/__tests__/screens/ForgotPasswordScreen.test.tsx
+++ b/apps/mobile/__tests__/screens/ForgotPasswordScreen.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import ForgotPasswordScreen from '../../src/screens/ForgotPasswordScreen';
+import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
+import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+jest.mock('expo-constants', () => ({
+  default: {
+    expoConfig: {
+      extra: {
+        supabaseUrl: 'http://localhost:54321',
+        supabaseAnonKey: 'test-anon-key',
+        googleWebClientId: 'test-web-client-id',
+        googleIosClientId: 'test-ios-client-id',
+        googleAndroidClientId: 'test-android-client-id',
+      },
+    },
+  },
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: null }, error: null }),
+      onAuthStateChange: jest.fn(() => ({
+        data: { subscription: { unsubscribe: jest.fn() } },
+      })),
+    },
+  },
+}));
+
+jest.mock('@beakerstack/shared/components/navigation/AppHeader.native', () => ({
+  AppHeader: () => null,
+}));
+
+const mockResetPasswordForEmail = jest.fn();
+
+const mockNavigate = jest.fn();
+const mockNavigation = { navigate: mockNavigate, reset: jest.fn() } as any;
+
+const createMockSupabaseClient = (): SupabaseClient =>
+  ({
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: null }, error: null }),
+      onAuthStateChange: jest.fn(() => ({
+        data: { subscription: { unsubscribe: jest.fn() } },
+      })),
+      signInWithPassword: jest.fn(),
+      signUp: jest.fn(),
+      signOut: jest.fn(),
+      signInWithOAuth: jest.fn(),
+      resetPasswordForEmail: mockResetPasswordForEmail,
+      updateUser: jest.fn(),
+    },
+    from: jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: jest.fn(() => ({
+          single: jest.fn().mockResolvedValue({ data: null, error: null }),
+        })),
+      })),
+    })),
+    channel: jest.fn(() => ({
+      on: jest.fn().mockReturnThis(),
+      subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+    })),
+    removeChannel: jest.fn().mockResolvedValue(undefined),
+  }) as unknown as SupabaseClient;
+
+const renderScreen = () => {
+  const client = createMockSupabaseClient();
+  return render(
+    <AuthProvider supabaseClient={client}>
+      <ProfileProvider supabaseClient={client}>
+        <ForgotPasswordScreen navigation={mockNavigation} />
+      </ProfileProvider>
+    </AuthProvider>
+  );
+};
+
+describe('ForgotPasswordScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the email form', () => {
+    const { getByPlaceholderText, getByText } = renderScreen();
+    expect(getByPlaceholderText('Email address')).toBeTruthy();
+    expect(getByText('Send reset link')).toBeTruthy();
+  });
+
+  it('shows error when email is empty', async () => {
+    const { getByText } = renderScreen();
+    fireEvent.press(getByText('Send reset link'));
+    await waitFor(() => {
+      expect(getByText('Please enter your email address')).toBeTruthy();
+    });
+    expect(mockResetPasswordForEmail).not.toHaveBeenCalled();
+  });
+
+  it('calls requestPasswordReset and shows non-enumerating success message', async () => {
+    mockResetPasswordForEmail.mockResolvedValue({ data: {}, error: null });
+    const { getByPlaceholderText, getByText, queryByText } = renderScreen();
+
+    fireEvent.changeText(getByPlaceholderText('Email address'), 'user@example.com');
+    fireEvent.press(getByText('Send reset link'));
+
+    await waitFor(() => {
+      expect(getByText(/If an account exists for/)).toBeTruthy();
+    });
+    expect(mockResetPasswordForEmail).toHaveBeenCalledWith(
+      'user@example.com',
+      expect.objectContaining({ redirectTo: expect.any(String) })
+    );
+    expect(queryByText(/account does not exist/i)).toBeNull();
+  });
+
+  it('shows error when API fails', async () => {
+    mockResetPasswordForEmail.mockResolvedValue({
+      data: {},
+      error: { message: 'Network error' },
+    });
+    const { getByPlaceholderText, getByText } = renderScreen();
+
+    fireEvent.changeText(getByPlaceholderText('Email address'), 'user@example.com');
+    fireEvent.press(getByText('Send reset link'));
+
+    await waitFor(() => {
+      expect(getByText('Network error')).toBeTruthy();
+    });
+  });
+
+  it('navigates to Login when Back to sign in is pressed', () => {
+    const { getByText } = renderScreen();
+    fireEvent.press(getByText('Back to sign in'));
+    expect(mockNavigate).toHaveBeenCalledWith('Login');
+  });
+});

--- a/apps/mobile/__tests__/screens/ResetPasswordScreen.test.tsx
+++ b/apps/mobile/__tests__/screens/ResetPasswordScreen.test.tsx
@@ -1,0 +1,244 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import ResetPasswordScreen from '../../src/screens/ResetPasswordScreen';
+import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
+import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { MIN_PASSWORD_LENGTH } from '@beakerstack/shared/constants/auth';
+
+jest.mock('expo-constants', () => ({
+  default: {
+    expoConfig: {
+      extra: {
+        supabaseUrl: 'http://localhost:54321',
+        supabaseAnonKey: 'test-anon-key',
+        googleWebClientId: 'test-web-client-id',
+        googleIosClientId: 'test-ios-client-id',
+        googleAndroidClientId: 'test-android-client-id',
+      },
+    },
+  },
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+      onAuthStateChange: jest.fn(() => ({
+        data: { subscription: { unsubscribe: jest.fn() } },
+      })),
+    },
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const mockGetSession = (require('../../src/lib/supabase') as {
+  supabase: { auth: { getSession: jest.Mock } };
+}).supabase.auth.getSession;
+
+jest.mock('@beakerstack/shared/components/navigation/AppHeader.native', () => ({
+  AppHeader: () => null,
+}));
+
+const mockUpdateUser = jest.fn();
+const mockReset = jest.fn();
+const mockNavigation = { reset: mockReset, navigate: jest.fn() } as any;
+
+const mockUser = {
+  id: '1',
+  email: 'user@example.com',
+  app_metadata: {},
+  user_metadata: {},
+  aud: 'authenticated',
+  created_at: new Date().toISOString(),
+};
+
+const mockSession = {
+  user: mockUser,
+  access_token: 'tok',
+  refresh_token: 'ref',
+  expires_in: 3600,
+  expires_at: Date.now() + 3600000,
+  token_type: 'bearer',
+};
+
+const createMockSupabaseClient = (): SupabaseClient =>
+  ({
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: mockSession }, error: null }),
+      onAuthStateChange: jest.fn(() => ({
+        data: { subscription: { unsubscribe: jest.fn() } },
+      })),
+      signInWithPassword: jest.fn(),
+      signUp: jest.fn(),
+      signOut: jest.fn(),
+      signInWithOAuth: jest.fn(),
+      resetPasswordForEmail: jest.fn(),
+      updateUser: mockUpdateUser,
+    },
+    from: jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: jest.fn(() => ({
+          single: jest.fn().mockResolvedValue({ data: null, error: null }),
+        })),
+      })),
+    })),
+    channel: jest.fn(() => ({
+      on: jest.fn().mockReturnThis(),
+      subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+    })),
+    removeChannel: jest.fn().mockResolvedValue(undefined),
+  }) as unknown as SupabaseClient;
+
+const renderScreen = () => {
+  const client = createMockSupabaseClient();
+  return render(
+    <AuthProvider supabaseClient={client}>
+      <ProfileProvider supabaseClient={client}>
+        <ResetPasswordScreen navigation={mockNavigation} />
+      </ProfileProvider>
+    </AuthProvider>
+  );
+};
+
+describe('ResetPasswordScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Alert, 'alert');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('shows loading state while session check is pending', () => {
+    mockGetSession.mockReturnValue(new Promise(() => {}));
+    const { queryByText } = renderScreen();
+    expect(queryByText('Update password')).toBeNull();
+  });
+
+  it('resets to ForgotPassword when there is no session', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
+    renderScreen();
+    await waitFor(() => {
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: 'ForgotPassword' }],
+      });
+    });
+  });
+
+  it('renders the form when a session exists', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: mockSession }, error: null });
+    const { getByPlaceholderText } = renderScreen();
+    await waitFor(() => {
+      expect(
+        getByPlaceholderText(`New password (min ${MIN_PASSWORD_LENGTH} characters)`)
+      ).toBeTruthy();
+    });
+    expect(getByPlaceholderText('Confirm new password')).toBeTruthy();
+  });
+
+  it('shows alert when password is too short', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: mockSession }, error: null });
+    const { getByPlaceholderText, getByText } = renderScreen();
+
+    await waitFor(() =>
+      expect(
+        getByPlaceholderText(`New password (min ${MIN_PASSWORD_LENGTH} characters)`)
+      ).toBeTruthy()
+    );
+
+    fireEvent.changeText(
+      getByPlaceholderText(`New password (min ${MIN_PASSWORD_LENGTH} characters)`),
+      'short'
+    );
+    fireEvent.changeText(getByPlaceholderText('Confirm new password'), 'short');
+    fireEvent.press(getByText('Update password'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Password too short',
+        expect.stringContaining(String(MIN_PASSWORD_LENGTH))
+      );
+    });
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it('shows alert when passwords do not match', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: mockSession }, error: null });
+    const { getByPlaceholderText, getByText } = renderScreen();
+
+    await waitFor(() =>
+      expect(
+        getByPlaceholderText(`New password (min ${MIN_PASSWORD_LENGTH} characters)`)
+      ).toBeTruthy()
+    );
+
+    fireEvent.changeText(
+      getByPlaceholderText(`New password (min ${MIN_PASSWORD_LENGTH} characters)`),
+      'newpassword1'
+    );
+    fireEvent.changeText(getByPlaceholderText('Confirm new password'), 'different123');
+    fireEvent.press(getByText('Update password'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('Error', 'Passwords do not match');
+    });
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it('calls updatePassword and navigates to Dashboard on success', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: mockSession }, error: null });
+    mockUpdateUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    const { getByPlaceholderText, getByText } = renderScreen();
+
+    await waitFor(() =>
+      expect(
+        getByPlaceholderText(`New password (min ${MIN_PASSWORD_LENGTH} characters)`)
+      ).toBeTruthy()
+    );
+
+    fireEvent.changeText(
+      getByPlaceholderText(`New password (min ${MIN_PASSWORD_LENGTH} characters)`),
+      'newpassword1'
+    );
+    fireEvent.changeText(getByPlaceholderText('Confirm new password'), 'newpassword1');
+    fireEvent.press(getByText('Update password'));
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith({ password: 'newpassword1' });
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: 'Dashboard' }],
+      });
+    });
+  });
+
+  it('shows alert when updatePassword fails', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: mockSession }, error: null });
+    mockUpdateUser.mockRejectedValue(new Error('Password too weak'));
+    const { getByPlaceholderText, getByText } = renderScreen();
+
+    await waitFor(() =>
+      expect(
+        getByPlaceholderText(`New password (min ${MIN_PASSWORD_LENGTH} characters)`)
+      ).toBeTruthy()
+    );
+
+    fireEvent.changeText(
+      getByPlaceholderText(`New password (min ${MIN_PASSWORD_LENGTH} characters)`),
+      'newpassword1'
+    );
+    fireEvent.changeText(getByPlaceholderText('Confirm new password'), 'newpassword1');
+    fireEvent.press(getByText('Update password'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('Error', 'Password too weak');
+    });
+    expect(mockReset).not.toHaveBeenCalledWith(
+      expect.objectContaining({ routes: [{ name: 'Dashboard' }] })
+    );
+  });
+});

--- a/apps/mobile/__tests__/screens/ResetPasswordScreen.test.tsx
+++ b/apps/mobile/__tests__/screens/ResetPasswordScreen.test.tsx
@@ -32,7 +32,6 @@ jest.mock('../../src/lib/supabase', () => ({
   },
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const mockGetSession = (require('../../src/lib/supabase') as {
   supabase: { auth: { getSession: jest.Mock } };
 }).supabase.auth.getSession;

--- a/apps/mobile/__tests__/screens/SignupScreen.test.tsx
+++ b/apps/mobile/__tests__/screens/SignupScreen.test.tsx
@@ -4,6 +4,7 @@ import { Alert } from 'react-native';
 import SignupScreen from '../../src/screens/SignupScreen';
 import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
+import { MIN_PASSWORD_LENGTH } from '@beakerstack/shared/constants/auth';
 import type { SupabaseClient } from '@supabase/supabase-js';
 // Mock expo-constants
 jest.mock('expo-constants', () => ({
@@ -164,6 +165,34 @@ describe('SignupScreen', () => {
         'Please fill in all fields'
       );
     });
+  });
+
+  it('shows error when password is too short', async () => {
+    const mockClient = createMockSupabaseClient();
+    const { getByPlaceholderText, getByText } = renderWithProviders(
+      <SignupScreen navigation={mockNavigation} />,
+      mockClient
+    );
+
+    await waitFor(() => {
+      const emailInput = getByPlaceholderText('Email address');
+      const passwordInput = getByPlaceholderText('Password');
+      const confirmPasswordInput = getByPlaceholderText('Confirm password');
+      const submitButton = getByText('Create Account');
+
+      fireEvent.changeText(emailInput, 'test@example.com');
+      fireEvent.changeText(passwordInput, 'short');
+      fireEvent.changeText(confirmPasswordInput, 'short');
+      fireEvent.press(submitButton);
+    });
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Password too short',
+        `Password must be at least ${MIN_PASSWORD_LENGTH} characters`
+      );
+    });
+    expect(mockClient.auth.signUp).not.toHaveBeenCalled();
   });
 
   it('shows error when passwords do not match', async () => {

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "Beaker Stack",
     "slug": "beaker-stack",
+    "scheme": "beaker-stack",
     "version": "1.0.0",
     "orientation": "portrait",
     "userInterfaceStyle": "light",

--- a/apps/mobile/src/lib/__tests__/supabase.test.ts
+++ b/apps/mobile/src/lib/__tests__/supabase.test.ts
@@ -93,7 +93,7 @@ describe('supabase.ts', () => {
           storage: mockAsyncStorage,
           autoRefreshToken: true,
           persistSession: true,
-          detectSessionInUrl: false,
+          detectSessionInUrl: true,
         },
       })
     );

--- a/apps/mobile/src/lib/supabase.ts
+++ b/apps/mobile/src/lib/supabase.ts
@@ -55,7 +55,7 @@ export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
     storage: AsyncStorage,
     autoRefreshToken: true,
     persistSession: true,
-    detectSessionInUrl: false,
+    detectSessionInUrl: true,
   },
 });
 

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   NavigationContainer,
   type NavigationContainerRef,
+  type LinkingOptions,
 } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HomeScreen from '../screens/HomeScreen';
@@ -10,18 +11,33 @@ import SignupScreen from '../screens/SignupScreen';
 import DashboardScreen from '../screens/DashboardScreen';
 import ProfileScreen from '../screens/ProfileScreen';
 import BillingNavigator from '../navigation/BillingNavigator';
+import ForgotPasswordScreen from '../screens/ForgotPasswordScreen';
+import AuthCallbackScreen from '../screens/AuthCallbackScreen';
+import ResetPasswordScreen from '../screens/ResetPasswordScreen';
 import { useFeatureFlags } from '../config/featureFlags';
 
-type RootStackParamList = {
+export type RootStackParamList = {
   Home: undefined;
   Login: undefined;
   Signup: undefined;
   Dashboard: undefined;
   Profile: undefined;
   Billing: undefined;
+  ForgotPassword: undefined;
+  AuthCallback: undefined;
+  ResetPassword: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
+
+const linking: LinkingOptions<RootStackParamList> = {
+  prefixes: ['beaker-stack://'],
+  config: {
+    screens: {
+      AuthCallback: 'auth/callback',
+    },
+  },
+};
 
 export const AppNavigator = () => {
   const navigationRef =
@@ -37,7 +53,7 @@ export const AppNavigator = () => {
   }
 
   return (
-    <NavigationContainer ref={navigationRef}>
+    <NavigationContainer ref={navigationRef} linking={linking}>
       <Stack.Navigator
         screenOptions={{
           gestureEnabled: false, // Disable swipe-back gestures
@@ -53,6 +69,9 @@ export const AppNavigator = () => {
         />
         <Stack.Screen name='Login' component={LoginScreen} />
         <Stack.Screen name='Signup' component={SignupScreen} />
+        <Stack.Screen name='ForgotPassword' component={ForgotPasswordScreen} />
+        <Stack.Screen name='AuthCallback' component={AuthCallbackScreen} />
+        <Stack.Screen name='ResetPassword' component={ResetPasswordScreen} />
         <Stack.Screen name='Dashboard' component={DashboardScreen} />
         <Stack.Screen name='Profile' component={ProfileScreen} />
         <Stack.Screen

--- a/apps/mobile/src/screens/AuthCallbackScreen.tsx
+++ b/apps/mobile/src/screens/AuthCallbackScreen.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef } from 'react';
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { colors } from '@beakerstack/shared/theme/colors';
+import { supabase } from '../lib/supabase';
+import { type RootStackParamList } from '../navigation/AppNavigator';
+
+type AuthCallbackScreenNavigationProp = NativeStackNavigationProp<
+  RootStackParamList,
+  'AuthCallback'
+>;
+
+interface Props {
+  navigation: AuthCallbackScreenNavigationProp;
+}
+
+export default function AuthCallbackScreen({ navigation }: Props) {
+  const navigatedRef = useRef(false);
+
+  useEffect(() => {
+    const fallbackTimer = setTimeout(() => {
+      if (navigatedRef.current) return;
+      navigatedRef.current = true;
+      navigation.reset({ index: 0, routes: [{ name: 'Login' }] });
+    }, 5000);
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event) => {
+      if (navigatedRef.current) return;
+
+      if (event === 'PASSWORD_RECOVERY') {
+        navigatedRef.current = true;
+        clearTimeout(fallbackTimer);
+        navigation.reset({ index: 0, routes: [{ name: 'ResetPassword' }] });
+      } else if (event === 'SIGNED_IN') {
+        navigatedRef.current = true;
+        clearTimeout(fallbackTimer);
+        navigation.reset({ index: 0, routes: [{ name: 'Dashboard' }] });
+      }
+    });
+
+    return () => {
+      clearTimeout(fallbackTimer);
+      subscription.unsubscribe();
+    };
+  }, [navigation]);
+
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size='large' color={colors.brand} />
+      <Text style={styles.text}>Completing authentication...</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.pageBg,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 16,
+  },
+  text: {
+    fontSize: 16,
+    color: colors.textMuted,
+  },
+});

--- a/apps/mobile/src/screens/ForgotPasswordScreen.tsx
+++ b/apps/mobile/src/screens/ForgotPasswordScreen.tsx
@@ -1,0 +1,204 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  ActivityIndicator,
+} from 'react-native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
+import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.native';
+import { colors } from '@beakerstack/shared/theme/colors';
+import { supabase } from '../lib/supabase';
+import { type RootStackParamList } from '../navigation/AppNavigator';
+
+type ForgotPasswordScreenNavigationProp = NativeStackNavigationProp<
+  RootStackParamList,
+  'ForgotPassword'
+>;
+
+interface Props {
+  navigation: ForgotPasswordScreenNavigationProp;
+}
+
+export default function ForgotPasswordScreen({ navigation }: Props) {
+  const [email, setEmail] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const auth = useAuthContext();
+
+  const handleSubmit = async () => {
+    setError(null);
+
+    if (!email) {
+      setError('Please enter your email address');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      await auth.requestPasswordReset(email);
+      setSubmitted(true);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Something went wrong. Please try again.'
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <AppHeader supabaseClient={supabase} />
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.content}>
+        <View style={styles.form}>
+          <Text style={styles.title}>Reset your password</Text>
+          <Text style={styles.subtitle}>
+            Enter your email and we&apos;ll send you a reset link.
+          </Text>
+
+          {submitted ? (
+            <View style={styles.successBox}>
+              <Text style={styles.successText}>
+                If an account exists for {email}, you will receive a password
+                reset email shortly.
+              </Text>
+            </View>
+          ) : (
+            <>
+              {error ? (
+                <View style={styles.errorBox}>
+                  <Text style={styles.errorText}>{error}</Text>
+                </View>
+              ) : null}
+
+              <TextInput
+                style={styles.input}
+                placeholder='Email address'
+                placeholderTextColor={colors.textMuted}
+                value={email}
+                onChangeText={setEmail}
+                keyboardType='email-address'
+                autoCapitalize='none'
+                autoComplete='email'
+                editable={!isLoading}
+              />
+
+              <TouchableOpacity
+                style={[styles.button, isLoading && styles.buttonDisabled]}
+                onPress={handleSubmit}
+                disabled={isLoading}
+              >
+                {isLoading ? (
+                  <ActivityIndicator color='#ffffff' />
+                ) : (
+                  <Text style={styles.buttonText}>Send reset link</Text>
+                )}
+              </TouchableOpacity>
+            </>
+          )}
+
+          <TouchableOpacity
+            style={styles.linkButton}
+            onPress={() => navigation.navigate('Login')}
+          >
+            <Text style={styles.linkText}>Back to sign in</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.pageBg,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  content: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    padding: 20,
+  },
+  form: {
+    maxWidth: 400,
+    alignSelf: 'center',
+    width: '100%',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: colors.textPrimary,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: colors.textMuted,
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  successBox: {
+    backgroundColor: '#f0fdf4',
+    borderRadius: 8,
+    padding: 16,
+    marginBottom: 16,
+  },
+  successText: {
+    color: '#166534',
+    fontSize: 14,
+  },
+  errorBox: {
+    backgroundColor: '#fef2f2',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 16,
+  },
+  errorText: {
+    color: '#991b1b',
+    fontSize: 14,
+  },
+  input: {
+    backgroundColor: colors.cardBg,
+    borderWidth: 1,
+    borderColor: colors.gray[300],
+    borderRadius: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    fontSize: 16,
+    marginBottom: 16,
+  },
+  button: {
+    backgroundColor: colors.brand,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonText: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  linkButton: {
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  linkText: {
+    color: colors.brand,
+    fontSize: 14,
+  },
+});

--- a/apps/mobile/src/screens/ForgotPasswordScreen.tsx
+++ b/apps/mobile/src/screens/ForgotPasswordScreen.tsx
@@ -87,6 +87,7 @@ export default function ForgotPasswordScreen({ navigation }: Props) {
                 onChangeText={setEmail}
                 keyboardType='email-address'
                 autoCapitalize='none'
+                autoCorrect={false}
                 autoComplete='email'
                 editable={!isLoading}
               />

--- a/apps/mobile/src/screens/LoginScreen.tsx
+++ b/apps/mobile/src/screens/LoginScreen.tsx
@@ -23,6 +23,7 @@ type RootStackParamList = {
   Login: undefined;
   Signup: undefined;
   Dashboard: undefined;
+  ForgotPassword: undefined;
 };
 
 type LoginScreenNavigationProp = NativeStackNavigationProp<
@@ -140,6 +141,13 @@ export default function LoginScreen({ navigation }: Props) {
             ) : (
               <Text style={styles.loginButtonText}>Sign In</Text>
             )}
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.linkButton}
+            onPress={() => navigation.navigate('ForgotPassword')}
+          >
+            <Text style={styles.linkText}>Forgot password?</Text>
           </TouchableOpacity>
 
           <TouchableOpacity

--- a/apps/mobile/src/screens/ResetPasswordScreen.tsx
+++ b/apps/mobile/src/screens/ResetPasswordScreen.tsx
@@ -1,0 +1,189 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
+import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.native';
+import { colors } from '@beakerstack/shared/theme/colors';
+import { MIN_PASSWORD_LENGTH } from '@beakerstack/shared/constants/auth';
+import { supabase } from '../lib/supabase';
+import { type RootStackParamList } from '../navigation/AppNavigator';
+
+type ResetPasswordScreenNavigationProp = NativeStackNavigationProp<
+  RootStackParamList,
+  'ResetPassword'
+>;
+
+interface Props {
+  navigation: ResetPasswordScreenNavigationProp;
+}
+
+export default function ResetPasswordScreen({ navigation }: Props) {
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [sessionChecked, setSessionChecked] = useState(false);
+  const auth = useAuthContext();
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session) {
+        navigation.reset({
+          index: 0,
+          routes: [{ name: 'ForgotPassword' }],
+        });
+      } else {
+        setSessionChecked(true);
+      }
+    });
+  }, [navigation]);
+
+  if (!sessionChecked) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size='large' color={colors.brand} />
+      </View>
+    );
+  }
+
+  const handleSubmit = async () => {
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      Alert.alert(
+        'Password too short',
+        `Password must be at least ${MIN_PASSWORD_LENGTH} characters`
+      );
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      Alert.alert('Error', 'Passwords do not match');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      await auth.updatePassword(password);
+      navigation.reset({ index: 0, routes: [{ name: 'Dashboard' }] });
+    } catch (err) {
+      Alert.alert(
+        'Error',
+        err instanceof Error ? err.message : 'Failed to update password. Please try again.'
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <AppHeader supabaseClient={supabase} />
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.content}>
+        <View style={styles.form}>
+          <Text style={styles.title}>Set new password</Text>
+
+          <TextInput
+            style={styles.input}
+            placeholder={`New password (min ${MIN_PASSWORD_LENGTH} characters)`}
+            placeholderTextColor={colors.textMuted}
+            value={password}
+            onChangeText={setPassword}
+            secureTextEntry
+            autoComplete='new-password'
+            editable={!isLoading}
+          />
+
+          <TextInput
+            style={styles.input}
+            placeholder='Confirm new password'
+            placeholderTextColor={colors.textMuted}
+            value={confirmPassword}
+            onChangeText={setConfirmPassword}
+            secureTextEntry
+            autoComplete='new-password'
+            editable={!isLoading}
+          />
+
+          <TouchableOpacity
+            style={[styles.button, isLoading && styles.buttonDisabled]}
+            onPress={handleSubmit}
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <ActivityIndicator color='#ffffff' />
+            ) : (
+              <Text style={styles.buttonText}>Update password</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.pageBg,
+  },
+  container: {
+    flex: 1,
+    backgroundColor: colors.pageBg,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  content: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    padding: 20,
+  },
+  form: {
+    maxWidth: 400,
+    alignSelf: 'center',
+    width: '100%',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: colors.textPrimary,
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  input: {
+    backgroundColor: colors.cardBg,
+    borderWidth: 1,
+    borderColor: colors.gray[300],
+    borderRadius: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    fontSize: 16,
+    marginBottom: 16,
+  },
+  button: {
+    backgroundColor: colors.brand,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonText: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/src/screens/ResetPasswordScreen.tsx
+++ b/apps/mobile/src/screens/ResetPasswordScreen.tsx
@@ -98,6 +98,8 @@ export default function ResetPasswordScreen({ navigation }: Props) {
             value={password}
             onChangeText={setPassword}
             secureTextEntry
+            autoCapitalize='none'
+            autoCorrect={false}
             autoComplete='new-password'
             editable={!isLoading}
           />
@@ -109,6 +111,8 @@ export default function ResetPasswordScreen({ navigation }: Props) {
             value={confirmPassword}
             onChangeText={setConfirmPassword}
             secureTextEntry
+            autoCapitalize='none'
+            autoCorrect={false}
             autoComplete='new-password'
             editable={!isLoading}
           />

--- a/apps/mobile/src/screens/SignupScreen.tsx
+++ b/apps/mobile/src/screens/SignupScreen.tsx
@@ -14,6 +14,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
 import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.native';
 import { colors } from '@beakerstack/shared/theme/colors';
+import { MIN_PASSWORD_LENGTH } from '@beakerstack/shared/constants/auth';
 import { supabase } from '../lib/supabase';
 import { SocialLoginButton } from '../components/SocialLoginButton';
 import { useFeatureFlags } from '../config/featureFlags';
@@ -54,6 +55,14 @@ export default function SignupScreen({ navigation }: Props) {
   const handleSignup = async () => {
     if (!email || !password || !confirmPassword) {
       Alert.alert('Error', 'Please fill in all fields');
+      return;
+    }
+
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      Alert.alert(
+        'Password too short',
+        `Password must be at least ${MIN_PASSWORD_LENGTH} characters`
+      );
       return;
     }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -24,6 +24,8 @@ const SignupInvitePage = lazy(() => import('./pages/SignupInvitePage'));
 const DashboardPage = lazy(() => import('./pages/DashboardPage'));
 const ProfilePage = lazy(() => import('./pages/ProfilePage'));
 const AuthCallbackPage = lazy(() => import('./pages/AuthCallbackPage'));
+const ForgotPasswordPage = lazy(() => import('./pages/ForgotPasswordPage'));
+const ResetPasswordPage = lazy(() => import('./pages/ResetPasswordPage'));
 const PolicyPage = lazy(() => import('./pages/PolicyPage'));
 const BillingOverviewPage = lazy(
   () => import('./pages/billing/BillingOverviewPage')
@@ -110,6 +112,8 @@ function App() {
                 <Route path='/login' element={<LoginPage />} />
                 <Route path='/signup' element={<SignupPage />} />
                 <Route path='/signup/invite' element={<SignupInvitePage />} />
+                <Route path='/forgot-password' element={<ForgotPasswordPage />} />
+                <Route path='/reset-password' element={<ResetPasswordPage />} />
                 <Route path='/auth/callback' element={<AuthCallbackPage />} />
                 <Route
                   path='/not-authorized'

--- a/apps/web/src/pages/AuthCallbackPage.tsx
+++ b/apps/web/src/pages/AuthCallbackPage.tsx
@@ -6,6 +6,7 @@ import {
   finalizeInviteSignup,
   INVITE_TOKEN_STORAGE_KEY,
 } from './SignupInvitePage';
+import { supabase } from '@/lib/supabase';
 
 export default function AuthCallbackPage() {
   const [error, setError] = useState<string | null>(null);
@@ -35,6 +36,19 @@ export default function AuthCallbackPage() {
     [navigate]
   );
 
+  // Handle PASSWORD_RECOVERY before auth.user triggers the /dashboard redirect.
+  useEffect(() => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event) => {
+      if (event === 'PASSWORD_RECOVERY' && !navigatedRef.current) {
+        navigatedRef.current = true;
+        navigate('/reset-password', { replace: true });
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [navigate]);
+
   useEffect(() => {
     if (navigatedRef.current) return;
 
@@ -53,6 +67,11 @@ export default function AuthCallbackPage() {
       }, 3000);
       return () => clearTimeout(t);
     }
+
+    // If type=recovery, let the onAuthStateChange subscription handle navigation
+    // to /reset-password — don't fall through to the auth.user → /dashboard branch.
+    const recoveryType = hashParams.get('type') || queryParams.get('type');
+    if (recoveryType === 'recovery') return;
 
     if (auth.loading) return;
 
@@ -132,7 +151,7 @@ export default function AuthCallbackPage() {
       <div className='max-w-md w-full space-y-8 text-center'>
         <div>
           <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900 dark:text-white'>
-            Completing sign in...
+            Completing authentication...
           </h2>
           <div className='mt-8 flex justify-center'>
             <svg

--- a/apps/web/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
+import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
+import { ContentContainer } from '@beakerstack/shared/components/layout/ContentContainer.web';
+import { supabase } from '@/lib/supabase';
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searchParams] = useSearchParams();
+  const isExpired = searchParams.get('expired') === '1';
+  const auth = useAuthContext();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!email) {
+      setError('Please enter your email address');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      await auth.requestPasswordReset(email);
+      setSubmitted(true);
+    } catch {
+      setError('Something went wrong. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
+      <AppHeader supabaseClient={supabase} />
+      <ContentContainer className='py-12'>
+        <div className='w-full max-w-md mx-auto space-y-8'>
+          <div>
+            <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900 dark:text-white'>
+              Reset your password
+            </h2>
+            <p className='mt-2 text-center text-sm text-gray-600 dark:text-gray-400'>
+              Enter your email and we&apos;ll send you a reset link.
+            </p>
+          </div>
+
+          {isExpired && (
+            <div className='rounded-md bg-yellow-50 dark:bg-yellow-900/30 p-4'>
+              <p className='text-sm text-yellow-800 dark:text-yellow-300'>
+                Your password reset link has expired. Enter your email below to request a new one.
+              </p>
+            </div>
+          )}
+
+          {submitted ? (
+            <div className='rounded-md bg-green-50 dark:bg-green-900/30 p-4'>
+              <p className='text-sm text-green-800 dark:text-green-300'>
+                If an account exists for <strong>{email}</strong>, you will
+                receive a password reset email shortly.
+              </p>
+            </div>
+          ) : (
+            <>
+              {error && (
+                <div className='rounded-md bg-red-50 dark:bg-red-900/30 p-4'>
+                  <p className='text-sm font-medium text-red-800 dark:text-red-300'>
+                    {error}
+                  </p>
+                </div>
+              )}
+
+              <form className='space-y-6' onSubmit={handleSubmit}>
+                <div>
+                  <label htmlFor='email' className='sr-only'>
+                    Email address
+                  </label>
+                  <input
+                    id='email'
+                    name='email'
+                    type='email'
+                    autoComplete='email'
+                    value={email}
+                    onChange={e => setEmail(e.target.value)}
+                    disabled={isLoading}
+                    className='appearance-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                    placeholder='Email address'
+                  />
+                </div>
+
+                <div>
+                  <button
+                    type='submit'
+                    disabled={isLoading}
+                    className='group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed'
+                  >
+                    {isLoading ? 'Sending...' : 'Send reset link'}
+                  </button>
+                </div>
+              </form>
+            </>
+          )}
+
+          <div className='text-center'>
+            <Link
+              to='/login'
+              className='font-medium text-primary-600 hover:text-primary-500 text-sm'
+            >
+              Back to sign in
+            </Link>
+          </div>
+        </div>
+      </ContentContainer>
+    </div>
+  );
+}

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -173,6 +173,15 @@ function LoginPageContent() {
                 </div>
               </div>
 
+              <div className='text-right'>
+                <Link
+                  to='/forgot-password'
+                  className='text-sm font-medium text-primary-600 hover:text-primary-500'
+                >
+                  Forgot password?
+                </Link>
+              </div>
+
               <div>
                 <button
                   type='submit'

--- a/apps/web/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
+import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
+import { ContentContainer } from '@beakerstack/shared/components/layout/ContentContainer.web';
+import { MIN_PASSWORD_LENGTH } from '@beakerstack/shared/constants/auth';
+import { supabase } from '@/lib/supabase';
+
+export default function ResetPasswordPage() {
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [sessionChecked, setSessionChecked] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const auth = useAuthContext();
+
+  useEffect(() => {
+    supabase.auth
+      .getSession()
+      .then(({ data: { session } }) => {
+        if (!session) {
+          navigate('/forgot-password?expired=1', { replace: true });
+        } else {
+          setSessionChecked(true);
+        }
+      })
+      .catch(() => {
+        navigate('/forgot-password', { replace: true });
+      });
+  }, [navigate]);
+
+  if (!sessionChecked) {
+    return (
+      <div className='min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center'>
+        <svg
+          className='animate-spin h-8 w-8 text-primary-600'
+          xmlns='http://www.w3.org/2000/svg'
+          fill='none'
+          viewBox='0 0 24 24'
+        >
+          <circle className='opacity-25' cx='12' cy='12' r='10' stroke='currentColor' strokeWidth='4' />
+          <path className='opacity-75' fill='currentColor' d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z' />
+        </svg>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      await auth.updatePassword(password);
+      navigate('/dashboard', { replace: true });
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to update password. Please try again.'
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
+      <AppHeader supabaseClient={supabase} />
+      <ContentContainer className='py-12'>
+        <div className='w-full max-w-md mx-auto space-y-8'>
+          <div>
+            <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900 dark:text-white'>
+              Set new password
+            </h2>
+          </div>
+
+          {error && (
+            <div className='rounded-md bg-red-50 dark:bg-red-900/30 p-4'>
+              <p className='text-sm font-medium text-red-800 dark:text-red-300'>
+                {error}
+              </p>
+            </div>
+          )}
+
+          <form className='space-y-6' onSubmit={handleSubmit}>
+            <div className='rounded-md shadow-sm -space-y-px'>
+              <div>
+                <label htmlFor='password' className='sr-only'>
+                  New password
+                </label>
+                <input
+                  id='password'
+                  name='password'
+                  type='password'
+                  autoComplete='new-password'
+                  required
+                  value={password}
+                  onChange={e => setPassword(e.target.value)}
+                  disabled={isLoading}
+                  className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                  placeholder={`New password (min ${MIN_PASSWORD_LENGTH} characters)`}
+                />
+              </div>
+              <div>
+                <label htmlFor='confirm-password' className='sr-only'>
+                  Confirm new password
+                </label>
+                <input
+                  id='confirm-password'
+                  name='confirm-password'
+                  type='password'
+                  autoComplete='new-password'
+                  required
+                  value={confirmPassword}
+                  onChange={e => setConfirmPassword(e.target.value)}
+                  disabled={isLoading}
+                  className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
+                  placeholder='Confirm new password'
+                />
+              </div>
+            </div>
+
+            <div>
+              <button
+                type='submit'
+                disabled={isLoading}
+                className='group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed'
+              >
+                {isLoading ? 'Updating...' : 'Update password'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </ContentContainer>
+    </div>
+  );
+}

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
 import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
 import { ContentContainer } from '@beakerstack/shared/components/layout/ContentContainer.web';
+import { MIN_PASSWORD_LENGTH } from '@beakerstack/shared/constants/auth';
 import { supabase } from '@/lib/supabase';
 import { SocialLoginButton } from '../components/SocialLoginButton';
 import { SignupPlanSummary } from '../components/auth/SignupPlanSummary';
@@ -58,6 +59,11 @@ function SignupPageContent() {
 
     if (!email || !password || !confirmPassword) {
       setError('Please fill in all fields');
+      return;
+    }
+
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
       return;
     }
 

--- a/apps/web/src/pages/__tests__/AuthCallbackPage.test.tsx
+++ b/apps/web/src/pages/__tests__/AuthCallbackPage.test.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import AuthCallbackPage from '../AuthCallbackPage';
 import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
 import type { SupabaseClient } from '@supabase/supabase-js';
+
+vi.mock('../SignupInvitePage', () => ({
+  finalizeInviteSignup: vi.fn().mockResolvedValue(undefined),
+  INVITE_TOKEN_STORAGE_KEY: 'beakerstack_invite_token',
+}));
 
 // Mock the supabase client
 vi.mock('@/lib/supabase', () => ({
@@ -32,6 +37,11 @@ vi.mock('react-router-dom', async () => {
 });
 
 const createMockSupabaseClient = (): SupabaseClient => {
+  const mockChannel = {
+    on: vi.fn().mockReturnThis(),
+    subscribe: vi.fn().mockReturnThis(),
+    unsubscribe: vi.fn().mockResolvedValue(undefined),
+  };
   return {
     auth: {
       getSession: vi
@@ -45,6 +55,8 @@ const createMockSupabaseClient = (): SupabaseClient => {
       signOut: vi.fn(),
       signInWithOAuth: vi.fn(),
     },
+    channel: vi.fn(() => mockChannel),
+    removeChannel: vi.fn().mockResolvedValue(undefined),
   } as unknown as SupabaseClient;
 };
 
@@ -86,7 +98,7 @@ describe('AuthCallbackPage', () => {
 
   it('renders loading state initially', () => {
     renderWithProviders(<AuthCallbackPage />);
-    expect(screen.getByText('Completing sign in...')).toBeInTheDocument();
+    expect(screen.getByText('Completing authentication...')).toBeInTheDocument();
     expect(
       screen.getByText('Please wait while we complete your authentication...')
     ).toBeInTheDocument();
@@ -136,7 +148,7 @@ describe('AuthCallbackPage', () => {
     );
 
     // Should show loading state while processing
-    expect(screen.getByText('Completing sign in...')).toBeInTheDocument();
+    expect(screen.getByText('Completing authentication...')).toBeInTheDocument();
   });
 
   it('handles case when user is already authenticated', async () => {
@@ -183,6 +195,148 @@ describe('AuthCallbackPage', () => {
     );
 
     // Should show loading state
-    expect(screen.getByText('Completing sign in...')).toBeInTheDocument();
+    expect(screen.getByText('Completing authentication...')).toBeInTheDocument();
+  });
+
+  it('navigates to /reset-password when PASSWORD_RECOVERY event fires (not /dashboard)', async () => {
+    vi.useRealTimers();
+    // Simulate: user opens recovery link — session is established, type=recovery in hash
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location;
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...originalLocation,
+        search: '',
+        hash: '#access_token=rec-token&type=recovery',
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const { supabase: mockSupabase } = await import('@/lib/supabase');
+    // Fire the PASSWORD_RECOVERY event synchronously as soon as the component subscribes,
+    // so the timing is deterministic (no need to capture and fire the callback separately).
+    (mockSupabase.auth.onAuthStateChange as ReturnType<typeof vi.fn>).mockImplementation(
+      (cb: (event: string) => void) => {
+        cb('PASSWORD_RECOVERY');
+        return { data: { subscription: { unsubscribe: vi.fn() } } };
+      }
+    );
+
+    const mockClient = createMockSupabaseClient();
+    render(
+      <MemoryRouter initialEntries={['/auth/callback']}>
+        <AuthProvider supabaseClient={mockClient}>
+          <ProfileProvider supabaseClient={mockClient}>
+            <AuthCallbackPage />
+          </ProfileProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/reset-password', {
+        replace: true,
+      });
+    });
+    // Must NOT navigate to /dashboard
+    expect(mockNavigate).not.toHaveBeenCalledWith('/dashboard', expect.anything());
+  });
+
+  it('navigates to /dashboard on SIGNED_IN for OAuth (regression)', async () => {
+    vi.useRealTimers();
+    // Previous test sets a mockImplementation on onAuthStateChange that fires PASSWORD_RECOVERY.
+    // vi.clearAllMocks() resets call counts but not implementations, so restore the default here.
+    const { supabase: mockSupabase } = await import('@/lib/supabase');
+    (mockSupabase.auth.onAuthStateChange as ReturnType<typeof vi.fn>).mockImplementation(
+      () => ({ data: { subscription: { unsubscribe: vi.fn() } } })
+    );
+
+    const mockUser = {
+      id: '1',
+      email: 'test@example.com',
+      app_metadata: {},
+      user_metadata: {},
+      aud: 'authenticated',
+      created_at: new Date().toISOString(),
+    };
+
+    const mockClient = createMockSupabaseClient();
+    mockClient.auth.getSession = vi.fn().mockResolvedValue({
+      data: { session: { user: mockUser, access_token: 'token' } },
+      error: null,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location;
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, search: '', hash: '' },
+      writable: true,
+      configurable: true,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/auth/callback']}>
+        <AuthProvider supabaseClient={mockClient}>
+          <ProfileProvider supabaseClient={mockClient}>
+            <AuthCallbackPage />
+          </ProfileProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith('/reset-password', expect.anything());
+  });
+
+  it('navigates to /dashboard for invite-type callback, not /reset-password (regression)', async () => {
+    vi.useRealTimers();
+    const { supabase: mockSupabase } = await import('@/lib/supabase');
+    (mockSupabase.auth.onAuthStateChange as ReturnType<typeof vi.fn>).mockImplementation(
+      () => ({ data: { subscription: { unsubscribe: vi.fn() } } })
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location;
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...originalLocation,
+        search: '',
+        hash: '#access_token=invite-tok&type=invite',
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const mockUser = {
+      id: '1',
+      email: 'test@example.com',
+      app_metadata: {},
+      user_metadata: {},
+      aud: 'authenticated',
+      created_at: new Date().toISOString(),
+    };
+    const mockClient = createMockSupabaseClient();
+    mockClient.auth.getSession = vi.fn().mockResolvedValue({
+      data: { session: { user: mockUser, access_token: 'invite-tok' } },
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/auth/callback']}>
+        <AuthProvider supabaseClient={mockClient}>
+          <ProfileProvider supabaseClient={mockClient}>
+            <AuthCallbackPage />
+          </ProfileProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith('/reset-password', expect.anything());
   });
 });

--- a/apps/web/src/pages/__tests__/ForgotPasswordPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ForgotPasswordPage.test.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import ForgotPasswordPage from '../ForgotPasswordPage';
+import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
+import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const mockRequestPasswordReset = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: vi
+        .fn()
+        .mockResolvedValue({ data: { session: null }, error: null }),
+      onAuthStateChange: vi.fn(() => ({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      })),
+      resetPasswordForEmail: mockRequestPasswordReset,
+    },
+  },
+}));
+
+vi.mock('@beakerstack/shared/components/navigation/AppHeader.web', () => ({
+  AppHeader: () => null,
+}));
+
+vi.mock('@beakerstack/shared/components/layout/ContentContainer.web', () => ({
+  ContentContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+const createMockSupabaseClient = (): SupabaseClient =>
+  ({
+    auth: {
+      getSession: vi
+        .fn()
+        .mockResolvedValue({ data: { session: null }, error: null }),
+      onAuthStateChange: vi.fn(() => ({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      })),
+      signInWithPassword: vi.fn(),
+      signUp: vi.fn(),
+      signOut: vi.fn(),
+      signInWithOAuth: vi.fn(),
+      resetPasswordForEmail: mockRequestPasswordReset,
+      updateUser: vi.fn(),
+    },
+  }) as unknown as SupabaseClient;
+
+const renderPage = (path = '/forgot-password') => {
+  const client = createMockSupabaseClient();
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AuthProvider supabaseClient={client}>
+        <ProfileProvider supabaseClient={client}>
+          <ForgotPasswordPage />
+        </ProfileProvider>
+      </AuthProvider>
+    </MemoryRouter>
+  );
+};
+
+describe('ForgotPasswordPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows expired-link banner when ?expired=1 is present', () => {
+    renderPage('/forgot-password?expired=1');
+    expect(
+      screen.getByText(/Your password reset link has expired/i)
+    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Email address')).toBeInTheDocument();
+  });
+
+  it('does not show expired-link banner on normal visit', () => {
+    renderPage();
+    expect(
+      screen.queryByText(/Your password reset link has expired/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the email form', () => {
+    renderPage();
+    expect(screen.getByPlaceholderText('Email address')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Send reset link' })
+    ).toBeInTheDocument();
+  });
+
+  it('shows error when submitted with no email', async () => {
+    renderPage();
+    await userEvent.click(screen.getByRole('button', { name: 'Send reset link' }));
+    expect(
+      screen.getByText('Please enter your email address')
+    ).toBeInTheDocument();
+    expect(mockRequestPasswordReset).not.toHaveBeenCalled();
+  });
+
+  it('calls requestPasswordReset and shows non-enumerating success message', async () => {
+    mockRequestPasswordReset.mockResolvedValue({ data: {}, error: null });
+    renderPage();
+
+    await userEvent.type(
+      screen.getByPlaceholderText('Email address'),
+      'user@example.com'
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Send reset link' }));
+
+    await waitFor(() => {
+      expect(mockRequestPasswordReset).toHaveBeenCalledWith(
+        'user@example.com',
+        expect.objectContaining({ redirectTo: expect.any(String) })
+      );
+    });
+
+    expect(
+      screen.getByText(/If an account exists for/i)
+    ).toBeInTheDocument();
+    // Must not reveal whether the address exists
+    expect(
+      screen.queryByText(/account does not exist/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows generic error message on failure', async () => {
+    mockRequestPasswordReset.mockRejectedValue(new Error('Rate limit exceeded'));
+    renderPage();
+
+    await userEvent.type(
+      screen.getByPlaceholderText('Email address'),
+      'user@example.com'
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Send reset link' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Something went wrong. Please try again.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('has a link back to login', () => {
+    renderPage();
+    expect(screen.getByRole('link', { name: 'Back to sign in' })).toHaveAttribute(
+      'href',
+      '/login'
+    );
+  });
+});

--- a/apps/web/src/pages/__tests__/ResetPasswordPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ResetPasswordPage.test.tsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import ResetPasswordPage from '../ResetPasswordPage';
+import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
+import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { MIN_PASSWORD_LENGTH } from '@beakerstack/shared/constants/auth';
+
+const mockUpdateUser = vi.hoisted(() => vi.fn());
+const mockGetSession = vi.hoisted(() => vi.fn());
+const mockNavigate = vi.fn();
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: mockGetSession,
+      onAuthStateChange: vi.fn(() => ({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      })),
+      updateUser: mockUpdateUser,
+    },
+  },
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('@beakerstack/shared/components/navigation/AppHeader.web', () => ({
+  AppHeader: () => null,
+}));
+
+vi.mock('@beakerstack/shared/components/layout/ContentContainer.web', () => ({
+  ContentContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+const mockUser = {
+  id: '1',
+  email: 'user@example.com',
+  app_metadata: {},
+  user_metadata: {},
+  aud: 'authenticated',
+  created_at: new Date().toISOString(),
+};
+
+const createMockSupabaseClient = (): SupabaseClient => {
+  const mockChannel = {
+    on: vi.fn().mockReturnThis(),
+    subscribe: vi.fn().mockReturnThis(),
+    unsubscribe: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    auth: {
+      getSession: mockGetSession,
+      onAuthStateChange: vi.fn(() => ({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      })),
+      signInWithPassword: vi.fn(),
+      signUp: vi.fn(),
+      signOut: vi.fn(),
+      signInWithOAuth: vi.fn(),
+      resetPasswordForEmail: vi.fn(),
+      updateUser: mockUpdateUser,
+    },
+    channel: vi.fn(() => mockChannel),
+    removeChannel: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SupabaseClient;
+};
+
+const renderPage = () => {
+  const client = createMockSupabaseClient();
+  return render(
+    <MemoryRouter initialEntries={['/reset-password']}>
+      <AuthProvider supabaseClient={client}>
+        <ProfileProvider supabaseClient={client}>
+          <ResetPasswordPage />
+        </ProfileProvider>
+      </AuthProvider>
+    </MemoryRouter>
+  );
+};
+
+describe('ResetPasswordPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects to /forgot-password when there is no session', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
+    renderPage();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/forgot-password?expired=1',
+        { replace: true }
+      );
+    });
+  });
+
+  it('renders the password form when a session exists', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { user: mockUser, access_token: 'tok' } },
+      error: null,
+    });
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/^New password/i)).toBeInTheDocument();
+    });
+    expect(screen.getByPlaceholderText('Confirm new password')).toBeInTheDocument();
+  });
+
+  it('shows error when password is too short', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { user: mockUser, access_token: 'tok' } },
+      error: null,
+    });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/^New password/i)).toBeInTheDocument()
+    );
+
+    await userEvent.type(screen.getByPlaceholderText(/^New password/i), 'short');
+    await userEvent.type(
+      screen.getByPlaceholderText('Confirm new password'),
+      'short'
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Update password' }));
+
+    expect(
+      screen.getByText(
+        `Password must be at least ${MIN_PASSWORD_LENGTH} characters`
+      )
+    ).toBeInTheDocument();
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it('shows error when passwords do not match', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { user: mockUser, access_token: 'tok' } },
+      error: null,
+    });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/^New password/i)).toBeInTheDocument()
+    );
+
+    await userEvent.type(
+      screen.getByPlaceholderText(/^New password/i),
+      'newpassword1'
+    );
+    await userEvent.type(
+      screen.getByPlaceholderText('Confirm new password'),
+      'differentpass'
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Update password' }));
+
+    expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it('calls updatePassword and navigates to /dashboard on success', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { user: mockUser, access_token: 'tok' } },
+      error: null,
+    });
+    mockUpdateUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/^New password/i)).toBeInTheDocument()
+    );
+
+    await userEvent.type(
+      screen.getByPlaceholderText(/^New password/i),
+      'newpassword1'
+    );
+    await userEvent.type(
+      screen.getByPlaceholderText('Confirm new password'),
+      'newpassword1'
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Update password' }));
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith({ password: 'newpassword1' });
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
+    });
+  });
+
+  it('shows API error if updatePassword fails', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { user: mockUser, access_token: 'tok' } },
+      error: null,
+    });
+    mockUpdateUser.mockResolvedValue({
+      data: {},
+      error: { message: 'Password too weak' },
+    });
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/^New password/i)).toBeInTheDocument()
+    );
+
+    await userEvent.type(
+      screen.getByPlaceholderText(/^New password/i),
+      'newpassword1'
+    );
+    await userEvent.type(
+      screen.getByPlaceholderText('Confirm new password'),
+      'newpassword1'
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Update password' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Password too weak')).toBeInTheDocument();
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith('/dashboard', expect.anything());
+  });
+});

--- a/apps/web/src/pages/__tests__/SignupPage.test.tsx
+++ b/apps/web/src/pages/__tests__/SignupPage.test.tsx
@@ -10,6 +10,7 @@ import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { POST_AUTH_REDIRECT_KEY } from '../../auth/postAuthRedirect';
+import { MIN_PASSWORD_LENGTH } from '@beakerstack/shared/constants/auth';
 
 const mockCatalogPlans = vi.hoisted(() => {
   const pro: Plan = {
@@ -278,6 +279,28 @@ describe('SignupPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Please fill in all fields')).toBeInTheDocument();
     });
+  });
+
+  it('shows error when password is too short', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SignupPage />);
+
+    await user.type(screen.getByPlaceholderText('Email address'), 'test@example.com');
+    await user.type(screen.getByPlaceholderText('Password'), 'short');
+    await user.type(screen.getByPlaceholderText('Confirm password'), 'short');
+
+    const form = screen.getByPlaceholderText('Email address').closest('form');
+    const submitButton = form?.querySelector('button[type="submit"]') as HTMLButtonElement;
+    if (submitButton) {
+      await user.click(submitButton);
+    }
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`)
+      ).toBeInTheDocument();
+    });
+    expect(authClientMocks.signUp).not.toHaveBeenCalled();
   });
 
   it('shows error when passwords do not match', async () => {

--- a/docs/PASSWORD_RESET.md
+++ b/docs/PASSWORD_RESET.md
@@ -1,0 +1,71 @@
+# Password Reset Flow
+
+## End-to-end flow
+
+### Web
+
+1. User clicks **Forgot password?** on `/login` → `/forgot-password`
+2. User enters email, submits. `auth.requestPasswordReset(email)` calls `supabase.auth.resetPasswordForEmail(email, { redirectTo })` where `redirectTo` is built by `getAuthRedirectUrl()`:
+   - Standard: `https://app.example.com/auth/callback`
+   - PR previews: `https://pr-9.example.com/pr-9/auth/callback`
+3. User receives email, clicks link → browser opens `/auth/callback#access_token=...&type=recovery`
+4. `AuthCallbackPage` detects `type=recovery` in the hash **before** the `auth.user → /dashboard` branch, then subscribes to `onAuthStateChange`. When the `PASSWORD_RECOVERY` event fires, the page navigates to `/reset-password`.
+5. `ResetPasswordPage` calls `supabase.auth.getSession()` on mount. If no session (link expired or revisited after use), redirects to `/forgot-password?expired=1`. With a valid session, the user sets a new password via `auth.updatePassword(password)` and is sent to `/dashboard` with `replace: true`.
+
+### Mobile (iOS / Android)
+
+1. User taps **Forgot password?** on `LoginScreen` → `ForgotPasswordScreen`
+2. User enters email, submits. `auth.requestPasswordReset(email)` calls `resetPasswordForEmail(email, { redirectTo: 'beaker-stack://auth/callback' })`
+3. User receives email, taps link → app opens via deep link to `AuthCallbackScreen`
+4. `AuthCallbackScreen` subscribes to `onAuthStateChange`:
+   - `PASSWORD_RECOVERY` → navigate to `ResetPasswordScreen`
+   - `SIGNED_IN` → navigate to `Dashboard`
+5. `ResetPasswordScreen` guards on `getSession()`. No session → navigate to `ForgotPasswordScreen`. With session, user sets new password via `auth.updatePassword(password)` and is reset-navigated to `Dashboard`.
+
+## `PASSWORD_RECOVERY` event ordering
+
+The `PASSWORD_RECOVERY` event from `supabase.auth.onAuthStateChange` is the authoritative signal that a user is in a reset session. On web, `AuthCallbackPage` must subscribe to this event **before** the generic `auth.user → /dashboard` check — otherwise an already-established recovery session would route to the dashboard instead of the reset form.
+
+The guard is two-layered:
+1. **Synchronous URL hash check** (`type=recovery`) — prevents the `auth.user` branch from running while the `onAuthStateChange` subscription hasn't fired yet.
+2. **`onAuthStateChange(PASSWORD_RECOVERY)`** — the authoritative redirect to `/reset-password`.
+
+## Supabase redirect URL allowlist
+
+Add these to your Supabase project's **Auth → URL Configuration → Redirect URLs**:
+
+| Environment | URL |
+|---|---|
+| Local dev | `http://localhost:5173/auth/callback` |
+| Staging | `https://staging.beakerstack.com/auth/callback` |
+| Production | `https://app.beakerstack.com/auth/callback` |
+| PR previews | `https://pr-*.beakerstack.com/pr-*/auth/callback` |
+| Mobile | `beaker-stack://auth/callback` |
+
+## Mobile deep-link setup
+
+The app scheme is `beaker-stack` (configured in `app.json` → `expo.scheme`). React Navigation's `linking` config in `AppNavigator.tsx` maps `beaker-stack://auth/callback` to the `AuthCallback` screen. `detectSessionInUrl: true` in `apps/mobile/src/lib/supabase.ts` allows Supabase to parse tokens from the deep-link URL.
+
+## Manual test checklist
+
+### Local dev (web — Inbucket)
+
+- [ ] `/forgot-password` with an unknown address shows the non-enumerating success message
+- [ ] `/forgot-password` with a known address: check Inbucket for email, click link → lands on `/reset-password`
+- [ ] Set new password ≥ 8 chars → redirected to `/dashboard`
+- [ ] Revisit the reset URL after using it → redirected to `/forgot-password?expired=1`
+- [ ] Google OAuth callback still routes to `/dashboard` (regression)
+- [ ] PR preview: reset link email uses `/pr-N/auth/callback` in `redirectTo`
+
+### Local dev (mobile — Expo Go / simulator)
+
+- [ ] `ForgotPasswordScreen` → submit known address → success message stays on screen
+- [ ] Tap reset link from email → app opens to `AuthCallbackScreen` → lands on `ResetPasswordScreen`
+- [ ] Set new password ≥ 8 chars → navigate to `Dashboard`
+- [ ] Password < 8 chars → alert shown, `updatePassword` not called
+- [ ] Revisit link after use → `ForgotPasswordScreen` (no session)
+- [ ] Mismatch confirmation → alert shown
+
+## Password minimum length
+
+`MIN_PASSWORD_LENGTH = 8` (from `packages/shared/src/constants/auth.ts`) must match the **Minimum password length** setting in Supabase → Authentication → Password. Update both together if the requirement changes.

--- a/packages/shared/src/constants/auth.ts
+++ b/packages/shared/src/constants/auth.ts
@@ -1,0 +1,1 @@
+export const MIN_PASSWORD_LENGTH = 8;

--- a/packages/shared/src/hooks/useAuth.native.ts
+++ b/packages/shared/src/hooks/useAuth.native.ts
@@ -503,6 +503,38 @@ export function useAuth(supabaseClient: SupabaseClient): AuthHookReturn {
     }
   };
 
+  const requestPasswordReset = async (email: string): Promise<void> => {
+    setLoading(true);
+    setError(null);
+
+    const { error } = await supabaseClient.auth.resetPasswordForEmail(email, {
+      redirectTo: 'beaker-stack://auth/callback',
+    });
+
+    setLoading(false);
+
+    if (error) {
+      const errorObj = new Error(error.message);
+      setError(errorObj);
+      throw errorObj;
+    }
+  };
+
+  const updatePassword = async (password: string): Promise<void> => {
+    setLoading(true);
+    setError(null);
+
+    const { error } = await supabaseClient.auth.updateUser({ password });
+
+    setLoading(false);
+
+    if (error) {
+      const errorObj = new Error(error.message);
+      setError(errorObj);
+      throw errorObj;
+    }
+  };
+
   return {
     user,
     session,
@@ -512,5 +544,7 @@ export function useAuth(supabaseClient: SupabaseClient): AuthHookReturn {
     signUp,
     signOut,
     signInWithGoogle,
+    requestPasswordReset,
+    updatePassword,
   };
 }

--- a/packages/shared/src/hooks/useAuth.ts
+++ b/packages/shared/src/hooks/useAuth.ts
@@ -7,6 +7,12 @@ import { Logger } from '../utils/logger';
 // Web platform does not require native Google configuration
 export function configureGoogleSignIn() {}
 
+function getAuthRedirectUrl(): string {
+  const basePath =
+    window.location.pathname.match(/^(\/pr-\d+)/)?.[1] || '';
+  return `${window.location.origin}${basePath}/auth/callback`;
+}
+
 export function useAuth(supabaseClient: SupabaseClient): AuthHookReturn {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
@@ -145,10 +151,7 @@ export function useAuth(supabaseClient: SupabaseClient): AuthHookReturn {
 
     let redirectTo: string | undefined;
     if (typeof window !== 'undefined' && window.location) {
-      // Extract base path from current location (e.g., /pr-9 from /pr-9/login)
-      // This handles path-based PR previews where the app is served from /pr-<N>/
-      const basePath = window.location.pathname.match(/^(\/pr-\d+)/)?.[1] || '';
-      redirectTo = `${window.location.origin}${basePath}/auth/callback`;
+      redirectTo = getAuthRedirectUrl();
     }
 
     const authArgs = redirectTo
@@ -171,6 +174,46 @@ export function useAuth(supabaseClient: SupabaseClient): AuthHookReturn {
     }
   };
 
+  const requestPasswordReset = async (email: string): Promise<void> => {
+    setLoading(true);
+    setError(null);
+
+    const redirectTo =
+      typeof window !== 'undefined' && window.location
+        ? getAuthRedirectUrl()
+        : undefined;
+
+    const options = redirectTo ? { redirectTo } : {};
+
+    const { error } = await supabaseClient.auth.resetPasswordForEmail(
+      email,
+      options
+    );
+
+    setLoading(false);
+
+    if (error) {
+      const errorObj = new Error(error.message);
+      setError(errorObj);
+      throw errorObj;
+    }
+  };
+
+  const updatePassword = async (password: string): Promise<void> => {
+    setLoading(true);
+    setError(null);
+
+    const { error } = await supabaseClient.auth.updateUser({ password });
+
+    setLoading(false);
+
+    if (error) {
+      const errorObj = new Error(error.message);
+      setError(errorObj);
+      throw errorObj;
+    }
+  };
+
   return {
     user,
     session,
@@ -180,5 +223,7 @@ export function useAuth(supabaseClient: SupabaseClient): AuthHookReturn {
     signUp,
     signOut,
     signInWithGoogle,
+    requestPasswordReset,
+    updatePassword,
   };
 }

--- a/packages/shared/src/types/auth.ts
+++ b/packages/shared/src/types/auth.ts
@@ -12,6 +12,8 @@ export interface AuthActions {
   signUp: (email: string, password: string) => Promise<void>;
   signOut: () => Promise<void>;
   signInWithGoogle: () => Promise<void>;
+  requestPasswordReset: (email: string) => Promise<void>;
+  updatePassword: (password: string) => Promise<void>;
 }
 
 export type AuthHookReturn = AuthState & AuthActions;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -149,7 +149,7 @@ enable_anonymous_sign_ins = false
 # Allow/disallow testing manual linking of accounts
 enable_manual_linking = false
 # Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
-minimum_password_length = 6
+minimum_password_length = 8
 # Passwords that do not meet the following requirements will be rejected as weak. Supported values
 # are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
 password_requirements = ""


### PR DESCRIPTION
## Summary

- Implements the full email-based forgot password / account recovery flow for web and mobile (issue #271)
- Web: `ForgotPasswordPage` (non-enumerating success), `ResetPasswordPage` (`getSession()` guard, min-length/match validation, navigate with `replace: true`)
- `AuthCallbackPage`: `PASSWORD_RECOVERY` routes to `/reset-password` before the `auth.user => /dashboard` branch (sync hash check + `onAuthStateChange` subscription); neutral loading copy
- Mobile: full parity with `ForgotPasswordScreen`, `AuthCallbackScreen`, `ResetPasswordScreen`, deep-link config (`beaker-stack://auth/callback`), `detectSessionInUrl: true`, `scheme: 'beaker-stack'` in app.json
- Shared: `MIN_PASSWORD_LENGTH = 8` constant (applied to signup on both platforms); `requestPasswordReset` + `updatePassword` in `AuthActions`; `getAuthRedirectUrl()` helper so OAuth and reset redirectTo cannot drift; "Forgot password?" links on LoginPage / LoginScreen

## Test plan

- [ ] `/forgot-password` with unknown address shows non-enumerating success message
- [ ] `/forgot-password` with known address: email received (Inbucket locally), link click lands on `/reset-password`
- [ ] `/reset-password`: valid password update navigates to `/dashboard`
- [ ] `/reset-password`: password < 8 chars shows error, `updatePassword` not called
- [ ] `/reset-password`: mismatched confirm shows error
- [ ] Revisit reset URL after use redirects to `/forgot-password?expired=1`
- [ ] Google OAuth callback still lands on `/dashboard` (regression — AuthCallbackPage.test.tsx)
- [ ] Mobile: tapping reset link opens `AuthCallbackScreen`, routes to `ResetPasswordScreen`
- [ ] Mobile: password < 8 chars shows Alert
- [ ] All new/updated tests pass: ForgotPasswordPage.test.tsx, ResetPasswordPage.test.tsx, AuthCallbackPage.test.tsx
