### PR TITLE
feat: transactional email templates and setup (#284)

### DIFF
--- a/apps/mobile/__tests__/screens/billing/BillingScreens.test.tsx
+++ b/apps/mobile/__tests__/screens/billing/BillingScreens.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ActivityIndicator } from 'react-native';
 import { render } from '@testing-library/react-native';
 import { NavigationContainer } from '@react-navigation/native';
-import type { BillingUiStateKind } from '@beakerstack/billing';
+import type { BillingUiStateKind, SubscriptionRow } from '@beakerstack/billing';
 import {
   useBillingState,
   usePlan,
@@ -138,7 +138,13 @@ const proPlan = {
   usage_limits: { ai_summarize: 500 },
 };
 
-const defaultSubscription = {
+const defaultSubscription: Pick<
+  SubscriptionRow,
+  | 'status'
+  | 'stripe_subscription_id'
+  | 'current_period_end'
+  | 'pending_target_plan_id'
+> = {
   status: 'free',
   stripe_subscription_id: null,
   current_period_end: null,
@@ -340,7 +346,7 @@ describe('BillingOverviewScreen', () => {
 
   it('treats missing collection count as zero', () => {
     mockUseDemoCollectionCount.mockReturnValue({
-      count: undefined,
+      count: undefined as unknown as number,
       maxItemsInAnyCollection: 0,
       loading: false,
       error: null,

--- a/apps/mobile/src/components/dashboard/__tests__/CollectionDetail.test.tsx
+++ b/apps/mobile/src/components/dashboard/__tests__/CollectionDetail.test.tsx
@@ -29,6 +29,8 @@ jest.mock('../../../lib/supabase', () => ({
   supabase: { rpc: jest.fn() },
 }));
 
+type RpcResult = { data: unknown; error: { message: string } | null };
+
 jest.mock('../../../lib/fakeAi', () => ({
   nextFakeAiSummary: () => 'Fake AI summary text',
 }));
@@ -40,7 +42,9 @@ jest.mock('../../../lib/randomUuid', () => ({
 const mockUseBillingContext = jest.mocked(useBillingContext);
 const mockUseUsage = jest.mocked(useUsage);
 const mockUseFeature = jest.mocked(useFeature);
-const mockRpc = jest.mocked(supabase.rpc);
+const mockRpc = supabase.rpc as unknown as jest.MockedFunction<
+  (...args: unknown[]) => Promise<RpcResult>
+>;
 const mockRandomUuid = jest.mocked(randomUuid);
 
 const hp = {
@@ -112,8 +116,13 @@ function setupMocks() {
   mockUseUsage.mockImplementation(
     () =>
       ({
+        used: 0,
+        limit: 30,
+        remaining: 30,
+        resetsAt: '',
         exceeded: hp.usageExceeded,
         loading: hp.usageLoading,
+        error: null,
         refresh: hp.refreshUsage,
       }) as ReturnType<typeof useUsage>
   );
@@ -267,10 +276,11 @@ describe('CollectionDetail', () => {
 
   it('disables other summarize buttons while one is in flight', async () => {
     let resolveRpc!: (v: { data: null; error: null }) => void;
-    mockRpc.mockReturnValue(
-      new Promise(res => {
-        resolveRpc = res;
-      })
+    mockRpc.mockImplementation(
+      () =>
+        new Promise(res => {
+          resolveRpc = res;
+        })
     );
 
     const { getAllByLabelText } = renderDetail(

--- a/apps/mobile/src/components/dashboard/__tests__/dashboardComponents.test.tsx
+++ b/apps/mobile/src/components/dashboard/__tests__/dashboardComponents.test.tsx
@@ -36,6 +36,8 @@ jest.mock('../../../lib/supabase', () => ({
   },
 }));
 
+type RpcResult = { data: unknown; error: { message: string } | null };
+
 jest.mock('../../../lib/fakeAi', () => ({
   nextFakeAiSummary: () => 'Fake summary from test',
 }));
@@ -47,8 +49,12 @@ jest.mock('../../../lib/randomUuid', () => ({
 const mockUseBillingContext = jest.mocked(useBillingContext);
 const mockUseUsage = jest.mocked(useUsage);
 const mockUseFeature = jest.mocked(useFeature);
-const mockRpc = jest.mocked(supabase.rpc);
-const mockInvoke = jest.mocked(supabase.functions.invoke);
+const mockRpc = supabase.rpc as unknown as jest.MockedFunction<
+  (...args: unknown[]) => Promise<RpcResult>
+>;
+const mockInvoke = supabase.functions.invoke as unknown as jest.MockedFunction<
+  typeof supabase.functions.invoke
+>;
 const mockRandomUuid = jest.mocked(randomUuid);
 
 const featureState = {

--- a/apps/mobile/src/screens/profileEditorLoader.ts
+++ b/apps/mobile/src/screens/profileEditorLoader.ts
@@ -12,7 +12,7 @@ export type ProfileEditorModule = {
 export function loadProfileEditorModule(): Promise<ProfileEditorModule> {
   return Promise.resolve().then(
     () =>
-      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      // eslint-disable-next-line @typescript-eslint/no-var-requires -- Metro async require for lazy bundle
       require('@beakerstack/shared/components/profile/ProfileEditor.native') as ProfileEditorModule
   );
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -24,6 +24,7 @@ const SignupInvitePage = lazy(() => import('./pages/SignupInvitePage'));
 const DashboardPage = lazy(() => import('./pages/DashboardPage'));
 const ProfilePage = lazy(() => import('./pages/ProfilePage'));
 const AuthCallbackPage = lazy(() => import('./pages/AuthCallbackPage'));
+const AuthConfirmPage = lazy(() => import('./pages/AuthConfirmPage'));
 const ForgotPasswordPage = lazy(() => import('./pages/ForgotPasswordPage'));
 const ResetPasswordPage = lazy(() => import('./pages/ResetPasswordPage'));
 const PolicyPage = lazy(() => import('./pages/PolicyPage'));
@@ -115,6 +116,7 @@ function App() {
                 <Route path='/forgot-password' element={<ForgotPasswordPage />} />
                 <Route path='/reset-password' element={<ResetPasswordPage />} />
                 <Route path='/auth/callback' element={<AuthCallbackPage />} />
+                <Route path='/auth/confirm' element={<AuthConfirmPage />} />
                 <Route
                   path='/not-authorized'
                   element={

--- a/apps/web/src/pages/AuthConfirmPage.tsx
+++ b/apps/web/src/pages/AuthConfirmPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { supabase } from '@/lib/supabase';
 import { readAndClearPostAuthRedirect } from '../auth/postAuthRedirect';
 
@@ -56,17 +56,15 @@ export default function AuthConfirmPage() {
       <div className='min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8'>
         <div className='max-w-md w-full space-y-8'>
           <div className='rounded-md bg-red-50 dark:bg-red-900/30 p-4'>
-            <div className='flex'>
-              <div className='ml-3'>
-                <h3 className='text-sm font-medium text-red-800 dark:text-red-300'>
-                  Confirmation Error
-                </h3>
-                <div className='mt-2 text-sm text-red-700 dark:text-red-400'>
-                  <p>{error}</p>
-                  <p className='mt-2'>
-                    <a href='/' className='underline'>Return to home</a>
-                  </p>
-                </div>
+            <div>
+              <h3 className='text-sm font-medium text-red-800 dark:text-red-300'>
+                Confirmation Error
+              </h3>
+              <div className='mt-2 text-sm text-red-700 dark:text-red-400'>
+                <p>{error}</p>
+                <p className='mt-2'>
+                  <Link to='/'>Return to home</Link>
+                </p>
               </div>
             </div>
           </div>

--- a/apps/web/src/pages/AuthConfirmPage.tsx
+++ b/apps/web/src/pages/AuthConfirmPage.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { supabase } from '@/lib/supabase';
+
+type OtpType = 'signup' | 'recovery' | 'magiclink' | 'email_change' | 'invite';
+
+export default function AuthConfirmPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const tokenHash = searchParams.get('token_hash');
+    const type = searchParams.get('type') as OtpType | null;
+
+    if (!tokenHash || !type) {
+      setError('This confirmation link is invalid or has already been used.');
+      return;
+    }
+
+    supabase.auth
+      .verifyOtp({ token_hash: tokenHash, type })
+      .then(({ error: verifyError }) => {
+        if (verifyError) {
+          if (type === 'recovery') {
+            navigate('/forgot-password?expired=1', { replace: true });
+          } else {
+            setError('This link has expired or is invalid. Please request a new one.');
+          }
+          return;
+        }
+        // recovery → ResetPasswordPage which reads the recovery session
+        // invite → waitlist SignupInvitePage is a separate flow using custom RPC tokens;
+        //          Supabase-native inviteUserByEmail tokens land here and go to dashboard
+        if (type === 'recovery') {
+          navigate('/reset-password', { replace: true });
+        } else {
+          navigate('/dashboard', { replace: true });
+        }
+      });
+  }, [searchParams, navigate]);
+
+  if (error) {
+    return (
+      <div className='min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8'>
+        <div className='max-w-md w-full space-y-8'>
+          <div className='rounded-md bg-red-50 dark:bg-red-900/30 p-4'>
+            <div className='flex'>
+              <div className='ml-3'>
+                <h3 className='text-sm font-medium text-red-800 dark:text-red-300'>
+                  Confirmation Error
+                </h3>
+                <div className='mt-2 text-sm text-red-700 dark:text-red-400'>
+                  <p>{error}</p>
+                  <p className='mt-2'>
+                    <a href='/' className='underline'>Return to home</a>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8'>
+      <div className='max-w-md w-full space-y-8 text-center'>
+        <div>
+          <h2 className='mt-6 text-center text-3xl font-extrabold text-gray-900 dark:text-white'>
+            Verifying your link…
+          </h2>
+          <div className='mt-8 flex justify-center'>
+            <svg
+              className='animate-spin h-12 w-12 text-primary-600'
+              xmlns='http://www.w3.org/2000/svg'
+              fill='none'
+              viewBox='0 0 24 24'
+            >
+              <circle
+                className='opacity-25'
+                cx='12'
+                cy='12'
+                r='10'
+                stroke='currentColor'
+                strokeWidth='4'
+              />
+              <path
+                className='opacity-75'
+                fill='currentColor'
+                d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
+              />
+            </svg>
+          </div>
+          <p className='mt-4 text-sm text-gray-600 dark:text-gray-400'>
+            Please wait while we verify your link…
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/AuthConfirmPage.tsx
+++ b/apps/web/src/pages/AuthConfirmPage.tsx
@@ -1,11 +1,17 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { supabase } from '@/lib/supabase';
-import { readAndClearPostAuthRedirect } from '../auth/postAuthRedirect';
+import { readAndClearPostAuthRedirect } from '@/auth/postAuthRedirect';
 
 type OtpType = 'signup' | 'recovery' | 'magiclink' | 'email_change' | 'invite';
 
-const VALID_TYPES: OtpType[] = ['signup', 'recovery', 'magiclink', 'email_change', 'invite'];
+const VALID_TYPES: OtpType[] = [
+  'signup',
+  'recovery',
+  'magiclink',
+  'email_change',
+  'invite',
+];
 
 export default function AuthConfirmPage() {
   const [searchParams] = useSearchParams();
@@ -32,7 +38,9 @@ export default function AuthConfirmPage() {
           if (type === 'recovery') {
             navigate('/forgot-password?expired=1', { replace: true });
           } else {
-            setError('This link has expired or is invalid. Please request a new one.');
+            setError(
+              'This link has expired or is invalid. Please request a new one.'
+            );
           }
           return;
         }

--- a/apps/web/src/pages/AuthConfirmPage.tsx
+++ b/apps/web/src/pages/AuthConfirmPage.tsx
@@ -1,19 +1,26 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { supabase } from '@/lib/supabase';
+import { readAndClearPostAuthRedirect } from '../auth/postAuthRedirect';
 
 type OtpType = 'signup' | 'recovery' | 'magiclink' | 'email_change' | 'invite';
+
+const VALID_TYPES: OtpType[] = ['signup', 'recovery', 'magiclink', 'email_change', 'invite'];
 
 export default function AuthConfirmPage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
+  const verifyingRef = useRef(false);
 
   useEffect(() => {
+    if (verifyingRef.current) return;
+    verifyingRef.current = true;
+
     const tokenHash = searchParams.get('token_hash');
     const type = searchParams.get('type') as OtpType | null;
 
-    if (!tokenHash || !type) {
+    if (!tokenHash || !type || !VALID_TYPES.includes(type)) {
       setError('This confirmation link is invalid or has already been used.');
       return;
     }
@@ -35,8 +42,12 @@ export default function AuthConfirmPage() {
         if (type === 'recovery') {
           navigate('/reset-password', { replace: true });
         } else {
-          navigate('/dashboard', { replace: true });
+          const stored = readAndClearPostAuthRedirect();
+          navigate(stored ?? '/dashboard', { replace: true });
         }
+      })
+      .catch(() => {
+        setError('Something went wrong. Please try again later.');
       });
   }, [searchParams, navigate]);
 

--- a/apps/web/src/pages/__tests__/AuthConfirmPage.test.tsx
+++ b/apps/web/src/pages/__tests__/AuthConfirmPage.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -31,7 +32,7 @@ const { mockReadAndClearPostAuthRedirect } = vi.hoisted(() => ({
   mockReadAndClearPostAuthRedirect: vi.fn(),
 }));
 
-vi.mock('../auth/postAuthRedirect', () => ({
+vi.mock('../../auth/postAuthRedirect', () => ({
   readAndClearPostAuthRedirect: mockReadAndClearPostAuthRedirect,
 }));
 
@@ -58,7 +59,9 @@ describe('AuthConfirmPage', () => {
     it('shows error when both token_hash and type are missing', () => {
       renderWithParams('');
       expect(
-        screen.getByText('This confirmation link is invalid or has already been used.')
+        screen.getByText(
+          'This confirmation link is invalid or has already been used.'
+        )
       ).toBeInTheDocument();
       expect(screen.getByText('Return to home')).toBeInTheDocument();
     });
@@ -66,21 +69,27 @@ describe('AuthConfirmPage', () => {
     it('shows error when token_hash is missing but type is present', () => {
       renderWithParams('?type=signup');
       expect(
-        screen.getByText('This confirmation link is invalid or has already been used.')
+        screen.getByText(
+          'This confirmation link is invalid or has already been used.'
+        )
       ).toBeInTheDocument();
     });
 
     it('shows error when type is missing but token_hash is present', () => {
       renderWithParams('?token_hash=abc123');
       expect(
-        screen.getByText('This confirmation link is invalid or has already been used.')
+        screen.getByText(
+          'This confirmation link is invalid or has already been used.'
+        )
       ).toBeInTheDocument();
     });
 
     it('shows error for invalid type in URL', () => {
       renderWithParams('?token_hash=abc123&type=invalid_type');
       expect(
-        screen.getByText('This confirmation link is invalid or has already been used.')
+        screen.getByText(
+          'This confirmation link is invalid or has already been used.'
+        )
       ).toBeInTheDocument();
       expect(mockVerifyOtp).not.toHaveBeenCalled();
     });
@@ -102,9 +111,12 @@ describe('AuthConfirmPage', () => {
       mockVerifyOtp.mockResolvedValue({ error: { message: 'token expired' } });
       renderWithParams('?token_hash=abc123&type=recovery');
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/forgot-password?expired=1', {
-          replace: true,
-        });
+        expect(mockNavigate).toHaveBeenCalledWith(
+          '/forgot-password?expired=1',
+          {
+            replace: true,
+          }
+        );
       });
     });
 
@@ -199,24 +211,21 @@ describe('AuthConfirmPage', () => {
   });
 
   describe('React Strict Mode guard', () => {
-    it('does not call verifyOtp a second time on remount (Strict Mode guard)', async () => {
+    it('does not call verifyOtp a second time when Strict Mode re-runs effects', async () => {
       mockVerifyOtp.mockResolvedValue({ error: null });
       mockReadAndClearPostAuthRedirect.mockReturnValue(null);
-      const { unmount, rerender } = renderWithParams('?token_hash=abc123&type=signup');
-      await waitFor(() => {
-        expect(mockVerifyOtp).toHaveBeenCalledTimes(1);
-      });
-      // Simulate remount (as React Strict Mode does in dev)
-      unmount();
-      rerender(
-        <MemoryRouter initialEntries={['/auth/confirm?token_hash=abc123&type=signup']}>
-          <Routes>
-            <Route path='/auth/confirm' element={<AuthConfirmPage />} />
-          </Routes>
-        </MemoryRouter>
+      render(
+        <StrictMode>
+          <MemoryRouter
+            initialEntries={['/auth/confirm?token_hash=abc123&type=signup']}
+          >
+            <Routes>
+              <Route path='/auth/confirm' element={<AuthConfirmPage />} />
+            </Routes>
+          </MemoryRouter>
+        </StrictMode>
       );
       await waitFor(() => {
-        // Still only one call total — guard prevents second invocation
         expect(mockVerifyOtp).toHaveBeenCalledTimes(1);
       });
     });

--- a/apps/web/src/pages/__tests__/AuthConfirmPage.test.tsx
+++ b/apps/web/src/pages/__tests__/AuthConfirmPage.test.tsx
@@ -26,6 +26,15 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
+// Mock postAuthRedirect
+const { mockReadAndClearPostAuthRedirect } = vi.hoisted(() => ({
+  mockReadAndClearPostAuthRedirect: vi.fn(),
+}));
+
+vi.mock('../auth/postAuthRedirect', () => ({
+  readAndClearPostAuthRedirect: mockReadAndClearPostAuthRedirect,
+}));
+
 const renderWithParams = (search: string = '') => {
   const path = `/auth/confirm${search}`;
   return render(
@@ -40,6 +49,8 @@ const renderWithParams = (search: string = '') => {
 describe('AuthConfirmPage', () => {
   beforeEach(() => {
     mockVerifyOtp.mockReset();
+    mockReadAndClearPostAuthRedirect.mockReset();
+    mockReadAndClearPostAuthRedirect.mockReturnValue(null);
     vi.clearAllMocks();
   });
 
@@ -64,6 +75,14 @@ describe('AuthConfirmPage', () => {
       expect(
         screen.getByText('This confirmation link is invalid or has already been used.')
       ).toBeInTheDocument();
+    });
+
+    it('shows error for invalid type in URL', () => {
+      renderWithParams('?token_hash=abc123&type=invalid_type');
+      expect(
+        screen.getByText('This confirmation link is invalid or has already been used.')
+      ).toBeInTheDocument();
+      expect(mockVerifyOtp).not.toHaveBeenCalled();
     });
   });
 
@@ -100,6 +119,16 @@ describe('AuthConfirmPage', () => {
         ).toBeInTheDocument();
       });
     });
+
+    it('shows error on network failure', async () => {
+      mockVerifyOtp.mockRejectedValue(new Error('Network error'));
+      renderWithParams('?token_hash=abc123&type=signup');
+      await waitFor(() => {
+        expect(
+          screen.getByText('Something went wrong. Please try again later.')
+        ).toBeInTheDocument();
+      });
+    });
   });
 
   describe('verifyOtp success', () => {
@@ -115,6 +144,7 @@ describe('AuthConfirmPage', () => {
 
     it('navigates to /dashboard on success with signup type', async () => {
       mockVerifyOtp.mockResolvedValue({ error: null });
+      mockReadAndClearPostAuthRedirect.mockReturnValue(null);
       renderWithParams('?token_hash=abc123&type=signup');
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
@@ -125,6 +155,7 @@ describe('AuthConfirmPage', () => {
 
     it('navigates to /dashboard on success with magiclink type', async () => {
       mockVerifyOtp.mockResolvedValue({ error: null });
+      mockReadAndClearPostAuthRedirect.mockReturnValue(null);
       renderWithParams('?token_hash=abc123&type=magiclink');
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
@@ -135,6 +166,7 @@ describe('AuthConfirmPage', () => {
 
     it('navigates to /dashboard on success with email_change type', async () => {
       mockVerifyOtp.mockResolvedValue({ error: null });
+      mockReadAndClearPostAuthRedirect.mockReturnValue(null);
       renderWithParams('?token_hash=abc123&type=email_change');
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
@@ -145,11 +177,47 @@ describe('AuthConfirmPage', () => {
 
     it('navigates to /dashboard on success with invite type', async () => {
       mockVerifyOtp.mockResolvedValue({ error: null });
+      mockReadAndClearPostAuthRedirect.mockReturnValue(null);
       renderWithParams('?token_hash=abc123&type=invite');
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
           replace: true,
         });
+      });
+    });
+
+    it('honors post-auth redirect on success', async () => {
+      mockVerifyOtp.mockResolvedValue({ error: null });
+      mockReadAndClearPostAuthRedirect.mockReturnValue('/some/path');
+      renderWithParams('?token_hash=abc123&type=signup');
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/some/path', {
+          replace: true,
+        });
+      });
+    });
+  });
+
+  describe('React Strict Mode guard', () => {
+    it('does not call verifyOtp a second time on remount (Strict Mode guard)', async () => {
+      mockVerifyOtp.mockResolvedValue({ error: null });
+      mockReadAndClearPostAuthRedirect.mockReturnValue(null);
+      const { unmount, rerender } = renderWithParams('?token_hash=abc123&type=signup');
+      await waitFor(() => {
+        expect(mockVerifyOtp).toHaveBeenCalledTimes(1);
+      });
+      // Simulate remount (as React Strict Mode does in dev)
+      unmount();
+      rerender(
+        <MemoryRouter initialEntries={['/auth/confirm?token_hash=abc123&type=signup']}>
+          <Routes>
+            <Route path='/auth/confirm' element={<AuthConfirmPage />} />
+          </Routes>
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        // Still only one call total — guard prevents second invocation
+        expect(mockVerifyOtp).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/apps/web/src/pages/__tests__/AuthConfirmPage.test.tsx
+++ b/apps/web/src/pages/__tests__/AuthConfirmPage.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import AuthConfirmPage from '../AuthConfirmPage';
+
+// Mock the supabase client
+const { mockVerifyOtp } = vi.hoisted(() => ({
+  mockVerifyOtp: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      verifyOtp: mockVerifyOtp,
+    },
+  },
+}));
+
+// Mock react-router-dom's useNavigate
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const renderWithParams = (search: string = '') => {
+  const path = `/auth/confirm${search}`;
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path='/auth/confirm' element={<AuthConfirmPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('AuthConfirmPage', () => {
+  beforeEach(() => {
+    mockVerifyOtp.mockReset();
+    vi.clearAllMocks();
+  });
+
+  describe('invalid / missing params', () => {
+    it('shows error when both token_hash and type are missing', () => {
+      renderWithParams('');
+      expect(
+        screen.getByText('This confirmation link is invalid or has already been used.')
+      ).toBeInTheDocument();
+      expect(screen.getByText('Return to home')).toBeInTheDocument();
+    });
+
+    it('shows error when token_hash is missing but type is present', () => {
+      renderWithParams('?type=signup');
+      expect(
+        screen.getByText('This confirmation link is invalid or has already been used.')
+      ).toBeInTheDocument();
+    });
+
+    it('shows error when type is missing but token_hash is present', () => {
+      renderWithParams('?token_hash=abc123');
+      expect(
+        screen.getByText('This confirmation link is invalid or has already been used.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows verifying text while verifyOtp is pending', () => {
+      mockVerifyOtp.mockImplementation(() => new Promise(() => {})); // never resolves
+      renderWithParams('?token_hash=abc123&type=signup');
+      expect(screen.getByText('Verifying your link…')).toBeInTheDocument();
+      expect(
+        screen.getByText('Please wait while we verify your link…')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('verifyOtp error', () => {
+    it('navigates to /forgot-password?expired=1 on error with recovery type', async () => {
+      mockVerifyOtp.mockResolvedValue({ error: { message: 'token expired' } });
+      renderWithParams('?token_hash=abc123&type=recovery');
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/forgot-password?expired=1', {
+          replace: true,
+        });
+      });
+    });
+
+    it('shows error message on verifyOtp error with non-recovery type (signup)', async () => {
+      mockVerifyOtp.mockResolvedValue({ error: { message: 'token expired' } });
+      renderWithParams('?token_hash=abc123&type=signup');
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'This link has expired or is invalid. Please request a new one.'
+          )
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('verifyOtp success', () => {
+    it('navigates to /reset-password on success with recovery type', async () => {
+      mockVerifyOtp.mockResolvedValue({ error: null });
+      renderWithParams('?token_hash=abc123&type=recovery');
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/reset-password', {
+          replace: true,
+        });
+      });
+    });
+
+    it('navigates to /dashboard on success with signup type', async () => {
+      mockVerifyOtp.mockResolvedValue({ error: null });
+      renderWithParams('?token_hash=abc123&type=signup');
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
+          replace: true,
+        });
+      });
+    });
+
+    it('navigates to /dashboard on success with magiclink type', async () => {
+      mockVerifyOtp.mockResolvedValue({ error: null });
+      renderWithParams('?token_hash=abc123&type=magiclink');
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
+          replace: true,
+        });
+      });
+    });
+
+    it('navigates to /dashboard on success with email_change type', async () => {
+      mockVerifyOtp.mockResolvedValue({ error: null });
+      renderWithParams('?token_hash=abc123&type=email_change');
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
+          replace: true,
+        });
+      });
+    });
+
+    it('navigates to /dashboard on success with invite type', async () => {
+      mockVerifyOtp.mockResolvedValue({ error: null });
+      renderWithParams('?token_hash=abc123&type=invite');
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
+          replace: true,
+        });
+      });
+    });
+  });
+
+  describe('error state rendering', () => {
+    it('renders a link to home when error is displayed', () => {
+      renderWithParams('');
+      const link = screen.getByRole('link', { name: 'Return to home' });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', '/');
+    });
+  });
+});

--- a/apps/web/src/pages/__tests__/AuthConfirmPage.test.tsx
+++ b/apps/web/src/pages/__tests__/AuthConfirmPage.test.tsx
@@ -32,7 +32,7 @@ const { mockReadAndClearPostAuthRedirect } = vi.hoisted(() => ({
   mockReadAndClearPostAuthRedirect: vi.fn(),
 }));
 
-vi.mock('../../auth/postAuthRedirect', () => ({
+vi.mock('@/auth/postAuthRedirect', () => ({
   readAndClearPostAuthRedirect: mockReadAndClearPostAuthRedirect,
 }));
 
@@ -49,10 +49,10 @@ const renderWithParams = (search: string = '') => {
 
 describe('AuthConfirmPage', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     mockVerifyOtp.mockReset();
     mockReadAndClearPostAuthRedirect.mockReset();
     mockReadAndClearPostAuthRedirect.mockReturnValue(null);
-    vi.clearAllMocks();
   });
 
   describe('invalid / missing params', () => {

--- a/docs/EMAIL_TEMPLATES.md
+++ b/docs/EMAIL_TEMPLATES.md
@@ -4,15 +4,17 @@ BeakerStack ships five ready-to-use transactional email templates that integrate
 
 ## Overview
 
-| Template | File | Supabase Type | Trigger |
-|---|---|---|---|
-| Signup confirmation | `signup_confirmation.html` | `signup` | New user registration |
-| Password reset | `password_reset.html` | `recovery` | Forgot password flow |
-| Magic link | `magic_link.html` | `magiclink` | Passwordless sign-in |
-| Email change | `email_change.html` | `email_change` | User updates their email |
-| Invite | `invite.html` | `invite` | Admin invites a user |
+| Template            | File                       | Supabase Type  | Trigger                  |
+| ------------------- | -------------------------- | -------------- | ------------------------ |
+| Signup confirmation | `signup_confirmation.html` | `signup`       | New user registration    |
+| Password reset      | `password_reset.html`      | `recovery`     | Forgot password flow     |
+| Magic link          | `magic_link.html`          | `magiclink`    | Passwordless sign-in     |
+| Email change        | `email_change.html`        | `email_change` | User updates their email |
+| Invite              | `invite.html`              | `invite`       | Admin invites a user     |
 
 All templates use the **token-hash strategy** — links resolve to `/auth/confirm?token_hash=...&type=...`, which calls `supabase.auth.verifyOtp()` and then redirects to the right page. This is the recommended Supabase PKCE-compatible approach.
+
+Links prefer `{{ .RedirectTo }}` (from `resetPasswordForEmail`, `signUp` `emailRedirectTo`, etc.) and fall back to `{{ .SiteURL }}/auth/confirm` when no redirect is passed. On PR preview deploys, the web app passes `https://deploy.example.com/pr-N/auth/confirm` so email links stay on the preview path instead of the root Site URL.
 
 Plain-text versions (`.txt` files) are provided alongside each HTML template for email clients that prefer or require plain text. **Note:** The `.txt` files in `supabase/templates/` are reference copies for human review only. Supabase derives plain-text email from the HTML template automatically — these files are not wired to Supabase via `config.toml` and do not affect sent emails.
 
@@ -27,6 +29,7 @@ npm run email:personalize
 ```
 
 The script will prompt for:
+
 - Product name (reads from `packages/shared/src/config/branding.ts` as default)
 - Brand color (hex, reads from `packages/shared/src/theme/colors.ts` as default)
 - Sender name
@@ -70,20 +73,21 @@ Templates live in `supabase/templates/`. Each is a self-contained HTML file with
 
 **Brand placeholders** (replaced by the personalization script):
 
-| Placeholder | Description |
-|---|---|
-| `{{PRODUCT_NAME}}` | Your product/app name |
-| `{{BRAND_COLOR}}` | Primary brand color (hex, e.g. `#6366f1`) |
-| `{{SENDER_NAME}}` | Sender display name (e.g. "Acme Team") |
-| `{{SUPPORT_EMAIL}}` | Support email address |
+| Placeholder           | Description                                  |
+| --------------------- | -------------------------------------------- |
+| `{{PRODUCT_NAME}}`    | Your product/app name                        |
+| `{{BRAND_COLOR}}`     | Primary brand color (hex, e.g. `#6366f1`)    |
+| `{{SENDER_NAME}}`     | Sender display name (e.g. "Acme Team")       |
+| `{{SUPPORT_EMAIL}}`   | Support email address                        |
 | `{{COMPANY_ADDRESS}}` | Physical mailing address (CAN-SPAM required) |
 
 **Supabase Go template variables** (never modify these — Supabase substitutes them at send time):
 
-| Variable | Description |
-|---|---|
-| `{{ .SiteURL }}` | Your configured site URL |
-| `{{ .TokenHash }}` | The OTP token hash |
+| Variable            | Description                                                               |
+| ------------------- | ------------------------------------------------------------------------- |
+| `{{ .SiteURL }}`    | Your configured site URL                                                  |
+| `{{ .RedirectTo }}` | Redirect URL from the auth API call (PR preview paths, mobile deep links) |
+| `{{ .TokenHash }}`  | The OTP token hash                                                        |
 
 ### Ejection marker
 
@@ -107,17 +111,18 @@ Resend is the recommended SMTP provider for transactional email. It offers a gen
 
 3. **Add DNS records** — Resend will give you SPF, DKIM, and DMARC records to add to your DNS provider:
 
-   | Record type | Host | Value |
-   |---|---|---|
-   | TXT | `@` or subdomain | SPF record (`v=spf1 include:amazonses.com ~all`) |
-   | TXT | `resend._domainkey` | DKIM public key |
-   | TXT | `_dmarc` | `v=DMARC1; p=quarantine; rua=mailto:dmarc@yourdomain.com` |
+   | Record type | Host                | Value                                                     |
+   | ----------- | ------------------- | --------------------------------------------------------- |
+   | TXT         | `@` or subdomain    | SPF record (`v=spf1 include:amazonses.com ~all`)          |
+   | TXT         | `resend._domainkey` | DKIM public key                                           |
+   | TXT         | `_dmarc`            | `v=DMARC1; p=quarantine; rua=mailto:dmarc@yourdomain.com` |
 
 4. **Wait for verification** — usually a few minutes; can take up to 48 hours for DNS propagation
 
 5. **Get an API key** — API Keys → Create API Key. Copy the key (shown once)
 
 6. **Set environment variables** in `.env.local`:
+
    ```
    SMTP_HOST=smtp.resend.com
    SMTP_PORT=587
@@ -128,6 +133,7 @@ Resend is the recommended SMTP provider for transactional email. It offers a gen
    ```
 
 7. **Uncomment the SMTP block** in `supabase/config.toml`:
+
    ```toml
    [auth.email.smtp]
    enabled = true
@@ -152,6 +158,7 @@ Proper domain authentication is critical for deliverability and protects your br
 **DMARC** (Domain-based Message Authentication, Reporting & Conformance) — tells receiving servers what to do when SPF or DKIM fails. Start with `p=none` for monitoring, then move to `p=quarantine` once you've confirmed legitimate mail is passing.
 
 Recommended DMARC policy for production:
+
 ```
 v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@yourdomain.com; pct=100
 ```
@@ -178,4 +185,3 @@ To switch from Resend to another SMTP provider (SendGrid, Postmark, AWS SES, etc
 3. Restart Supabase: `supabase stop && supabase start`
 
 No template changes required — the SMTP block in `supabase/config.toml` uses `env()` substitution for all connection details.
-

--- a/docs/EMAIL_TEMPLATES.md
+++ b/docs/EMAIL_TEMPLATES.md
@@ -14,7 +14,7 @@ BeakerStack ships five ready-to-use transactional email templates that integrate
 
 All templates use the **token-hash strategy** — links resolve to `/auth/confirm?token_hash=...&type=...`, which calls `supabase.auth.verifyOtp()` and then redirects to the right page. This is the recommended Supabase PKCE-compatible approach.
 
-Plain-text versions (`.txt` files) are provided alongside each HTML template for email clients that prefer or require plain text.
+Plain-text versions (`.txt` files) are provided alongside each HTML template for email clients that prefer or require plain text. **Note:** The `.txt` files in `supabase/templates/` are reference copies for human review only. Supabase derives plain-text email from the HTML template automatically — these files are not wired to Supabase via `config.toml` and do not affect sent emails.
 
 ## Quick start
 
@@ -32,6 +32,8 @@ The script will prompt for:
 - Sender name
 - Support email address
 - Company address (required by CAN-SPAM)
+
+The script is **idempotent** — re-running it restores the previous placeholders before applying new values, so you can safely update your branding at any time.
 
 ### 2. Configure SMTP (optional)
 
@@ -176,3 +178,4 @@ To switch from Resend to another SMTP provider (SendGrid, Postmark, AWS SES, etc
 3. Restart Supabase: `supabase stop && supabase start`
 
 No template changes required — the SMTP block in `supabase/config.toml` uses `env()` substitution for all connection details.
+

--- a/docs/EMAIL_TEMPLATES.md
+++ b/docs/EMAIL_TEMPLATES.md
@@ -1,0 +1,178 @@
+# Email Templates
+
+BeakerStack ships five ready-to-use transactional email templates that integrate directly with Supabase Auth. Each template is styled, CAN-SPAM compliant, and customizable through a single personalization script.
+
+## Overview
+
+| Template | File | Supabase Type | Trigger |
+|---|---|---|---|
+| Signup confirmation | `signup_confirmation.html` | `signup` | New user registration |
+| Password reset | `password_reset.html` | `recovery` | Forgot password flow |
+| Magic link | `magic_link.html` | `magiclink` | Passwordless sign-in |
+| Email change | `email_change.html` | `email_change` | User updates their email |
+| Invite | `invite.html` | `invite` | Admin invites a user |
+
+All templates use the **token-hash strategy** — links resolve to `/auth/confirm?token_hash=...&type=...`, which calls `supabase.auth.verifyOtp()` and then redirects to the right page. This is the recommended Supabase PKCE-compatible approach.
+
+Plain-text versions (`.txt` files) are provided alongside each HTML template for email clients that prefer or require plain text.
+
+## Quick start
+
+### 1. Personalize templates
+
+Run the personalization script to replace brand placeholders with your actual values:
+
+```bash
+npm run email:personalize
+```
+
+The script will prompt for:
+- Product name (reads from `packages/shared/src/config/branding.ts` as default)
+- Brand color (hex, reads from `packages/shared/src/theme/colors.ts` as default)
+- Sender name
+- Support email address
+- Company address (required by CAN-SPAM)
+
+### 2. Configure SMTP (optional)
+
+Uncomment and fill in the SMTP block in `supabase/config.toml` (see [SMTP setup](#smtp-setup-resend) below), then set `SMTP_*` vars in your `.env.local`.
+
+### 3. Apply configuration
+
+```bash
+supabase stop && supabase start
+```
+
+### 4. Test with Inbucket
+
+Open [http://localhost:54324](http://localhost:54324) to view emails sent during local development.
+
+## Enabling signup confirmations
+
+By default, `enable_confirmations = false` in `supabase/config.toml`. This means users can sign up and sign in immediately without verifying their email address.
+
+To require email verification:
+
+1. Open `supabase/config.toml`
+2. Find the `[auth.email]` section
+3. Set `enable_confirmations = true`
+4. Restart Supabase: `supabase stop && supabase start`
+
+**UX tradeoff:** Requiring confirmation reduces fake/mistyped registrations and verifies ownership, but adds friction to the signup flow. Consider your audience before enabling it.
+
+## Customizing templates
+
+### Editing HTML
+
+Templates live in `supabase/templates/`. Each is a self-contained HTML file with inline CSS for maximum email client compatibility.
+
+**Brand placeholders** (replaced by the personalization script):
+
+| Placeholder | Description |
+|---|---|
+| `{{PRODUCT_NAME}}` | Your product/app name |
+| `{{BRAND_COLOR}}` | Primary brand color (hex, e.g. `#6366f1`) |
+| `{{SENDER_NAME}}` | Sender display name (e.g. "Acme Team") |
+| `{{SUPPORT_EMAIL}}` | Support email address |
+| `{{COMPANY_ADDRESS}}` | Physical mailing address (CAN-SPAM required) |
+
+**Supabase Go template variables** (never modify these — Supabase substitutes them at send time):
+
+| Variable | Description |
+|---|---|
+| `{{ .SiteURL }}` | Your configured site URL |
+| `{{ .TokenHash }}` | The OTP token hash |
+
+### Ejection marker
+
+If you heavily customize a template and want to prevent the personalization script from overwriting your changes, add this comment anywhere in the file:
+
+```html
+<!-- beakerstack-email:customized -->
+```
+
+The script will skip any file containing this marker and log a warning.
+
+## SMTP setup (Resend)
+
+Resend is the recommended SMTP provider for transactional email. It offers a generous free tier and excellent deliverability.
+
+### Step-by-step
+
+1. **Create a Resend account** at [resend.com](https://resend.com)
+
+2. **Add and verify your domain** in the Resend dashboard (Domains → Add Domain)
+
+3. **Add DNS records** — Resend will give you SPF, DKIM, and DMARC records to add to your DNS provider:
+
+   | Record type | Host | Value |
+   |---|---|---|
+   | TXT | `@` or subdomain | SPF record (`v=spf1 include:amazonses.com ~all`) |
+   | TXT | `resend._domainkey` | DKIM public key |
+   | TXT | `_dmarc` | `v=DMARC1; p=quarantine; rua=mailto:dmarc@yourdomain.com` |
+
+4. **Wait for verification** — usually a few minutes; can take up to 48 hours for DNS propagation
+
+5. **Get an API key** — API Keys → Create API Key. Copy the key (shown once)
+
+6. **Set environment variables** in `.env.local`:
+   ```
+   SMTP_HOST=smtp.resend.com
+   SMTP_PORT=587
+   SMTP_USER=resend
+   SMTP_PASS=re_xxxxxxxxxxxx       # Your Resend API key
+   SMTP_ADMIN_EMAIL=you@yourdomain.com
+   SMTP_SENDER_NAME=Your App Team
+   ```
+
+7. **Uncomment the SMTP block** in `supabase/config.toml`:
+   ```toml
+   [auth.email.smtp]
+   enabled = true
+   host = "env(SMTP_HOST)"
+   port = 587
+   user = "env(SMTP_USER)"
+   pass = "env(SMTP_PASS)"
+   admin_email = "env(SMTP_ADMIN_EMAIL)"
+   sender_name = "env(SMTP_SENDER_NAME)"
+   ```
+
+8. **Restart Supabase**: `supabase stop && supabase start`
+
+## Domain verification
+
+Proper domain authentication is critical for deliverability and protects your brand from email spoofing.
+
+**SPF** (Sender Policy Framework) — declares which mail servers are authorized to send email from your domain. Add a TXT record to your DNS.
+
+**DKIM** (DomainKeys Identified Mail) — cryptographically signs outgoing email so recipients can verify it hasn't been tampered with. Add the DKIM TXT record that Resend provides.
+
+**DMARC** (Domain-based Message Authentication, Reporting & Conformance) — tells receiving servers what to do when SPF or DKIM fails. Start with `p=none` for monitoring, then move to `p=quarantine` once you've confirmed legitimate mail is passing.
+
+Recommended DMARC policy for production:
+```
+v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@yourdomain.com; pct=100
+```
+
+## Auth vs marketing email separation
+
+Transactional auth emails (this feature) and marketing/promotional emails should use **separate sending domains** or subdomains. For example:
+
+- Auth: `noreply@app.yourdomain.com`
+- Marketing: `hello@yourdomain.com`
+
+This prevents deliverability issues on your marketing domain if a transactional email triggers a spam complaint, and vice versa.
+
+## Mobile
+
+Password reset and magic link emails link to the web `/auth/confirm` page. On mobile, these open in the device browser. Universal link support (routing directly into the app) is out of scope for v1.
+
+## Switching SMTP providers
+
+To switch from Resend to another SMTP provider (SendGrid, Postmark, AWS SES, etc.):
+
+1. Update `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` in your `.env.local`
+2. Update `SMTP_ADMIN_EMAIL` and `SMTP_SENDER_NAME` if needed
+3. Restart Supabase: `supabase stop && supabase start`
+
+No template changes required — the SMTP block in `supabase/config.toml` uses `env()` substitution for all connection details.

--- a/docs/PASSWORD_RESET.md
+++ b/docs/PASSWORD_RESET.md
@@ -5,26 +5,27 @@
 ### Web
 
 1. User clicks **Forgot password?** on `/login` → `/forgot-password`
-2. User enters email, submits. `auth.requestPasswordReset(email)` calls `supabase.auth.resetPasswordForEmail(email, { redirectTo })` where `redirectTo` is built by `getAuthRedirectUrl()`:
+2. User enters email, submits. `auth.requestPasswordReset(email)` calls `supabase.auth.resetPasswordForEmail(email, { redirectTo })` where `redirectTo` is built by `getAuthConfirmUrl()`:
    - Standard: `https://app.example.com/auth/confirm`
    - PR previews: `https://pr-9.example.com/pr-9/auth/confirm`
 3. User receives email, clicks link → browser opens `/auth/confirm?token_hash=...&type=recovery`
 4. `AuthConfirmPage` calls `supabase.auth.verifyOtp({ token_hash, type: 'recovery' })`. On success, redirects to `/reset-password`. On error (expired or already used), redirects to `/forgot-password?expired=1`.
 5. `ResetPasswordPage` calls `supabase.auth.getSession()` on mount. If no session (link expired or revisited after use), redirects to `/forgot-password?expired=1`. With a valid session, the user sets a new password via `auth.updatePassword(password)` and is sent to `/dashboard` with `replace: true`.
 
-### Mobile (iOS / Android)
+### Mobile (iOS / Android) — v1
+
+This PR adds the web **token-hash** flow (`AuthConfirmPage`). Native apps are unchanged:
 
 1. User taps **Forgot password?** on `LoginScreen` → `ForgotPasswordScreen`
-2. User enters email, submits. `auth.requestPasswordReset(email)` calls `resetPasswordForEmail(email, { redirectTo: 'beaker-stack://auth/confirm' })`
-3. User receives email, taps link → app opens via deep link to `AuthConfirmScreen`
-4. `AuthConfirmScreen` calls `supabase.auth.verifyOtp({ token_hash, type: 'recovery' })`:
-   - Success → navigate to `ResetPasswordScreen`
-   - Error → navigate to `ForgotPasswordScreen`
-5. `ResetPasswordScreen` guards on `getSession()`. No session → navigate to `ForgotPasswordScreen`. With session, user sets new password via `auth.updatePassword(password)` and is reset-navigated to `Dashboard`.
+2. User submits. `auth.requestPasswordReset(email)` calls `resetPasswordForEmail` with `redirectTo: 'beaker-stack://auth/callback'`
+3. Branded email templates use `{{ .RedirectTo }}`, so the link targets the app deep link when the request comes from mobile
+4. `AuthCallbackScreen` handles the session via `onAuthStateChange(PASSWORD_RECOVERY)` → `ResetPasswordScreen`
+
+When a user opens a reset link on a phone without the app installed, the link opens in the device browser. Ensure your hosted web `/auth/confirm` URL is allowlisted (see web flow above). A native `AuthConfirm` screen and `beaker-stack://auth/confirm` deep link are follow-up work.
 
 ## Token-hash flow vs legacy hash-fragment flow
 
-BeakerStack uses the **token-hash strategy** throughout: email links contain `?token_hash=...&type=recovery` as query parameters (not `#access_token=...` hash fragments). `AuthConfirmPage` / `AuthConfirmScreen` calls `verifyOtp()` to exchange the token for a session, then redirects to the appropriate page.
+BeakerStack uses the **token-hash strategy** on web: email links contain `?token_hash=...&type=recovery` as query parameters (not `#access_token=...` hash fragments). `AuthConfirmPage` calls `verifyOtp()` to exchange the token for a session, then redirects to the appropriate page.
 
 This is the Supabase-recommended PKCE-compatible approach and avoids exposing tokens in browser history or server logs.
 
@@ -39,17 +40,18 @@ This is the Supabase-recommended PKCE-compatible approach and avoids exposing to
 
 Add these to your Supabase project's **Auth → URL Configuration → Redirect URLs**:
 
-| Environment | URL                                               |
-| ----------- | ------------------------------------------------- |
-| Local dev   | `http://localhost:5173/auth/confirm`              |
-| Staging     | `https://staging.beakerstack.com/auth/confirm`    |
-| Production  | `https://app.beakerstack.com/auth/confirm`        |
-| PR previews | `https://pr-*.beakerstack.com/pr-*/auth/confirm`  |
-| Mobile      | `beaker-stack://auth/confirm`                     |
+| Environment               | URL                                              |
+| ------------------------- | ------------------------------------------------ |
+| Local dev                 | `http://localhost:5173/auth/confirm`             |
+| Staging                   | `https://staging.beakerstack.com/auth/confirm`   |
+| Production                | `https://app.beakerstack.com/auth/confirm`       |
+| PR previews               | `https://pr-*.beakerstack.com/pr-*/auth/confirm` |
+| Mobile (native app)       | `beaker-stack://auth/callback`                   |
+| Mobile (browser fallback) | same hosted `/auth/confirm` URLs as web          |
 
-## Mobile deep-link setup
+## Mobile deep-link setup (native v1)
 
-The app scheme is `beaker-stack` (configured in `app.json` → `expo.scheme`). React Navigation's `linking` config in `AppNavigator.tsx` maps `beaker-stack://auth/confirm` to the `AuthConfirm` screen. The screen reads `token_hash` and `type` from the URL query parameters and calls `verifyOtp()`.
+The app scheme is `beaker-stack` (configured in `app.config.js` → `expo.scheme`). React Navigation's `linking` config in `AppNavigator.tsx` maps `beaker-stack://auth/callback` to `AuthCallbackScreen` for OAuth and password recovery.
 
 ## Manual test checklist
 
@@ -65,7 +67,7 @@ The app scheme is `beaker-stack` (configured in `app.json` → `expo.scheme`). R
 ### Local dev (mobile — Expo Go / simulator)
 
 - [ ] `ForgotPasswordScreen` → submit known address → success message stays on screen
-- [ ] Tap reset link from email → app opens to `AuthConfirmScreen` → lands on `ResetPasswordScreen`
+- [ ] Tap reset link from email → app opens to `AuthCallbackScreen` → lands on `ResetPasswordScreen`
 - [ ] Set new password ≥ 8 chars → navigate to `Dashboard`
 - [ ] Password < 8 chars → alert shown, `updatePassword` not called
 - [ ] Revisit link after use → `ForgotPasswordScreen` (no session)
@@ -74,4 +76,3 @@ The app scheme is `beaker-stack` (configured in `app.json` → `expo.scheme`). R
 ## Password minimum length
 
 `MIN_PASSWORD_LENGTH = 8` (from `packages/shared/src/constants/auth.ts`) must match the **Minimum password length** setting in Supabase → Authentication → Password. Update both together if the requirement changes.
-

--- a/docs/PASSWORD_RESET.md
+++ b/docs/PASSWORD_RESET.md
@@ -6,29 +6,31 @@
 
 1. User clicks **Forgot password?** on `/login` → `/forgot-password`
 2. User enters email, submits. `auth.requestPasswordReset(email)` calls `supabase.auth.resetPasswordForEmail(email, { redirectTo })` where `redirectTo` is built by `getAuthRedirectUrl()`:
-   - Standard: `https://app.example.com/auth/callback`
-   - PR previews: `https://pr-9.example.com/pr-9/auth/callback`
-3. User receives email, clicks link → browser opens `/auth/callback#access_token=...&type=recovery`
-4. `AuthCallbackPage` detects `type=recovery` in the hash **before** the `auth.user → /dashboard` branch, then subscribes to `onAuthStateChange`. When the `PASSWORD_RECOVERY` event fires, the page navigates to `/reset-password`.
+   - Standard: `https://app.example.com/auth/confirm`
+   - PR previews: `https://pr-9.example.com/pr-9/auth/confirm`
+3. User receives email, clicks link → browser opens `/auth/confirm?token_hash=...&type=recovery`
+4. `AuthConfirmPage` calls `supabase.auth.verifyOtp({ token_hash, type: 'recovery' })`. On success, redirects to `/reset-password`. On error (expired or already used), redirects to `/forgot-password?expired=1`.
 5. `ResetPasswordPage` calls `supabase.auth.getSession()` on mount. If no session (link expired or revisited after use), redirects to `/forgot-password?expired=1`. With a valid session, the user sets a new password via `auth.updatePassword(password)` and is sent to `/dashboard` with `replace: true`.
 
 ### Mobile (iOS / Android)
 
 1. User taps **Forgot password?** on `LoginScreen` → `ForgotPasswordScreen`
-2. User enters email, submits. `auth.requestPasswordReset(email)` calls `resetPasswordForEmail(email, { redirectTo: 'beaker-stack://auth/callback' })`
-3. User receives email, taps link → app opens via deep link to `AuthCallbackScreen`
-4. `AuthCallbackScreen` subscribes to `onAuthStateChange`:
-   - `PASSWORD_RECOVERY` → navigate to `ResetPasswordScreen`
-   - `SIGNED_IN` → navigate to `Dashboard`
+2. User enters email, submits. `auth.requestPasswordReset(email)` calls `resetPasswordForEmail(email, { redirectTo: 'beaker-stack://auth/confirm' })`
+3. User receives email, taps link → app opens via deep link to `AuthConfirmScreen`
+4. `AuthConfirmScreen` calls `supabase.auth.verifyOtp({ token_hash, type: 'recovery' })`:
+   - Success → navigate to `ResetPasswordScreen`
+   - Error → navigate to `ForgotPasswordScreen`
 5. `ResetPasswordScreen` guards on `getSession()`. No session → navigate to `ForgotPasswordScreen`. With session, user sets new password via `auth.updatePassword(password)` and is reset-navigated to `Dashboard`.
 
-## `PASSWORD_RECOVERY` event ordering
+## Token-hash flow vs legacy hash-fragment flow
 
-The `PASSWORD_RECOVERY` event from `supabase.auth.onAuthStateChange` is the authoritative signal that a user is in a reset session. On web, `AuthCallbackPage` must subscribe to this event **before** the generic `auth.user → /dashboard` check — otherwise an already-established recovery session would route to the dashboard instead of the reset form.
+BeakerStack uses the **token-hash strategy** throughout: email links contain `?token_hash=...&type=recovery` as query parameters (not `#access_token=...` hash fragments). `AuthConfirmPage` / `AuthConfirmScreen` calls `verifyOtp()` to exchange the token for a session, then redirects to the appropriate page.
 
-The guard is layered:
+This is the Supabase-recommended PKCE-compatible approach and avoids exposing tokens in browser history or server logs.
 
-1. **Synchronous URL capture** (`isPasswordRecoveryCallback` in `apps/web/src/lib/supabase.ts`) — reads `type=recovery` before Supabase initializes and clears the hash, persisting intent in `sessionStorage`.
+`AuthCallbackPage` handles OAuth and legacy hash redirects. Password recovery routed through `/auth/callback` uses layered guards in `apps/web/src/lib/supabase.ts`:
+
+1. **Synchronous URL capture** (`isPasswordRecoveryCallback`) — reads `type=recovery` before Supabase initializes and clears the hash, persisting intent in `sessionStorage`.
 2. **Synchronous URL hash check** (`type=recovery`) — prevents the `auth.user` branch from running while the `onAuthStateChange` subscription hasn't fired yet.
 3. **`onAuthStateChange(PASSWORD_RECOVERY)`** — the authoritative redirect to `/reset-password`.
 4. **Recovery fallback timer** (~1.5s) — if a session exists but `PASSWORD_RECOVERY` never fires (e.g. stale localStorage session), navigate to `/reset-password` anyway.
@@ -39,15 +41,15 @@ Add these to your Supabase project's **Auth → URL Configuration → Redirect U
 
 | Environment | URL                                               |
 | ----------- | ------------------------------------------------- |
-| Local dev   | `http://localhost:5173/auth/callback`             |
-| Staging     | `https://staging.beakerstack.com/auth/callback`   |
-| Production  | `https://app.beakerstack.com/auth/callback`       |
-| PR previews | `https://pr-*.beakerstack.com/pr-*/auth/callback` |
-| Mobile      | `beaker-stack://auth/callback`                    |
+| Local dev   | `http://localhost:5173/auth/confirm`              |
+| Staging     | `https://staging.beakerstack.com/auth/confirm`    |
+| Production  | `https://app.beakerstack.com/auth/confirm`        |
+| PR previews | `https://pr-*.beakerstack.com/pr-*/auth/confirm`  |
+| Mobile      | `beaker-stack://auth/confirm`                     |
 
 ## Mobile deep-link setup
 
-The app scheme is `beaker-stack` (configured in `app.json` → `expo.scheme`). React Navigation's `linking` config in `AppNavigator.tsx` maps `beaker-stack://auth/callback` to the `AuthCallback` screen. `detectSessionInUrl: true` in `apps/mobile/src/lib/supabase.ts` allows Supabase to parse tokens from the deep-link URL.
+The app scheme is `beaker-stack` (configured in `app.json` → `expo.scheme`). React Navigation's `linking` config in `AppNavigator.tsx` maps `beaker-stack://auth/confirm` to the `AuthConfirm` screen. The screen reads `token_hash` and `type` from the URL query parameters and calls `verifyOtp()`.
 
 ## Manual test checklist
 
@@ -58,12 +60,12 @@ The app scheme is `beaker-stack` (configured in `app.json` → `expo.scheme`). R
 - [ ] Set new password ≥ 8 chars → redirected to `/dashboard`
 - [ ] Revisit the reset URL after using it → redirected to `/forgot-password?expired=1`
 - [ ] Google OAuth callback still routes to `/dashboard` (regression)
-- [ ] PR preview: reset link email uses `/pr-N/auth/callback` in `redirectTo`
+- [ ] PR preview: reset link email uses `/pr-N/auth/confirm` in `redirectTo`
 
 ### Local dev (mobile — Expo Go / simulator)
 
 - [ ] `ForgotPasswordScreen` → submit known address → success message stays on screen
-- [ ] Tap reset link from email → app opens to `AuthCallbackScreen` → lands on `ResetPasswordScreen`
+- [ ] Tap reset link from email → app opens to `AuthConfirmScreen` → lands on `ResetPasswordScreen`
 - [ ] Set new password ≥ 8 chars → navigate to `Dashboard`
 - [ ] Password < 8 chars → alert shown, `updatePassword` not called
 - [ ] Revisit link after use → `ForgotPasswordScreen` (no session)
@@ -72,3 +74,4 @@ The app scheme is `beaker-stack` (configured in `app.json` → `expo.scheme`). R
 ## Password minimum length
 
 `MIN_PASSWORD_LENGTH = 8` (from `packages/shared/src/constants/auth.ts`) must match the **Minimum password length** setting in Supabase → Authentication → Password. Update both together if the requirement changes.
+

--- a/docs/supabase-preview-setup.md
+++ b/docs/supabase-preview-setup.md
@@ -164,6 +164,7 @@ Supabase needs to know which URLs are allowed for OAuth redirects.
 
    ```
    https://deploy.<your-domain>/pr-*/auth/callback
+   https://deploy.<your-domain>/pr-*/auth/confirm
    https://deploy.<your-domain>/pr-*/**
    https://deploy.<your-domain>/**
    ```
@@ -174,6 +175,7 @@ Supabase needs to know which URLs are allowed for OAuth redirects.
 
    ```
    https://deploy.beakerstack.com/pr-*/auth/callback
+   https://deploy.beakerstack.com/pr-*/auth/confirm
    https://deploy.beakerstack.com/pr-*/**
    https://deploy.beakerstack.com/**
    ```
@@ -182,7 +184,8 @@ Supabase needs to know which URLs are allowed for OAuth redirects.
 
 **Important**: Supabase supports wildcard patterns (`*`) in paths. The `**` pattern matches all paths recursively. The patterns above cover:
 
-- Individual PR callback paths: `/pr-123/auth/callback`
+- Individual PR callback paths: `/pr-123/auth/callback` (OAuth)
+- Token-hash email links: `/pr-123/auth/confirm` (password reset, signup confirm)
 - All paths within a PR: `/pr-123/**`
 - All paths on the deploy domain: `/**` (catch-all for any path)
 

--- a/env.example
+++ b/env.example
@@ -129,3 +129,11 @@ GOOGLE_SERVICES_API_KEY=your-google-services-api-key
 # OAuth Client IDs (for app.config.js)
 # These are used by app.config.js for Google Sign-In configuration
 # Use GOOGLE_SERVICES_* variables (defined above) - no EXPO_PUBLIC_ prefix needed
+
+# Email / SMTP (optional — see docs/EMAIL_TEMPLATES.md for Resend setup)
+SMTP_HOST=smtp.resend.com
+SMTP_PORT=587
+SMTP_USER=resend
+SMTP_PASS=                  # Your Resend API key (get one at resend.com)
+SMTP_ADMIN_EMAIL=           # Sender address (must be a verified domain in Resend)
+SMTP_SENDER_NAME=           # Display name, e.g. "BeakerStack Team"

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "setup:local": "./scripts/setup-local.sh",
     "setup:full": "node ./scripts/setup-full.mjs",
     "setup-full": "node ./scripts/setup-full.mjs",
+    "email:personalize": "node scripts/personalize-email-templates.mjs",
     "setup:diagnose-secret-input": "node ./scripts/dev-diagnose-secret-input.mjs",
     "clean": "rm -rf node_modules apps/*/node_modules packages/*/node_modules apps/*/dist apps/*/build",
     "clean:all": "npm run clean && supabase stop && docker system prune -f",

--- a/packages/shared-tests/__tests__/hooks/useAuth.test.ts
+++ b/packages/shared-tests/__tests__/hooks/useAuth.test.ts
@@ -136,6 +136,7 @@ describe('useAuth', () => {
     expect(mockClient.auth.signUp).toHaveBeenCalledWith({
       email: 'test@example.com',
       password: 'password123',
+      options: { emailRedirectTo: 'http://localhost/auth/confirm' },
     });
   });
 
@@ -403,8 +404,35 @@ describe('useAuth', () => {
 
     expect(mockClient.auth.resetPasswordForEmail).toHaveBeenCalledWith(
       'user@example.com',
-      { redirectTo: 'http://localhost/auth/callback' }
+      { redirectTo: 'http://localhost/auth/confirm' }
     );
+  });
+
+  it('should use PR preview path for password reset redirect', async () => {
+    const originalHref = window.location.href;
+    window.history.replaceState({}, '', '/pr-9/forgot-password');
+
+    const { mockClient } = createMockSupabaseClient();
+    mockClient.auth.resetPasswordForEmail = jest.fn().mockResolvedValue({
+      data: {},
+      error: null,
+    });
+    const { result } = renderHook(() => useAuth(mockClient));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.requestPasswordReset('user@example.com');
+    });
+
+    expect(mockClient.auth.resetPasswordForEmail).toHaveBeenCalledWith(
+      'user@example.com',
+      { redirectTo: `${window.location.origin}/pr-9/auth/confirm` }
+    );
+
+    window.history.replaceState({}, '', originalHref);
   });
 
   it('should throw when password reset fails', async () => {

--- a/packages/shared/src/hooks/useAuth.ts
+++ b/packages/shared/src/hooks/useAuth.ts
@@ -7,10 +7,19 @@ import { Logger } from '../utils/logger';
 // Web platform does not require native Google configuration
 export function configureGoogleSignIn() {}
 
-function getAuthRedirectUrl(): string {
-  const basePath =
-    window.location.pathname.match(/^(\/pr-\d+)/)?.[1] || '';
-  return `${window.location.origin}${basePath}/auth/callback`;
+function getAuthRedirectBase(): string {
+  const basePath = window.location.pathname.match(/^(\/pr-\d+)/)?.[1] || '';
+  return `${window.location.origin}${basePath}`;
+}
+
+/** OAuth and legacy hash callbacks (Google sign-in). */
+function getAuthCallbackUrl(): string {
+  return `${getAuthRedirectBase()}/auth/callback`;
+}
+
+/** Token-hash emails (password reset, signup confirm, magic link). */
+function getAuthConfirmUrl(): string {
+  return `${getAuthRedirectBase()}/auth/confirm`;
 }
 
 export function useAuth(supabaseClient: SupabaseClient): AuthHookReturn {
@@ -66,9 +75,15 @@ export function useAuth(supabaseClient: SupabaseClient): AuthHookReturn {
     setLoading(true);
     setError(null);
 
+    const emailRedirectTo =
+      typeof window !== 'undefined' && window.location
+        ? getAuthConfirmUrl()
+        : undefined;
+
     const { error } = await supabaseClient.auth.signUp({
       email,
       password,
+      ...(emailRedirectTo ? { options: { emailRedirectTo } } : {}),
     });
 
     setLoading(false);
@@ -151,7 +166,7 @@ export function useAuth(supabaseClient: SupabaseClient): AuthHookReturn {
 
     let redirectTo: string | undefined;
     if (typeof window !== 'undefined' && window.location) {
-      redirectTo = getAuthRedirectUrl();
+      redirectTo = getAuthCallbackUrl();
     }
 
     const authArgs = redirectTo
@@ -180,7 +195,7 @@ export function useAuth(supabaseClient: SupabaseClient): AuthHookReturn {
 
     const redirectTo =
       typeof window !== 'undefined' && window.location
-        ? getAuthRedirectUrl()
+        ? getAuthConfirmUrl()
         : undefined;
 
     const options = redirectTo ? { redirectTo } : {};

--- a/scripts/personalize-email-templates.mjs
+++ b/scripts/personalize-email-templates.mjs
@@ -12,6 +12,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 const TEMPLATES_DIR = join(ROOT, 'supabase', 'templates');
 const CONFIG_TOML = join(ROOT, 'supabase', 'config.toml');
+const PERSONALIZATION_FILE = join(TEMPLATES_DIR, '.personalization.json');
 const EJECTION_MARKER = 'beakerstack-email:customized';
 const NON_INTERACTIVE = process.argv.includes('--non-interactive');
 
@@ -38,19 +39,25 @@ const colorsFile = join(ROOT, 'packages', 'shared', 'src', 'theme', 'colors.ts')
 
 const defaultProductName = readBrandingValue(brandingFile, 'displayName') ?? 'BeakerStack';
 
-// Try to extract primary color — look for common patterns including Tailwind token style
+// Try to extract primary brand color — understands the actual colors.ts structure:
+// `brand: indigo[600]` where `indigo` is a local const with hex values.
 function readPrimaryColor(file) {
   try {
     const src = readFileSync(file, 'utf8');
-    // Try direct hex first: primary: '#...' or primaryColor: '#...'
-    const hexMatch = src.match(/primary(?:Color)?['"]?\s*:\s*['"]?(#[0-9a-fA-F]{3,8})/);
+
+    // Try direct hex first: brand/primary: '#...'
+    const hexMatch = src.match(/(?:brand|primary(?:Color)?)['"]?\s*:\s*['"]?(#[0-9a-fA-F]{3,8})/);
     if (hexMatch) return hexMatch[1];
-    // Try Tailwind token like colors.indigo[600] or indigo[600]
-    const tokenMatch = src.match(/primary(?:Color)?['"]?\s*:\s*(?:colors\.)?(\w+)\[(\d+)\]/);
+
+    // Try `brand: colorName[shade]` or `primary: colors.colorName[shade]`
+    const tokenMatch = src.match(/(?:brand|primary(?:Color)?)['"]?\s*:\s*(?:colors\.)?(\w+)\[(\d+)\]/);
     if (tokenMatch) {
       const [, colorName, shade] = tokenMatch;
-      const shadeDef = src.match(new RegExp(`${shade}:\\s*['"]?(#[0-9a-fA-F]{3,8})`));
-      if (shadeDef) return shadeDef[1];
+      // Look for the shade within the named color's block
+      const colorBlockMatch = src.match(
+        new RegExp(`${colorName}[^{]*\\{[^}]*${shade}[^:]*:\\s*['"]?(#[0-9a-fA-F]{3,8})`, 's')
+      );
+      if (colorBlockMatch) return colorBlockMatch[1];
     }
     return '#6366f1';
   } catch { return '#6366f1'; }
@@ -81,10 +88,52 @@ function checkConfirmations() {
   } catch { /* no-op */ }
 }
 
+// --- Load previous personalization state ---
+function loadPreviousPersonalization() {
+  try {
+    return JSON.parse(readFileSync(PERSONALIZATION_FILE, 'utf8'));
+  } catch { return null; }
+}
+
+// --- Reverse previous personalization in content ---
+function reversePersonalization(content, prev) {
+  let reversed = content;
+  const tokenMap = {
+    PRODUCT_NAME: '{{PRODUCT_NAME}}',
+    BRAND_COLOR: '{{BRAND_COLOR}}',
+    SENDER_NAME: '{{SENDER_NAME}}',
+    SUPPORT_EMAIL: '{{SUPPORT_EMAIL}}',
+    COMPANY_ADDRESS: '{{COMPANY_ADDRESS}}',
+  };
+  for (const [key, token] of Object.entries(tokenMap)) {
+    if (prev[key]) {
+      reversed = reversed.replaceAll(prev[key], token);
+    }
+  }
+  return reversed;
+}
+
+// --- Reverse previous personalization in config.toml ---
+function reverseTomlPersonalization(content, prev) {
+  let reversed = content;
+  if (prev.PRODUCT_NAME) {
+    reversed = reversed.replaceAll(prev.PRODUCT_NAME, '__PRODUCT_NAME__');
+  }
+  if (prev.BRAND_COLOR) {
+    reversed = reversed.replaceAll(prev.BRAND_COLOR, '__BRAND_COLOR__');
+  }
+  return reversed;
+}
+
 // --- Main ---
 async function main() {
   console.log('BeakerStack Email Template Personalization\n');
   checkConfirmations();
+
+  const prev = loadPreviousPersonalization();
+  if (prev) {
+    console.log('i  Previous personalization found — will restore placeholders before re-applying.\n');
+  }
 
   const productName = await prompt('Product name', defaultProductName);
   const brandColor = await prompt('Brand color (hex)', defaultBrandColor);
@@ -131,11 +180,15 @@ async function main() {
   let modified = 0, skipped = 0;
   for (const file of files) {
     const path = join(TEMPLATES_DIR, file);
-    const content = readFileSync(path, 'utf8');
+    let content = readFileSync(path, 'utf8');
     if (content.includes(EJECTION_MARKER)) {
       console.log(`!  Skipping ${file} — marked as customized.`);
       skipped++;
       continue;
+    }
+    // Reverse previous personalization so tokens are clean before re-applying
+    if (prev) {
+      content = reversePersonalization(content, prev);
     }
     let updated = content;
     for (const [token, value] of Object.entries(replacements)) {
@@ -150,7 +203,11 @@ async function main() {
 
   // Personalize config.toml subject lines (uses __PLACEHOLDER__ style, not {{}} Go template syntax)
   try {
-    const toml = readFileSync(CONFIG_TOML, 'utf8');
+    let toml = readFileSync(CONFIG_TOML, 'utf8');
+    // Reverse previous personalization first
+    if (prev) {
+      toml = reverseTomlPersonalization(toml, prev);
+    }
     let updatedToml = toml;
     for (const [token, value] of Object.entries(tomlReplacements)) {
       updatedToml = updatedToml.replaceAll(token, value);
@@ -161,6 +218,16 @@ async function main() {
       modified++;
     }
   } catch { /* config.toml optional */ }
+
+  // Save current personalization state for idempotent re-runs
+  const newState = {
+    PRODUCT_NAME: productName,
+    BRAND_COLOR: brandColor,
+    SENDER_NAME: senderName,
+    ...(supportEmail ? { SUPPORT_EMAIL: supportEmail } : {}),
+    ...(companyAddress ? { COMPANY_ADDRESS: companyAddress } : {}),
+  };
+  writeFileSync(PERSONALIZATION_FILE, JSON.stringify(newState, null, 2) + '\n', 'utf8');
 
   console.log(`\nDone — ${modified} file(s) updated, ${skipped} skipped.`);
   if (!NON_INTERACTIVE) {
@@ -173,3 +240,4 @@ async function main() {
 }
 
 main().catch(err => { console.error(err); process.exit(1); });
+

--- a/scripts/personalize-email-templates.mjs
+++ b/scripts/personalize-email-templates.mjs
@@ -31,13 +31,30 @@ function readBrandingValue(file, key) {
     const src = readFileSync(file, 'utf8');
     const match = src.match(new RegExp(`${key}:\\s*['"]([^'"]+)['"]`));
     return match ? match[1] : null;
-  } catch { return null; }
+  } catch {
+    return null;
+  }
 }
 
-const brandingFile = join(ROOT, 'packages', 'shared', 'src', 'config', 'branding.ts');
-const colorsFile = join(ROOT, 'packages', 'shared', 'src', 'theme', 'colors.ts');
+const brandingFile = join(
+  ROOT,
+  'packages',
+  'shared',
+  'src',
+  'config',
+  'branding.ts'
+);
+const colorsFile = join(
+  ROOT,
+  'packages',
+  'shared',
+  'src',
+  'theme',
+  'colors.ts'
+);
 
-const defaultProductName = readBrandingValue(brandingFile, 'displayName') ?? 'BeakerStack';
+const defaultProductName =
+  readBrandingValue(brandingFile, 'displayName') ?? 'BeakerStack';
 
 // Try to extract primary brand color — understands the actual colors.ts structure:
 // `brand: indigo[600]` where `indigo` is a local const with hex values.
@@ -46,21 +63,36 @@ function readPrimaryColor(file) {
     const src = readFileSync(file, 'utf8');
 
     // Try direct hex first: brand/primary: '#...'
-    const hexMatch = src.match(/(?:brand|primary(?:Color)?)['"]?\s*:\s*['"]?(#[0-9a-fA-F]{3,8})/);
+    const hexMatch = src.match(
+      /(?:brand|primary(?:Color)?)['"]?\s*:\s*['"]?(#[0-9a-fA-F]{3,8})/
+    );
     if (hexMatch) return hexMatch[1];
 
     // Try `brand: colorName[shade]` or `primary: colors.colorName[shade]`
-    const tokenMatch = src.match(/(?:brand|primary(?:Color)?)['"]?\s*:\s*(?:colors\.)?(\w+)\[(\d+)\]/);
+    const tokenMatch = src.match(
+      /(?:brand|primary(?:Color)?)['"]?\s*:\s*(?:colors\.)?(\w+)\[(\d+)\]/
+    );
     if (tokenMatch) {
       const [, colorName, shade] = tokenMatch;
-      // Look for the shade within the named color's block
-      const colorBlockMatch = src.match(
-        new RegExp(`${colorName}[^{]*\\{[^}]*${shade}[^:]*:\\s*['"]?(#[0-9a-fA-F]{3,8})`, 's')
+      // Match `const indigo = { ... }` — avoid false positives from comments or
+      // other objects that mention `indigo[600]` before the palette definition.
+      const paletteMatch = src.match(
+        new RegExp(
+          `const\\s+${colorName}\\s*=\\s*\\{([\\s\\S]*?)\\}\\s*as const`,
+          'm'
+        )
       );
-      if (colorBlockMatch) return colorBlockMatch[1];
+      if (paletteMatch) {
+        const shadeMatch = paletteMatch[1].match(
+          new RegExp(`${shade}\\s*:\\s*['"]?(#[0-9a-fA-F]{3,8})`)
+        );
+        if (shadeMatch) return shadeMatch[1];
+      }
     }
     return '#6366f1';
-  } catch { return '#6366f1'; }
+  } catch {
+    return '#6366f1';
+  }
 }
 const defaultBrandColor = readPrimaryColor(colorsFile);
 
@@ -68,7 +100,10 @@ const defaultBrandColor = readPrimaryColor(colorsFile);
 async function prompt(question, defaultVal) {
   if (NON_INTERACTIVE) return defaultVal;
   return new Promise(resolve => {
-    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
     rl.question(`${question} [${defaultVal}]: `, answer => {
       rl.close();
       resolve(answer.trim() || defaultVal);
@@ -81,18 +116,26 @@ function checkConfirmations() {
   try {
     const toml = readFileSync(CONFIG_TOML, 'utf8');
     if (/^\s*enable_confirmations\s*=\s*false/m.test(toml)) {
-      console.log('\ni  Note: enable_confirmations = false in supabase/config.toml.');
-      console.log('   Signup confirmation emails are dormant until you set it to true.');
+      console.log(
+        '\ni  Note: enable_confirmations = false in supabase/config.toml.'
+      );
+      console.log(
+        '   Signup confirmation emails are dormant until you set it to true.'
+      );
       console.log('   See docs/EMAIL_TEMPLATES.md for details.\n');
     }
-  } catch { /* no-op */ }
+  } catch {
+    /* no-op */
+  }
 }
 
 // --- Load previous personalization state ---
 function loadPreviousPersonalization() {
   try {
     return JSON.parse(readFileSync(PERSONALIZATION_FILE, 'utf8'));
-  } catch { return null; }
+  } catch {
+    return null;
+  }
 }
 
 // --- Reverse previous personalization in content ---
@@ -132,7 +175,9 @@ async function main() {
 
   const prev = loadPreviousPersonalization();
   if (prev) {
-    console.log('i  Previous personalization found — will restore placeholders before re-applying.\n');
+    console.log(
+      'i  Previous personalization found — will restore placeholders before re-applying.\n'
+    );
   }
 
   const productName = await prompt('Product name', defaultProductName);
@@ -147,11 +192,16 @@ async function main() {
     supportEmail = flagSupportEmail ?? null;
     companyAddress = flagCompanyAddress ?? null;
     if (!supportEmail || !companyAddress) {
-      console.log('i  Run without --non-interactive to personalize CAN-SPAM fields (required before sending email).');
+      console.log(
+        'i  Run without --non-interactive to personalize CAN-SPAM fields (required before sending email).'
+      );
     }
   } else {
     supportEmail = await prompt('Support email', 'support@example.com');
-    companyAddress = await prompt('Company address (CAN-SPAM required)', '123 Main St, City, State 00000, Country');
+    companyAddress = await prompt(
+      'Company address (CAN-SPAM required)',
+      '123 Main St, City, State 00000, Country'
+    );
   }
 
   const replacements = {
@@ -164,20 +214,25 @@ async function main() {
 
   // config.toml uses __PRODUCT_NAME__ (double underscores) to avoid Go template conflicts
   const tomlReplacements = {
-    '__PRODUCT_NAME__': productName,
-    '__BRAND_COLOR__': brandColor,
+    __PRODUCT_NAME__: productName,
+    __BRAND_COLOR__: brandColor,
   };
 
   // Personalize template files
   let files;
   try {
-    files = readdirSync(TEMPLATES_DIR).filter(f => f.endsWith('.html') || f.endsWith('.txt'));
+    files = readdirSync(TEMPLATES_DIR).filter(
+      f => f.endsWith('.html') || f.endsWith('.txt')
+    );
   } catch {
-    console.error('x  supabase/templates/ not found. Make sure you have the templates directory.');
+    console.error(
+      'x  supabase/templates/ not found. Make sure you have the templates directory.'
+    );
     process.exit(1);
   }
 
-  let modified = 0, skipped = 0;
+  let modified = 0,
+    skipped = 0;
   for (const file of files) {
     const path = join(TEMPLATES_DIR, file);
     let content = readFileSync(path, 'utf8');
@@ -217,7 +272,9 @@ async function main() {
       console.log('ok supabase/config.toml (subject lines)');
       modified++;
     }
-  } catch { /* config.toml optional */ }
+  } catch {
+    /* config.toml optional */
+  }
 
   // Save current personalization state for idempotent re-runs
   const newState = {
@@ -227,17 +284,27 @@ async function main() {
     ...(supportEmail ? { SUPPORT_EMAIL: supportEmail } : {}),
     ...(companyAddress ? { COMPANY_ADDRESS: companyAddress } : {}),
   };
-  writeFileSync(PERSONALIZATION_FILE, JSON.stringify(newState, null, 2) + '\n', 'utf8');
+  writeFileSync(
+    PERSONALIZATION_FILE,
+    JSON.stringify(newState, null, 2) + '\n',
+    'utf8'
+  );
 
   console.log(`\nDone — ${modified} file(s) updated, ${skipped} skipped.`);
   if (!NON_INTERACTIVE) {
     console.log('\nNext steps:');
-    console.log('  1. Enable SMTP in supabase/config.toml if sending via custom domain');
+    console.log(
+      '  1. Enable SMTP in supabase/config.toml if sending via custom domain'
+    );
     console.log('  2. Set SMTP_* vars in .env.local');
-    console.log('  3. Run: supabase stop && supabase start to apply config changes');
+    console.log(
+      '  3. Run: supabase stop && supabase start to apply config changes'
+    );
     console.log('  4. Test with Inbucket at http://localhost:54324');
   }
 }
 
-main().catch(err => { console.error(err); process.exit(1); });
-
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/personalize-email-templates.mjs
+++ b/scripts/personalize-email-templates.mjs
@@ -15,6 +15,15 @@ const CONFIG_TOML = join(ROOT, 'supabase', 'config.toml');
 const EJECTION_MARKER = 'beakerstack-email:customized';
 const NON_INTERACTIVE = process.argv.includes('--non-interactive');
 
+// Parse CLI flags for non-interactive CAN-SPAM overrides
+function parseFlag(name) {
+  const prefix = `--${name}=`;
+  const arg = process.argv.find(a => a.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : null;
+}
+const flagSupportEmail = parseFlag('support-email');
+const flagCompanyAddress = parseFlag('company-address');
+
 // --- Read branding from source ---
 function readBrandingValue(file, key) {
   try {
@@ -29,13 +38,21 @@ const colorsFile = join(ROOT, 'packages', 'shared', 'src', 'theme', 'colors.ts')
 
 const defaultProductName = readBrandingValue(brandingFile, 'displayName') ?? 'BeakerStack';
 
-// Try to extract primary color — look for common patterns
+// Try to extract primary color — look for common patterns including Tailwind token style
 function readPrimaryColor(file) {
   try {
     const src = readFileSync(file, 'utf8');
-    // Match: brand: '#...' or primary: '#...'
-    const match = src.match(/brand(?:Color)?['"]?\s*:\s*['"]?(#[0-9a-fA-F]{3,8})/);
-    return match ? match[1] : '#6366f1';
+    // Try direct hex first: primary: '#...' or primaryColor: '#...'
+    const hexMatch = src.match(/primary(?:Color)?['"]?\s*:\s*['"]?(#[0-9a-fA-F]{3,8})/);
+    if (hexMatch) return hexMatch[1];
+    // Try Tailwind token like colors.indigo[600] or indigo[600]
+    const tokenMatch = src.match(/primary(?:Color)?['"]?\s*:\s*(?:colors\.)?(\w+)\[(\d+)\]/);
+    if (tokenMatch) {
+      const [, colorName, shade] = tokenMatch;
+      const shadeDef = src.match(new RegExp(`${shade}:\\s*['"]?(#[0-9a-fA-F]{3,8})`));
+      if (shadeDef) return shadeDef[1];
+    }
+    return '#6366f1';
   } catch { return '#6366f1'; }
 }
 const defaultBrandColor = readPrimaryColor(colorsFile);
@@ -72,15 +89,34 @@ async function main() {
   const productName = await prompt('Product name', defaultProductName);
   const brandColor = await prompt('Brand color (hex)', defaultBrandColor);
   const senderName = await prompt('Sender name', `${productName} Team`);
-  const supportEmail = await prompt('Support email', 'support@example.com');
-  const companyAddress = await prompt('Company address (CAN-SPAM required)', '123 Main St, City, State 00000, Country');
+
+  // CAN-SPAM fields: in non-interactive mode, skip unless provided via CLI flags.
+  // Leaving placeholders is intentional — they must be filled before sending email.
+  let supportEmail;
+  let companyAddress;
+  if (NON_INTERACTIVE) {
+    supportEmail = flagSupportEmail ?? null;
+    companyAddress = flagCompanyAddress ?? null;
+    if (!supportEmail || !companyAddress) {
+      console.log('i  Run without --non-interactive to personalize CAN-SPAM fields (required before sending email).');
+    }
+  } else {
+    supportEmail = await prompt('Support email', 'support@example.com');
+    companyAddress = await prompt('Company address (CAN-SPAM required)', '123 Main St, City, State 00000, Country');
+  }
 
   const replacements = {
     '{{PRODUCT_NAME}}': productName,
     '{{BRAND_COLOR}}': brandColor,
     '{{SENDER_NAME}}': senderName,
-    '{{SUPPORT_EMAIL}}': supportEmail,
-    '{{COMPANY_ADDRESS}}': companyAddress,
+    ...(supportEmail ? { '{{SUPPORT_EMAIL}}': supportEmail } : {}),
+    ...(companyAddress ? { '{{COMPANY_ADDRESS}}': companyAddress } : {}),
+  };
+
+  // config.toml uses __PRODUCT_NAME__ (double underscores) to avoid Go template conflicts
+  const tomlReplacements = {
+    '__PRODUCT_NAME__': productName,
+    '__BRAND_COLOR__': brandColor,
   };
 
   // Personalize template files
@@ -112,11 +148,11 @@ async function main() {
     }
   }
 
-  // Personalize config.toml subject lines
+  // Personalize config.toml subject lines (uses __PLACEHOLDER__ style, not {{}} Go template syntax)
   try {
     const toml = readFileSync(CONFIG_TOML, 'utf8');
     let updatedToml = toml;
-    for (const [token, value] of Object.entries(replacements)) {
+    for (const [token, value] of Object.entries(tomlReplacements)) {
       updatedToml = updatedToml.replaceAll(token, value);
     }
     if (updatedToml !== toml) {

--- a/scripts/personalize-email-templates.mjs
+++ b/scripts/personalize-email-templates.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+// Personalizes BeakerStack email templates with project branding.
+// Run: node scripts/personalize-email-templates.mjs
+// Or:  npm run email:personalize
+
+import { readFileSync, writeFileSync, readdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { createInterface } from 'readline';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const TEMPLATES_DIR = join(ROOT, 'supabase', 'templates');
+const CONFIG_TOML = join(ROOT, 'supabase', 'config.toml');
+const EJECTION_MARKER = 'beakerstack-email:customized';
+const NON_INTERACTIVE = process.argv.includes('--non-interactive');
+
+// --- Read branding from source ---
+function readBrandingValue(file, key) {
+  try {
+    const src = readFileSync(file, 'utf8');
+    const match = src.match(new RegExp(`${key}:\\s*['"]([^'"]+)['"]`));
+    return match ? match[1] : null;
+  } catch { return null; }
+}
+
+const brandingFile = join(ROOT, 'packages', 'shared', 'src', 'config', 'branding.ts');
+const colorsFile = join(ROOT, 'packages', 'shared', 'src', 'theme', 'colors.ts');
+
+const defaultProductName = readBrandingValue(brandingFile, 'displayName') ?? 'BeakerStack';
+
+// Try to extract primary color — look for common patterns
+function readPrimaryColor(file) {
+  try {
+    const src = readFileSync(file, 'utf8');
+    // Match: brand: '#...' or primary: '#...'
+    const match = src.match(/brand(?:Color)?['"]?\s*:\s*['"]?(#[0-9a-fA-F]{3,8})/);
+    return match ? match[1] : '#6366f1';
+  } catch { return '#6366f1'; }
+}
+const defaultBrandColor = readPrimaryColor(colorsFile);
+
+// --- Prompt helper ---
+async function prompt(question, defaultVal) {
+  if (NON_INTERACTIVE) return defaultVal;
+  return new Promise(resolve => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(`${question} [${defaultVal}]: `, answer => {
+      rl.close();
+      resolve(answer.trim() || defaultVal);
+    });
+  });
+}
+
+// --- Check enable_confirmations ---
+function checkConfirmations() {
+  try {
+    const toml = readFileSync(CONFIG_TOML, 'utf8');
+    if (/^\s*enable_confirmations\s*=\s*false/m.test(toml)) {
+      console.log('\ni  Note: enable_confirmations = false in supabase/config.toml.');
+      console.log('   Signup confirmation emails are dormant until you set it to true.');
+      console.log('   See docs/EMAIL_TEMPLATES.md for details.\n');
+    }
+  } catch { /* no-op */ }
+}
+
+// --- Main ---
+async function main() {
+  console.log('BeakerStack Email Template Personalization\n');
+  checkConfirmations();
+
+  const productName = await prompt('Product name', defaultProductName);
+  const brandColor = await prompt('Brand color (hex)', defaultBrandColor);
+  const senderName = await prompt('Sender name', `${productName} Team`);
+  const supportEmail = await prompt('Support email', 'support@example.com');
+  const companyAddress = await prompt('Company address (CAN-SPAM required)', '123 Main St, City, State 00000, Country');
+
+  const replacements = {
+    '{{PRODUCT_NAME}}': productName,
+    '{{BRAND_COLOR}}': brandColor,
+    '{{SENDER_NAME}}': senderName,
+    '{{SUPPORT_EMAIL}}': supportEmail,
+    '{{COMPANY_ADDRESS}}': companyAddress,
+  };
+
+  // Personalize template files
+  let files;
+  try {
+    files = readdirSync(TEMPLATES_DIR).filter(f => f.endsWith('.html') || f.endsWith('.txt'));
+  } catch {
+    console.error('x  supabase/templates/ not found. Make sure you have the templates directory.');
+    process.exit(1);
+  }
+
+  let modified = 0, skipped = 0;
+  for (const file of files) {
+    const path = join(TEMPLATES_DIR, file);
+    const content = readFileSync(path, 'utf8');
+    if (content.includes(EJECTION_MARKER)) {
+      console.log(`!  Skipping ${file} — marked as customized.`);
+      skipped++;
+      continue;
+    }
+    let updated = content;
+    for (const [token, value] of Object.entries(replacements)) {
+      updated = updated.replaceAll(token, value);
+    }
+    if (updated !== content) {
+      writeFileSync(path, updated, 'utf8');
+      console.log(`ok ${file}`);
+      modified++;
+    }
+  }
+
+  // Personalize config.toml subject lines
+  try {
+    const toml = readFileSync(CONFIG_TOML, 'utf8');
+    let updatedToml = toml;
+    for (const [token, value] of Object.entries(replacements)) {
+      updatedToml = updatedToml.replaceAll(token, value);
+    }
+    if (updatedToml !== toml) {
+      writeFileSync(CONFIG_TOML, updatedToml, 'utf8');
+      console.log('ok supabase/config.toml (subject lines)');
+      modified++;
+    }
+  } catch { /* config.toml optional */ }
+
+  console.log(`\nDone — ${modified} file(s) updated, ${skipped} skipped.`);
+  if (!NON_INTERACTIVE) {
+    console.log('\nNext steps:');
+    console.log('  1. Enable SMTP in supabase/config.toml if sending via custom domain');
+    console.log('  2. Set SMTP_* vars in .env.local');
+    console.log('  3. Run: supabase stop && supabase start to apply config changes');
+    console.log('  4. Test with Inbucket at http://localhost:54324');
+  }
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -2743,16 +2743,18 @@ async function main() {
       }
     }
     // Personalize email templates
-    logInfo('');
-    logInfo('Personalizing email templates...');
-    try {
-      const { execSync } = await import('node:child_process');
-      execSync('node scripts/personalize-email-templates.mjs --non-interactive', {
-        stdio: 'inherit',
-        cwd: REPO_ROOT,
-      });
-    } catch {
-      logInfo('Email template personalization skipped (run manually: npm run email:personalize)');
+    if (!flags.dryRun) {
+      logInfo('');
+      logInfo('Personalizing email templates...');
+      try {
+        const { execSync } = await import('node:child_process');
+        execSync('node scripts/personalize-email-templates.mjs --non-interactive', {
+          stdio: 'inherit',
+          cwd: REPO_ROOT,
+        });
+      } catch {
+        logInfo('Email template personalization skipped (run manually: npm run email:personalize)');
+      }
     }
 
         if (flags.dryRun) {

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -2757,7 +2757,7 @@ async function main() {
       }
     }
 
-        if (flags.dryRun) {
+    if (flags.dryRun) {
       logInfo(
         '[dry-run] finished: no env/state files written; no real API keys or tokens merged by this script.'
       );

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -2742,7 +2742,20 @@ async function main() {
           break;
       }
     }
-    if (flags.dryRun) {
+    // Personalize email templates
+    logInfo('');
+    logInfo('Personalizing email templates...');
+    try {
+      const { execSync } = await import('node:child_process');
+      execSync('node scripts/personalize-email-templates.mjs --non-interactive', {
+        stdio: 'inherit',
+        cwd: REPO_ROOT,
+      });
+    } catch {
+      logInfo('Email template personalization skipped (run manually: npm run email:personalize)');
+    }
+
+        if (flags.dryRun) {
       logInfo(
         '[dry-run] finished: no env/state files written; no real API keys or tokens merged by this script.'
       );

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -183,7 +183,7 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
-enable_confirmations = false
+enable_confirmations = false  # set to true to require email verification on signup
 # If enabled, users will need to reauthenticate or have logged in recently to change their password.
 secure_password_change = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
@@ -192,10 +192,6 @@ max_frequency = "1s"
 otp_length = 6
 # Number of seconds before the email OTP expires (defaults to 1 hour).
 otp_expiry = 3600
-
-# Uncomment to enable signup email confirmation (disabled by default — see docs/EMAIL_TEMPLATES.md)
-# [auth.email]
-# enable_confirmations = true
 
 [auth.email.template.confirmation]
 subject = "Confirm your __PRODUCT_NAME__ account"
@@ -406,3 +402,4 @@ s3_region = "env(S3_REGION)"
 s3_access_key = "env(S3_ACCESS_KEY)"
 # Configures AWS_SECRET_ACCESS_KEY for S3 bucket
 s3_secret_key = "env(S3_SECRET_KEY)"
+

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -198,23 +198,23 @@ otp_expiry = 3600
 # enable_confirmations = true
 
 [auth.email.template.confirmation]
-subject = "Confirm your {{PRODUCT_NAME}} account"
+subject = "Confirm your __PRODUCT_NAME__ account"
 content_path = "./supabase/templates/signup_confirmation.html"
 
 [auth.email.template.recovery]
-subject = "Reset your {{PRODUCT_NAME}} password"
+subject = "Reset your __PRODUCT_NAME__ password"
 content_path = "./supabase/templates/password_reset.html"
 
 [auth.email.template.magic_link]
-subject = "Your {{PRODUCT_NAME}} sign-in link"
+subject = "Your __PRODUCT_NAME__ sign-in link"
 content_path = "./supabase/templates/magic_link.html"
 
 [auth.email.template.email_change]
-subject = "Confirm your new {{PRODUCT_NAME}} email address"
+subject = "Confirm your new __PRODUCT_NAME__ email address"
 content_path = "./supabase/templates/email_change.html"
 
 [auth.email.template.invite]
-subject = "You've been invited to {{PRODUCT_NAME}}"
+subject = "You've been invited to __PRODUCT_NAME__"
 content_path = "./supabase/templates/invite.html"
 
 # Optional: custom SMTP (Resend recommended — see docs/EMAIL_TEMPLATES.md)

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -193,20 +193,41 @@ otp_length = 6
 # Number of seconds before the email OTP expires (defaults to 1 hour).
 otp_expiry = 3600
 
-# Use a production-ready SMTP server
+# Uncomment to enable signup email confirmation (disabled by default — see docs/EMAIL_TEMPLATES.md)
+# [auth.email]
+# enable_confirmations = true
+
+[auth.email.template.confirmation]
+subject = "Confirm your {{PRODUCT_NAME}} account"
+content_path = "./supabase/templates/signup_confirmation.html"
+
+[auth.email.template.recovery]
+subject = "Reset your {{PRODUCT_NAME}} password"
+content_path = "./supabase/templates/password_reset.html"
+
+[auth.email.template.magic_link]
+subject = "Your {{PRODUCT_NAME}} sign-in link"
+content_path = "./supabase/templates/magic_link.html"
+
+[auth.email.template.email_change]
+subject = "Confirm your new {{PRODUCT_NAME}} email address"
+content_path = "./supabase/templates/email_change.html"
+
+[auth.email.template.invite]
+subject = "You've been invited to {{PRODUCT_NAME}}"
+content_path = "./supabase/templates/invite.html"
+
+# Optional: custom SMTP (Resend recommended — see docs/EMAIL_TEMPLATES.md)
 # [auth.email.smtp]
 # enabled = true
-# host = "smtp.sendgrid.net"
+# host = "env(SMTP_HOST)"
 # port = 587
-# user = "apikey"
-# pass = "env(SENDGRID_API_KEY)"
-# admin_email = "admin@email.com"
-# sender_name = "Admin"
+# user = "env(SMTP_USER)"
+# pass = "env(SMTP_PASS)"
+# admin_email = "env(SMTP_ADMIN_EMAIL)"
+# sender_name = "env(SMTP_SENDER_NAME)"
 
-# Uncomment to customize email template
-# [auth.email.template.invite]
-# subject = "You have been invited"
-# content_path = "./supabase/templates/invite.html"
+
 
 [auth.sms]
 # Allow/disallow new user signups via SMS to your project.

--- a/supabase/templates/email_change.html
+++ b/supabase/templates/email_change.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Confirm your new email address — {{PRODUCT_NAME}}</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="background:#f4f4f5;padding:40px 0;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" role="presentation" style="max-width:560px;width:100%;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+        <!-- Header -->
+        <tr>
+          <td style="background:{{BRAND_COLOR}};padding:28px 40px;">
+            <p style="margin:0;color:#ffffff;font-size:18px;font-weight:600;letter-spacing:-0.01em;">{{PRODUCT_NAME}}</p>
+          </td>
+        </tr>
+        <!-- Body -->
+        <tr>
+          <td style="padding:40px;">
+            <h1 style="margin:0 0 16px;font-size:22px;font-weight:600;color:#18181b;letter-spacing:-0.02em;">Confirm your new email address</h1>
+            <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#52525b;">We received a request to update the email address on your {{PRODUCT_NAME}} account. Click the button below to confirm your new email address.</p>
+            <!-- CTA button -->
+            <table cellpadding="0" cellspacing="0" role="presentation">
+              <tr>
+                <td style="border-radius:6px;background:{{BRAND_COLOR}};">
+                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email_change"
+                     style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Confirm new email</a>
+                </td>
+              </tr>
+            </table>
+            <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
+              Or copy this link into your browser:<br>
+              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email_change</span>
+            </p>
+          </td>
+        </tr>
+        <!-- Footer (CAN-SPAM) -->
+        <tr>
+          <td style="padding:20px 40px 28px;border-top:1px solid #f4f4f5;">
+            <p style="margin:0 0 6px;font-size:12px;color:#a1a1aa;line-height:1.5;">
+              This email was sent by {{SENDER_NAME}} on behalf of {{PRODUCT_NAME}}.<br>
+              {{COMPANY_ADDRESS}}
+            </p>
+            <p style="margin:0;font-size:12px;color:#a1a1aa;">
+              Questions? Email <a href="mailto:{{SUPPORT_EMAIL}}" style="color:#a1a1aa;text-decoration:underline;">{{SUPPORT_EMAIL}}</a>.
+              If you didn't request this, you can safely ignore it.
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>

--- a/supabase/templates/email_change.html
+++ b/supabase/templates/email_change.html
@@ -24,14 +24,14 @@
             <table cellpadding="0" cellspacing="0" role="presentation">
               <tr>
                 <td style="border-radius:6px;background:{{BRAND_COLOR}};">
-                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=email_change"
+                  <a href="{{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&amp;type=email_change{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=email_change{{ end }}"
                      style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Confirm new email</a>
                 </td>
               </tr>
             </table>
             <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
               Or copy this link into your browser:<br>
-              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=email_change</span>
+              <span style="word-break:break-all;color:#71717a;">{{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&amp;type=email_change{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=email_change{{ end }}</span>
             </p>
           </td>
         </tr>

--- a/supabase/templates/email_change.html
+++ b/supabase/templates/email_change.html
@@ -24,14 +24,14 @@
             <table cellpadding="0" cellspacing="0" role="presentation">
               <tr>
                 <td style="border-radius:6px;background:{{BRAND_COLOR}};">
-                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email_change"
+                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=email_change"
                      style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Confirm new email</a>
                 </td>
               </tr>
             </table>
             <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
               Or copy this link into your browser:<br>
-              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email_change</span>
+              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=email_change</span>
             </p>
           </td>
         </tr>

--- a/supabase/templates/email_change.txt
+++ b/supabase/templates/email_change.txt
@@ -2,7 +2,7 @@ Confirm your new email address
 
 We received a request to update the email address on your {{PRODUCT_NAME}} account. Click the link below to confirm your new email address.
 
-Confirm new email: {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email_change
+Confirm new email: {{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=email_change{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email_change{{ end }}
 
 ---
 Sent by {{SENDER_NAME}} ({{PRODUCT_NAME}})

--- a/supabase/templates/email_change.txt
+++ b/supabase/templates/email_change.txt
@@ -1,0 +1,10 @@
+Confirm your new email address
+
+We received a request to update the email address on your {{PRODUCT_NAME}} account. Click the link below to confirm your new email address.
+
+Confirm new email: {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email_change
+
+---
+Sent by {{SENDER_NAME}} ({{PRODUCT_NAME}})
+{{COMPANY_ADDRESS}}
+Questions? {{SUPPORT_EMAIL}}

--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -24,14 +24,14 @@
             <table cellpadding="0" cellspacing="0" role="presentation">
               <tr>
                 <td style="border-radius:6px;background:{{BRAND_COLOR}};">
-                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=invite"
+                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=invite"
                      style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Accept invitation</a>
                 </td>
               </tr>
             </table>
             <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
               Or copy this link into your browser:<br>
-              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=invite</span>
+              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=invite</span>
             </p>
           </td>
         </tr>

--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -24,14 +24,14 @@
             <table cellpadding="0" cellspacing="0" role="presentation">
               <tr>
                 <td style="border-radius:6px;background:{{BRAND_COLOR}};">
-                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=invite"
+                  <a href="{{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&amp;type=invite{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=invite{{ end }}"
                      style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Accept invitation</a>
                 </td>
               </tr>
             </table>
             <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
               Or copy this link into your browser:<br>
-              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=invite</span>
+              <span style="word-break:break-all;color:#71717a;">{{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&amp;type=invite{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=invite{{ end }}</span>
             </p>
           </td>
         </tr>

--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>You've been invited to {{PRODUCT_NAME}}</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="background:#f4f4f5;padding:40px 0;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" role="presentation" style="max-width:560px;width:100%;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+        <!-- Header -->
+        <tr>
+          <td style="background:{{BRAND_COLOR}};padding:28px 40px;">
+            <p style="margin:0;color:#ffffff;font-size:18px;font-weight:600;letter-spacing:-0.01em;">{{PRODUCT_NAME}}</p>
+          </td>
+        </tr>
+        <!-- Body -->
+        <tr>
+          <td style="padding:40px;">
+            <h1 style="margin:0 0 16px;font-size:22px;font-weight:600;color:#18181b;letter-spacing:-0.02em;">You've been invited to {{PRODUCT_NAME}}</h1>
+            <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#52525b;">{{SENDER_NAME}} has invited you to join {{PRODUCT_NAME}}. Click the button below to accept your invitation and create your account.</p>
+            <!-- CTA button -->
+            <table cellpadding="0" cellspacing="0" role="presentation">
+              <tr>
+                <td style="border-radius:6px;background:{{BRAND_COLOR}};">
+                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=invite"
+                     style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Accept invitation</a>
+                </td>
+              </tr>
+            </table>
+            <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
+              Or copy this link into your browser:<br>
+              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=invite</span>
+            </p>
+          </td>
+        </tr>
+        <!-- Footer (CAN-SPAM) -->
+        <tr>
+          <td style="padding:20px 40px 28px;border-top:1px solid #f4f4f5;">
+            <p style="margin:0 0 6px;font-size:12px;color:#a1a1aa;line-height:1.5;">
+              This email was sent by {{SENDER_NAME}} on behalf of {{PRODUCT_NAME}}.<br>
+              {{COMPANY_ADDRESS}}
+            </p>
+            <p style="margin:0;font-size:12px;color:#a1a1aa;">
+              Questions? Email <a href="mailto:{{SUPPORT_EMAIL}}" style="color:#a1a1aa;text-decoration:underline;">{{SUPPORT_EMAIL}}</a>.
+              If you didn't request this, you can safely ignore it.
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>

--- a/supabase/templates/invite.txt
+++ b/supabase/templates/invite.txt
@@ -2,7 +2,7 @@ You've been invited to {{PRODUCT_NAME}}
 
 {{SENDER_NAME}} has invited you to join {{PRODUCT_NAME}}. Click the link below to accept your invitation and create your account.
 
-Accept invitation: {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=invite
+Accept invitation: {{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=invite{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=invite{{ end }}
 
 ---
 Sent by {{SENDER_NAME}} ({{PRODUCT_NAME}})

--- a/supabase/templates/invite.txt
+++ b/supabase/templates/invite.txt
@@ -1,0 +1,10 @@
+You've been invited to {{PRODUCT_NAME}}
+
+{{SENDER_NAME}} has invited you to join {{PRODUCT_NAME}}. Click the link below to accept your invitation and create your account.
+
+Accept invitation: {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=invite
+
+---
+Sent by {{SENDER_NAME}} ({{PRODUCT_NAME}})
+{{COMPANY_ADDRESS}}
+Questions? {{SUPPORT_EMAIL}}

--- a/supabase/templates/magic_link.html
+++ b/supabase/templates/magic_link.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Your sign-in link — {{PRODUCT_NAME}}</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="background:#f4f4f5;padding:40px 0;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" role="presentation" style="max-width:560px;width:100%;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+        <!-- Header -->
+        <tr>
+          <td style="background:{{BRAND_COLOR}};padding:28px 40px;">
+            <p style="margin:0;color:#ffffff;font-size:18px;font-weight:600;letter-spacing:-0.01em;">{{PRODUCT_NAME}}</p>
+          </td>
+        </tr>
+        <!-- Body -->
+        <tr>
+          <td style="padding:40px;">
+            <h1 style="margin:0 0 16px;font-size:22px;font-weight:600;color:#18181b;letter-spacing:-0.02em;">Your sign-in link</h1>
+            <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#52525b;">Here's your magic link for {{PRODUCT_NAME}}. Click the button below to sign in. This link expires in 1 hour and can only be used once.</p>
+            <!-- CTA button -->
+            <table cellpadding="0" cellspacing="0" role="presentation">
+              <tr>
+                <td style="border-radius:6px;background:{{BRAND_COLOR}};">
+                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=magiclink"
+                     style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Sign in now</a>
+                </td>
+              </tr>
+            </table>
+            <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
+              Or copy this link into your browser:<br>
+              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=magiclink</span>
+            </p>
+          </td>
+        </tr>
+        <!-- Footer (CAN-SPAM) -->
+        <tr>
+          <td style="padding:20px 40px 28px;border-top:1px solid #f4f4f5;">
+            <p style="margin:0 0 6px;font-size:12px;color:#a1a1aa;line-height:1.5;">
+              This email was sent by {{SENDER_NAME}} on behalf of {{PRODUCT_NAME}}.<br>
+              {{COMPANY_ADDRESS}}
+            </p>
+            <p style="margin:0;font-size:12px;color:#a1a1aa;">
+              Questions? Email <a href="mailto:{{SUPPORT_EMAIL}}" style="color:#a1a1aa;text-decoration:underline;">{{SUPPORT_EMAIL}}</a>.
+              If you didn't request this, you can safely ignore it.
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>

--- a/supabase/templates/magic_link.html
+++ b/supabase/templates/magic_link.html
@@ -24,14 +24,14 @@
             <table cellpadding="0" cellspacing="0" role="presentation">
               <tr>
                 <td style="border-radius:6px;background:{{BRAND_COLOR}};">
-                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=magiclink"
+                  <a href="{{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&amp;type=magiclink{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=magiclink{{ end }}"
                      style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Sign in now</a>
                 </td>
               </tr>
             </table>
             <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
               Or copy this link into your browser:<br>
-              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=magiclink</span>
+              <span style="word-break:break-all;color:#71717a;">{{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&amp;type=magiclink{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=magiclink{{ end }}</span>
             </p>
           </td>
         </tr>

--- a/supabase/templates/magic_link.html
+++ b/supabase/templates/magic_link.html
@@ -24,14 +24,14 @@
             <table cellpadding="0" cellspacing="0" role="presentation">
               <tr>
                 <td style="border-radius:6px;background:{{BRAND_COLOR}};">
-                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=magiclink"
+                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=magiclink"
                      style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Sign in now</a>
                 </td>
               </tr>
             </table>
             <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
               Or copy this link into your browser:<br>
-              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=magiclink</span>
+              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=magiclink</span>
             </p>
           </td>
         </tr>

--- a/supabase/templates/magic_link.txt
+++ b/supabase/templates/magic_link.txt
@@ -2,7 +2,7 @@ Your sign-in link
 
 Here's your magic link for {{PRODUCT_NAME}}. Click the link below to sign in. This link expires in 1 hour and can only be used once.
 
-Sign in now: {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=magiclink
+Sign in now: {{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=magiclink{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=magiclink{{ end }}
 
 ---
 Sent by {{SENDER_NAME}} ({{PRODUCT_NAME}})

--- a/supabase/templates/magic_link.txt
+++ b/supabase/templates/magic_link.txt
@@ -1,0 +1,10 @@
+Your sign-in link
+
+Here's your magic link for {{PRODUCT_NAME}}. Click the link below to sign in. This link expires in 1 hour and can only be used once.
+
+Sign in now: {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=magiclink
+
+---
+Sent by {{SENDER_NAME}} ({{PRODUCT_NAME}})
+{{COMPANY_ADDRESS}}
+Questions? {{SUPPORT_EMAIL}}

--- a/supabase/templates/password_reset.html
+++ b/supabase/templates/password_reset.html
@@ -24,14 +24,14 @@
             <table cellpadding="0" cellspacing="0" role="presentation">
               <tr>
                 <td style="border-radius:6px;background:{{BRAND_COLOR}};">
-                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=recovery"
+                  <a href="{{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&amp;type=recovery{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=recovery{{ end }}"
                      style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Reset my password</a>
                 </td>
               </tr>
             </table>
             <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
               Or copy this link into your browser:<br>
-              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=recovery</span>
+              <span style="word-break:break-all;color:#71717a;">{{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&amp;type=recovery{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=recovery{{ end }}</span>
             </p>
             <p style="margin:20px 0 0;font-size:13px;color:#a1a1aa;">If you didn't request a password reset, you can safely ignore this email — your password will not change.</p>
           </td>

--- a/supabase/templates/password_reset.html
+++ b/supabase/templates/password_reset.html
@@ -24,14 +24,14 @@
             <table cellpadding="0" cellspacing="0" role="presentation">
               <tr>
                 <td style="border-radius:6px;background:{{BRAND_COLOR}};">
-                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery"
+                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=recovery"
                      style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Reset my password</a>
                 </td>
               </tr>
             </table>
             <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
               Or copy this link into your browser:<br>
-              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery</span>
+              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=recovery</span>
             </p>
             <p style="margin:20px 0 0;font-size:13px;color:#a1a1aa;">If you didn't request a password reset, you can safely ignore this email — your password will not change.</p>
           </td>

--- a/supabase/templates/password_reset.html
+++ b/supabase/templates/password_reset.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Reset your password — {{PRODUCT_NAME}}</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="background:#f4f4f5;padding:40px 0;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" role="presentation" style="max-width:560px;width:100%;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+        <!-- Header -->
+        <tr>
+          <td style="background:{{BRAND_COLOR}};padding:28px 40px;">
+            <p style="margin:0;color:#ffffff;font-size:18px;font-weight:600;letter-spacing:-0.01em;">{{PRODUCT_NAME}}</p>
+          </td>
+        </tr>
+        <!-- Body -->
+        <tr>
+          <td style="padding:40px;">
+            <h1 style="margin:0 0 16px;font-size:22px;font-weight:600;color:#18181b;letter-spacing:-0.02em;">Reset your password</h1>
+            <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#52525b;">We received a request to reset the password for your {{PRODUCT_NAME}} account. Click the button below to set a new password. This link expires in 1 hour.</p>
+            <!-- CTA button -->
+            <table cellpadding="0" cellspacing="0" role="presentation">
+              <tr>
+                <td style="border-radius:6px;background:{{BRAND_COLOR}};">
+                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery"
+                     style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Reset my password</a>
+                </td>
+              </tr>
+            </table>
+            <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
+              Or copy this link into your browser:<br>
+              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery</span>
+            </p>
+            <p style="margin:20px 0 0;font-size:13px;color:#a1a1aa;">If you didn't request a password reset, you can safely ignore this email — your password will not change.</p>
+          </td>
+        </tr>
+        <!-- Footer (CAN-SPAM) -->
+        <tr>
+          <td style="padding:20px 40px 28px;border-top:1px solid #f4f4f5;">
+            <p style="margin:0 0 6px;font-size:12px;color:#a1a1aa;line-height:1.5;">
+              This email was sent by {{SENDER_NAME}} on behalf of {{PRODUCT_NAME}}.<br>
+              {{COMPANY_ADDRESS}}
+            </p>
+            <p style="margin:0;font-size:12px;color:#a1a1aa;">
+              Questions? Email <a href="mailto:{{SUPPORT_EMAIL}}" style="color:#a1a1aa;text-decoration:underline;">{{SUPPORT_EMAIL}}</a>.
+              If you didn't request this, you can safely ignore it.
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>

--- a/supabase/templates/password_reset.txt
+++ b/supabase/templates/password_reset.txt
@@ -1,0 +1,12 @@
+Reset your password
+
+We received a request to reset the password for your {{PRODUCT_NAME}} account. Click the link below to set a new password. This link expires in 1 hour.
+
+Reset my password: {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery
+
+If you didn't request a password reset, you can safely ignore this email — your password will not change.
+
+---
+Sent by {{SENDER_NAME}} ({{PRODUCT_NAME}})
+{{COMPANY_ADDRESS}}
+Questions? {{SUPPORT_EMAIL}}

--- a/supabase/templates/password_reset.txt
+++ b/supabase/templates/password_reset.txt
@@ -2,7 +2,7 @@ Reset your password
 
 We received a request to reset the password for your {{PRODUCT_NAME}} account. Click the link below to set a new password. This link expires in 1 hour.
 
-Reset my password: {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery
+Reset my password: {{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=recovery{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery{{ end }}
 
 If you didn't request a password reset, you can safely ignore this email — your password will not change.
 

--- a/supabase/templates/signup_confirmation.html
+++ b/supabase/templates/signup_confirmation.html
@@ -19,7 +19,7 @@
         <tr>
           <td style="padding:40px;">
             <h1 style="margin:0 0 16px;font-size:22px;font-weight:600;color:#18181b;letter-spacing:-0.02em;">Confirm your email address</h1>
-            <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#52525b;">Thanks for signing up! Click the button below to confirm your email address and activate your account. This link expires in 24 hours.</p>
+            <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#52525b;">Thanks for signing up! Click the button below to confirm your email address and activate your account. This link expires in 1 hour.</p>
             <!-- CTA button -->
             <table cellpadding="0" cellspacing="0" role="presentation">
               <tr>

--- a/supabase/templates/signup_confirmation.html
+++ b/supabase/templates/signup_confirmation.html
@@ -24,14 +24,14 @@
             <table cellpadding="0" cellspacing="0" role="presentation">
               <tr>
                 <td style="border-radius:6px;background:{{BRAND_COLOR}};">
-                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=signup"
+                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=signup"
                      style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Confirm your email</a>
                 </td>
               </tr>
             </table>
             <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
               Or copy this link into your browser:<br>
-              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=signup</span>
+              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=signup</span>
             </p>
           </td>
         </tr>

--- a/supabase/templates/signup_confirmation.html
+++ b/supabase/templates/signup_confirmation.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Confirm your email address — {{PRODUCT_NAME}}</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="background:#f4f4f5;padding:40px 0;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" role="presentation" style="max-width:560px;width:100%;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+        <!-- Header -->
+        <tr>
+          <td style="background:{{BRAND_COLOR}};padding:28px 40px;">
+            <p style="margin:0;color:#ffffff;font-size:18px;font-weight:600;letter-spacing:-0.01em;">{{PRODUCT_NAME}}</p>
+          </td>
+        </tr>
+        <!-- Body -->
+        <tr>
+          <td style="padding:40px;">
+            <h1 style="margin:0 0 16px;font-size:22px;font-weight:600;color:#18181b;letter-spacing:-0.02em;">Confirm your email address</h1>
+            <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#52525b;">Thanks for signing up! Click the button below to confirm your email address and activate your account. This link expires in 24 hours.</p>
+            <!-- CTA button -->
+            <table cellpadding="0" cellspacing="0" role="presentation">
+              <tr>
+                <td style="border-radius:6px;background:{{BRAND_COLOR}};">
+                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=signup"
+                     style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Confirm your email</a>
+                </td>
+              </tr>
+            </table>
+            <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
+              Or copy this link into your browser:<br>
+              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=signup</span>
+            </p>
+          </td>
+        </tr>
+        <!-- Footer (CAN-SPAM) -->
+        <tr>
+          <td style="padding:20px 40px 28px;border-top:1px solid #f4f4f5;">
+            <p style="margin:0 0 6px;font-size:12px;color:#a1a1aa;line-height:1.5;">
+              This email was sent by {{SENDER_NAME}} on behalf of {{PRODUCT_NAME}}.<br>
+              {{COMPANY_ADDRESS}}
+            </p>
+            <p style="margin:0;font-size:12px;color:#a1a1aa;">
+              Questions? Email <a href="mailto:{{SUPPORT_EMAIL}}" style="color:#a1a1aa;text-decoration:underline;">{{SUPPORT_EMAIL}}</a>.
+              If you didn't request this, you can safely ignore it.
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>

--- a/supabase/templates/signup_confirmation.html
+++ b/supabase/templates/signup_confirmation.html
@@ -24,14 +24,14 @@
             <table cellpadding="0" cellspacing="0" role="presentation">
               <tr>
                 <td style="border-radius:6px;background:{{BRAND_COLOR}};">
-                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=signup"
+                  <a href="{{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&amp;type=signup{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=signup{{ end }}"
                      style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:500;text-decoration:none;border-radius:6px;">Confirm your email</a>
                 </td>
               </tr>
             </table>
             <p style="margin:24px 0 0;font-size:13px;color:#a1a1aa;">
               Or copy this link into your browser:<br>
-              <span style="word-break:break-all;color:#71717a;">{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=signup</span>
+              <span style="word-break:break-all;color:#71717a;">{{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&amp;type=signup{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&amp;type=signup{{ end }}</span>
             </p>
           </td>
         </tr>

--- a/supabase/templates/signup_confirmation.txt
+++ b/supabase/templates/signup_confirmation.txt
@@ -1,0 +1,10 @@
+Confirm your email address
+
+Thanks for signing up! Click the link below to confirm your email address and activate your account. This link expires in 24 hours.
+
+Confirm your email: {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=signup
+
+---
+Sent by {{SENDER_NAME}} ({{PRODUCT_NAME}})
+{{COMPANY_ADDRESS}}
+Questions? {{SUPPORT_EMAIL}}

--- a/supabase/templates/signup_confirmation.txt
+++ b/supabase/templates/signup_confirmation.txt
@@ -2,7 +2,7 @@ Confirm your email address
 
 Thanks for signing up! Click the link below to confirm your email address and activate your account. This link expires in 1 hour.
 
-Confirm your email: {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=signup
+Confirm your email: {{ if .RedirectTo }}{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=signup{{ else }}{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=signup{{ end }}
 
 ---
 Sent by {{SENDER_NAME}} ({{PRODUCT_NAME}})

--- a/supabase/templates/signup_confirmation.txt
+++ b/supabase/templates/signup_confirmation.txt
@@ -1,6 +1,6 @@
 Confirm your email address
 
-Thanks for signing up! Click the link below to confirm your email address and activate your account. This link expires in 24 hours.
+Thanks for signing up! Click the link below to confirm your email address and activate your account. This link expires in 1 hour.
 
 Confirm your email: {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=signup
 


### PR DESCRIPTION
## Summary

Implements [#284](https://github.com/Artificer-Innovations/BeakerStack/issues/284) — transactional email templates and setup.

### What's included

- **5 HTML email templates** (signup confirmation, password reset, magic link, email change, invite) — table-based layout, inline CSS, CAN-SPAM compliant, with brand placeholder tokens
- **5 plain-text counterparts** for email clients that prefer plain text
- **`/auth/confirm` route** (`AuthConfirmPage.tsx`) — handles token-hash OTP verification via `supabase.auth.verifyOtp()` and redirects to the appropriate page
- **`scripts/personalize-email-templates.mjs`** — interactive CLI to replace `{{PRODUCT_NAME}}`, `{{BRAND_COLOR}}`, etc. with real values; reads defaults from `branding.ts` and `colors.ts`; skips files marked with ejection marker
- **`supabase/config.toml`** — adds `[auth.email.template.*]` blocks for all five templates, commented-out SMTP block (Resend-ready), and a comment about `enable_confirmations`
- **`env.example`** — adds `SMTP_*` placeholder variables
- **`scripts/setup-full.mjs`** — wires `personalize-email-templates.mjs --non-interactive` into the setup flow
- **`docs/EMAIL_TEMPLATES.md`** — comprehensive guide: quick start, enabling signup confirmations, template reference, customization, SMTP setup (Resend), domain verification (SPF/DKIM/DMARC), mobile notes, provider switching

### Design decisions

- Uses token-hash strategy (`/auth/confirm?token_hash=...&type=...`) rather than the older `#access_token` fragment approach — PKCE compatible
- `enable_confirmations` remains `false` by default to avoid breaking existing signups; opt-in documented in the guide
- `AuthConfirmPage` matches `AuthCallbackPage`'s style (Tailwind classes, spinner SVG)
- Ejection marker pattern (`<!-- beakerstack-email:customized -->`) prevents personalization script from overwriting manual customizations

Closes #284