### PR TITLE
test: improve coverage for mobile, shared, and billing

### DIFF
--- a/apps/mobile/__tests__/screens/AuthCallbackScreen.test.tsx
+++ b/apps/mobile/__tests__/screens/AuthCallbackScreen.test.tsx
@@ -26,12 +26,15 @@ jest.mock('../../src/lib/supabase', () => ({
   },
 }));
 
-const mockOnAuthStateChange = (require('../../src/lib/supabase') as {
-  supabase: { auth: { onAuthStateChange: jest.Mock } };
-}).supabase.auth.onAuthStateChange;
+const mockOnAuthStateChange = (
+  require('../../src/lib/supabase') as {
+    supabase: { auth: { onAuthStateChange: jest.Mock } };
+  }
+).supabase.auth.onAuthStateChange;
 
 const mockReset = jest.fn();
 const mockNavigation = { reset: mockReset, navigate: jest.fn() } as any;
+const mockUnsubscribe = jest.fn();
 
 describe('AuthCallbackScreen', () => {
   beforeEach(() => {
@@ -42,7 +45,9 @@ describe('AuthCallbackScreen', () => {
   });
 
   it('shows loading spinner', () => {
-    const { getByText } = render(<AuthCallbackScreen navigation={mockNavigation} />);
+    const { getByText } = render(
+      <AuthCallbackScreen navigation={mockNavigation} />
+    );
     expect(getByText('Completing authentication...')).toBeTruthy();
   });
 
@@ -101,6 +106,62 @@ describe('AuthCallbackScreen', () => {
     jest.useRealTimers();
   });
 
+  it('ignores unrelated auth events until fallback timeout', () => {
+    jest.useFakeTimers();
+    mockOnAuthStateChange.mockImplementation((cb: (event: string) => void) => {
+      cb('TOKEN_REFRESHED');
+      return { data: { subscription: { unsubscribe: mockUnsubscribe } } };
+    });
+
+    render(<AuthCallbackScreen navigation={mockNavigation} />);
+    expect(mockReset).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(mockReset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: 'Login' }],
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('navigates only once when multiple auth events fire', async () => {
+    let authCallback: ((event: string) => void) | undefined;
+    mockOnAuthStateChange.mockImplementation((cb: (event: string) => void) => {
+      authCallback = cb;
+      return { data: { subscription: { unsubscribe: mockUnsubscribe } } };
+    });
+
+    render(<AuthCallbackScreen navigation={mockNavigation} />);
+    authCallback?.('SIGNED_IN');
+    authCallback?.('SIGNED_IN');
+
+    await waitFor(() => expect(mockReset).toHaveBeenCalledTimes(1));
+  });
+
+  it('unsubscribes and clears timeout on unmount', () => {
+    jest.useFakeTimers();
+    mockOnAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: mockUnsubscribe } },
+    });
+
+    const { unmount } = render(
+      <AuthCallbackScreen navigation={mockNavigation} />
+    );
+    unmount();
+
+    expect(mockUnsubscribe).toHaveBeenCalled();
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(mockReset).not.toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+
   it('does not reset after timeout if auth event already handled', () => {
     jest.useFakeTimers();
 
@@ -117,10 +178,10 @@ describe('AuthCallbackScreen', () => {
     });
 
     const dashboardCalls = mockReset.mock.calls.filter(
-      (c) => c[0]?.routes?.[0]?.name === 'Dashboard'
+      c => c[0]?.routes?.[0]?.name === 'Dashboard'
     );
     const loginCalls = mockReset.mock.calls.filter(
-      (c) => c[0]?.routes?.[0]?.name === 'Login'
+      c => c[0]?.routes?.[0]?.name === 'Login'
     );
     expect(dashboardCalls).toHaveLength(1);
     expect(loginCalls).toHaveLength(0);

--- a/apps/mobile/__tests__/screens/DashboardScreen.test.tsx
+++ b/apps/mobile/__tests__/screens/DashboardScreen.test.tsx
@@ -695,6 +695,103 @@ describe('DashboardScreen', () => {
     });
   });
 
+  it('reselects another collection when the selected one is deleted', async () => {
+    const rows = [
+      { id: 'keepcol1', item_count: 0 },
+      { id: 'gonecol2', item_count: 0 },
+    ];
+    (supabase.rpc as jest.Mock).mockImplementation((name: string) => {
+      if (name === 'billing_demo_get_collections') {
+        return Promise.resolve({ data: [...rows], error: null });
+      }
+      if (name === 'billing_demo_delete_collection') {
+        const idx = rows.findIndex(r => r.id === 'gonecol2');
+        if (idx >= 0) rows.splice(idx, 1);
+        return Promise.resolve({ data: null, error: null });
+      }
+      if (name === 'billing_record_usage_event') {
+        return Promise.resolve({ data: null, error: null });
+      }
+      if (name === 'ensure_billing_subscription') {
+        return Promise.resolve({ data: null, error: null });
+      }
+      if (name === 'billing_get_remaining_usage') {
+        return Promise.resolve({
+          data: {
+            used: 0,
+            limit: 30,
+            remaining: 30,
+            periodEnd: '',
+            periodStart: '',
+          },
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: null, error: null });
+    });
+
+    const { getByText, queryByText, getAllByLabelText, getAllByText } =
+      renderWithProviders(<DashboardScreen navigation={mockNavigation} />);
+
+    await waitFor(() => {
+      expect(getByText('gonecol2…')).toBeTruthy();
+    });
+
+    const collectionCards = getAllByText('Collection');
+    fireEvent.press(collectionCards[collectionCards.length - 1]!);
+
+    const deleteButtons = getAllByLabelText('Delete collection');
+    fireEvent.press(deleteButtons[deleteButtons.length - 1]!);
+
+    await waitFor(() => {
+      expect(queryByText(/gonecol2/)).toBeNull();
+      expect(getByText('keepcol1…')).toBeTruthy();
+    });
+  });
+
+  it('shows demo control error message when simulate upgrade rejects with Error', async () => {
+    process.env.EXPO_PUBLIC_BILLING_DEMO_MODE = 'true';
+    (supabase.rpc as jest.Mock).mockImplementation((name: string) => {
+      if (name === 'billing_demo_simulate_upgrade') {
+        return Promise.reject(new Error('Upgrade boom'));
+      }
+      if (name === 'billing_record_usage_event') {
+        return Promise.resolve({ data: null, error: null });
+      }
+      if (name === 'billing_demo_get_collections') {
+        return Promise.resolve({ data: [], error: null });
+      }
+      if (name === 'billing_demo_reset_usage') {
+        return Promise.resolve({ data: null, error: null });
+      }
+      if (name === 'ensure_billing_subscription') {
+        return Promise.resolve({ data: null, error: null });
+      }
+      if (name === 'billing_get_remaining_usage') {
+        return Promise.resolve({
+          data: {
+            used: 0,
+            limit: 30,
+            remaining: 30,
+            periodEnd: '',
+            periodStart: '',
+          },
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: null, error: null });
+    });
+
+    const { getByText } = renderWithProviders(
+      <DashboardScreen navigation={mockNavigation} />
+    );
+
+    await waitFor(() => expect(getByText('To Pro')).toBeTruthy());
+    fireEvent.press(getByText('To Pro'));
+
+    await waitFor(() => expect(getByText('Upgrade boom')).toBeTruthy());
+  });
+
   it('shows Limit on add item when at item cap', async () => {
     const billing = jest.requireMock('@beakerstack/billing') as {
       useFeature: jest.Mock;

--- a/apps/mobile/__tests__/screens/ProfileScreen.test.tsx
+++ b/apps/mobile/__tests__/screens/ProfileScreen.test.tsx
@@ -6,6 +6,8 @@ import { AuthProvider } from '@beakerstack/shared/contexts/AuthContext';
 import { ProfileProvider } from '@beakerstack/shared/contexts/ProfileContext';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { BRANDING } from '@beakerstack/shared/config/branding';
+import { Logger } from '@beakerstack/shared/utils/logger';
+import { loadProfileEditorModule } from '../../src/screens/profileEditorLoader';
 
 // Mock expo-constants
 jest.mock('expo-constants', () => ({
@@ -118,25 +120,56 @@ jest.mock('@beakerstack/shared/components/profile/ProfileStats.native', () => ({
   },
 }));
 
-jest.mock(
-  '@beakerstack/shared/components/profile/ProfileEditor.native',
-  () => ({
-    ProfileEditor: () => {
-      const { View, Text } = require('react-native');
-      return (
-        <View testID='profile-editor'>
-          <Text>Editor</Text>
-        </View>
-      );
-    },
-  })
-);
+jest.mock('@beakerstack/shared/utils/logger', () => ({
+  Logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/screens/profileEditorLoader', () => {
+  const { View, Text, Pressable } = require('react-native');
+  const MockProfileEditor = ({
+    onSuccess,
+    onError,
+  }: {
+    onSuccess?: () => void;
+    onError?: (error: Error) => void;
+  }) => (
+    <View testID='profile-editor'>
+      <Pressable testID='profile-editor-save' onPress={() => onSuccess?.()}>
+        <Text>Save profile</Text>
+      </Pressable>
+      <Pressable
+        testID='profile-editor-fail'
+        onPress={() => onError?.(new Error('save failed'))}
+      >
+        <Text>Fail save</Text>
+      </Pressable>
+    </View>
+  );
+
+  return {
+    loadProfileEditorModule: jest.fn().mockResolvedValue({
+      ProfileEditor: MockProfileEditor,
+    }),
+    __mockProfileEditor: MockProfileEditor,
+  };
+});
 
 describe('ProfileScreen', () => {
   let mockSupabaseClient: Partial<SupabaseClient>;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    const { __mockProfileEditor } = jest.requireMock(
+      '../../src/screens/profileEditorLoader'
+    ) as { __mockProfileEditor: React.ComponentType<unknown> };
+    jest.mocked(loadProfileEditorModule).mockResolvedValue({
+      ProfileEditor: __mockProfileEditor,
+    });
 
     // Mock database query for useProfile hook
     const mockFrom = jest.fn(() => ({
@@ -200,62 +233,53 @@ describe('ProfileScreen', () => {
     );
   };
 
-  it('renders profile screen', async () => {
-    const { getAllByText } = renderWithAuth(
+  it('renders profile screen with header and edit affordance', async () => {
+    const { findByText, getAllByText } = renderWithAuth(
       <ProfileScreen navigation={mockNavigation} />
     );
 
-    // Profile screen should render with header
-    await waitFor(
-      () => {
-        // The header should be visible with "Beaker Stack" text
-        const beakerStackText = getAllByText(BRANDING.displayName);
-        expect(beakerStackText.length).toBeGreaterThan(0);
-      },
-      { timeout: 3000 }
-    );
+    expect(
+      await findByText('Edit Profile', {}, { timeout: 5000 })
+    ).toBeTruthy();
+    const headerTitles = getAllByText(BRANDING.displayName);
+    expect(headerTitles.length).toBeGreaterThan(0);
   });
 
   it('displays user email when authenticated', async () => {
-    const { getAllByText } = renderWithAuth(
+    const { findByText } = renderWithAuth(
       <ProfileScreen navigation={mockNavigation} />
     );
 
-    // The screen should render - check for header or profile content
-    await waitFor(
-      () => {
-        // The header should be visible
-        const beakerStackText = getAllByText(BRANDING.displayName);
-        expect(beakerStackText.length).toBeGreaterThan(0);
-      },
-      { timeout: 3000 }
-    );
+    expect(
+      await findByText('Edit Profile', {}, { timeout: 5000 })
+    ).toBeTruthy();
   });
 
-  it('shows dashboard navigation button', async () => {
-    const { getAllByText } = renderWithAuth(
+  it('shows dashboard navigation button in header', async () => {
+    const { findByText, getAllByText } = renderWithAuth(
       <ProfileScreen navigation={mockNavigation} />
     );
 
-    // Dashboard should appear in the header menu
-    await waitFor(
-      () => {
-        // The header should be rendered with "Beaker Stack" text
-        const beakerStackText = getAllByText(BRANDING.displayName);
-        expect(beakerStackText.length).toBeGreaterThan(0);
-      },
-      { timeout: 3000 }
-    );
+    expect(
+      await findByText('Edit Profile', {}, { timeout: 5000 })
+    ).toBeTruthy();
+    expect(getAllByText(BRANDING.displayName).length).toBeGreaterThan(0);
   });
 
-  it('redirects to home when not authenticated', async () => {
+  it('shows Redirecting before navigating home when not authenticated', async () => {
     mockSupabaseClient.auth!.getSession = jest.fn().mockResolvedValue({
       data: {
         session: null,
       },
     });
 
-    renderWithAuth(<ProfileScreen navigation={mockNavigation} />);
+    const { getByText } = renderWithAuth(
+      <ProfileScreen navigation={mockNavigation} />
+    );
+
+    await waitFor(() => {
+      expect(getByText('Redirecting...')).toBeTruthy();
+    });
 
     await waitFor(
       () => {
@@ -278,30 +302,155 @@ describe('ProfileScreen', () => {
   });
 
   it('shows edit button when profile is loaded', async () => {
+    const { findByText } = renderWithAuth(
+      <ProfileScreen navigation={mockNavigation} />
+    );
+
+    expect(
+      await findByText('Edit Profile', {}, { timeout: 5000 })
+    ).toBeTruthy();
+  });
+
+  it('shows loading editor after entering edit mode', async () => {
+    const { findByText } = renderWithAuth(
+      <ProfileScreen navigation={mockNavigation} />
+    );
+
+    fireEvent.press(await findByText('Edit Profile', {}, { timeout: 5000 }));
+
+    expect(await findByText('Loading editor...')).toBeTruthy();
+  });
+
+  it('shows profile loading state while profile context loads', async () => {
+    mockSupabaseClient.from = jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: jest.fn(() => ({
+          single: jest.fn(() => new Promise(() => {})),
+        })),
+      })),
+    })) as any;
+
     const { getByText } = renderWithAuth(
       <ProfileScreen navigation={mockNavigation} />
     );
 
     await waitFor(() => {
-      expect(getByText('Edit Profile')).toBeTruthy();
+      expect(getByText('Loading profile...')).toBeTruthy();
     });
   });
 
-  it('shows loading editor state after Edit Profile is pressed', async () => {
-    const { getByText, queryByText } = renderWithAuth(
+  it('shows profile error when fetch fails', async () => {
+    mockSupabaseClient.from = jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: jest.fn(() => ({
+          single: jest.fn().mockResolvedValue({
+            data: null,
+            error: { code: '500', message: 'Database unavailable' },
+          }),
+        })),
+      })),
+    })) as any;
+
+    const { findByText } = renderWithAuth(
       <ProfileScreen navigation={mockNavigation} />
     );
 
-    await waitFor(() => {
-      expect(getByText('Edit Profile')).toBeTruthy();
-    });
+    expect(
+      await findByText('Error loading profile', {}, { timeout: 5000 })
+    ).toBeTruthy();
+    expect(await findByText('Database unavailable')).toBeTruthy();
+  });
 
-    fireEvent.press(getByText('Edit Profile'));
+  it('loads ProfileEditor after entering edit mode', async () => {
+    const { findByText, findByTestId } = renderWithAuth(
+      <ProfileScreen navigation={mockNavigation} />
+    );
+
+    fireEvent.press(await findByText('Edit Profile', {}, { timeout: 5000 }));
+
+    expect(
+      await findByTestId('profile-editor', {}, { timeout: 5000 })
+    ).toBeTruthy();
+  });
+
+  it('exits edit mode and refreshes profile after successful save', async () => {
+    const { findByText, findByTestId, queryByTestId } = renderWithAuth(
+      <ProfileScreen navigation={mockNavigation} />
+    );
+
+    fireEvent.press(await findByText('Edit Profile', {}, { timeout: 5000 }));
+    fireEvent.press(
+      await findByTestId('profile-editor-save', {}, { timeout: 5000 })
+    );
+
+    expect(
+      await findByText('Edit Profile', {}, { timeout: 5000 })
+    ).toBeTruthy();
+    expect(queryByTestId('profile-editor')).toBeNull();
+  });
+
+  it('logs when ProfileEditor fails to load', async () => {
+    jest
+      .mocked(loadProfileEditorModule)
+      .mockRejectedValueOnce(new Error('chunk failed'));
+
+    const { findByText } = renderWithAuth(
+      <ProfileScreen navigation={mockNavigation} />
+    );
+
+    fireEvent.press(await findByText('Edit Profile', {}, { timeout: 5000 }));
 
     await waitFor(() => {
-      const loading = queryByText('Loading editor...');
-      const editor = queryByText('Editor');
-      expect(loading || editor).toBeTruthy();
+      expect(Logger.error).toHaveBeenCalledWith(
+        '[ProfileScreen] Failed to load ProfileEditor:',
+        expect.objectContaining({ message: 'chunk failed' })
+      );
     });
+  });
+
+  it('logs profile save errors from ProfileEditor', async () => {
+    const { findByText, findByTestId } = renderWithAuth(
+      <ProfileScreen navigation={mockNavigation} />
+    );
+
+    fireEvent.press(await findByText('Edit Profile', {}, { timeout: 5000 }));
+    fireEvent.press(
+      await findByTestId('profile-editor-fail', {}, { timeout: 5000 })
+    );
+
+    await waitFor(() => {
+      expect(Logger.error).toHaveBeenCalledWith(
+        'Profile save error:',
+        expect.objectContaining({ message: 'save failed' })
+      );
+    });
+  });
+
+  it('shows profile stats when profile data exists', async () => {
+    mockSupabaseClient.from = jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: jest.fn(() => ({
+          single: jest.fn().mockResolvedValue({
+            data: {
+              id: 'profile-1',
+              user_id: 'test-user-id',
+              username: 'testuser',
+              display_name: 'Test User',
+              avatar_url: null,
+              bio: null,
+            },
+            error: null,
+          }),
+        })),
+      })),
+    })) as any;
+
+    const { findByTestId } = renderWithAuth(
+      <ProfileScreen navigation={mockNavigation} />
+    );
+
+    expect(
+      await findByTestId('profile-stats', {}, { timeout: 5000 })
+    ).toBeTruthy();
   });
 });

--- a/apps/mobile/__tests__/screens/billing/BillingScreens.test.tsx
+++ b/apps/mobile/__tests__/screens/billing/BillingScreens.test.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
+import { ActivityIndicator } from 'react-native';
 import { render } from '@testing-library/react-native';
 import { NavigationContainer } from '@react-navigation/native';
+import type { BillingUiStateKind } from '@beakerstack/billing';
+import {
+  useBillingState,
+  usePlan,
+  usePlanCatalog,
+  useUsage,
+} from '@beakerstack/billing';
+import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
 import { BillingOverviewScreen } from '../../../src/screens/billing/BillingOverviewScreen';
 import { BillingUsageScreen } from '../../../src/screens/billing/BillingUsageScreen';
+import { useDemoCollectionCount } from '../../../src/billing/useDemoCollectionCount';
 
 jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
@@ -18,19 +28,11 @@ jest.mock('@react-navigation/native', () => {
 });
 
 jest.mock('@beakerstack/shared/contexts/AuthContext', () => ({
-  useAuthContext: () => ({
-    user: { created_at: '2024-01-15T00:00:00.000Z' },
-  }),
+  useAuthContext: jest.fn(),
 }));
 
 jest.mock('../../../src/billing/useDemoCollectionCount', () => ({
-  useDemoCollectionCount: () => ({
-    count: 1,
-    maxItemsInAnyCollection: 2,
-    loading: false,
-    error: null,
-    refresh: jest.fn(),
-  }),
+  useDemoCollectionCount: jest.fn(),
 }));
 
 jest.mock('@beakerstack/billing/presentation', () => ({
@@ -61,31 +63,10 @@ jest.mock('@beakerstack/billing/presentation', () => ({
 
 jest.mock('@beakerstack/billing', () => ({
   defineBillingConfig: (c: unknown) => c,
-  useBillingState: jest.fn(() => ({
-    kind: 'free',
-    subscription: { status: 'free', stripe_subscription_id: null },
-  })),
-  usePlan: jest.fn(() => ({
-    data: {
-      id: 'beakerstack_free',
-      display_name: 'Free',
-      features: {
-        containers_per_account_max: 2,
-        items_per_container_max: 3,
-        feature_a: false,
-        feature_b: false,
-      },
-      usage_limits: { ai_summarize: 30 },
-    },
-    loading: false,
-  })),
-  usePlanCatalog: jest.fn(() => ({ plans: [] })),
-  useUsage: jest.fn(() => ({
-    used: 1,
-    limit: 30,
-    remaining: 29,
-    loading: false,
-  })),
+  useBillingState: jest.fn(),
+  usePlan: jest.fn(),
+  usePlanCatalog: jest.fn(),
+  useUsage: jest.fn(),
   useBillingConfig: jest.fn(() => ({
     productId: 'beakerstack',
     planFeatureRows: [
@@ -126,25 +107,349 @@ jest.mock('../../../src/lib/supabase', () => ({
   supabase: {},
 }));
 
+const mockUseBillingState = jest.mocked(useBillingState);
+const mockUsePlan = jest.mocked(usePlan);
+const mockUsePlanCatalog = jest.mocked(usePlanCatalog);
+const mockUseUsage = jest.mocked(useUsage);
+const mockUseAuthContext = jest.mocked(useAuthContext);
+const mockUseDemoCollectionCount = jest.mocked(useDemoCollectionCount);
+
+const freePlan = {
+  id: 'beakerstack_free',
+  display_name: 'Free',
+  features: {
+    containers_per_account_max: 2,
+    items_per_container_max: 3,
+    feature_a: false,
+    feature_b: false,
+  },
+  usage_limits: { ai_summarize: 30 },
+};
+
+const proPlan = {
+  id: 'beakerstack_pro',
+  display_name: 'Pro',
+  features: {
+    containers_per_account_max: -1,
+    items_per_container_max: 25,
+    feature_a: true,
+    feature_b: false,
+  },
+  usage_limits: { ai_summarize: 500 },
+};
+
+const defaultSubscription = {
+  status: 'free',
+  stripe_subscription_id: null,
+  current_period_end: null,
+  pending_target_plan_id: null,
+};
+
+function setupOverviewMocks(
+  overrides: {
+    kind?: BillingUiStateKind;
+    subscription?: Partial<typeof defaultSubscription>;
+    plan?: typeof freePlan | typeof proPlan | null;
+    planLoading?: boolean;
+    catalogPlans?: { id: string; display_name: string }[];
+    usage?: {
+      used?: number;
+      limit?: number | null;
+      loading?: boolean;
+    };
+    collections?: {
+      count?: number;
+      maxItemsInAnyCollection?: number;
+      loading?: boolean;
+      error?: Error | null;
+    };
+    authUser?: { created_at?: string } | null;
+  } = {}
+) {
+  const {
+    kind = 'free',
+    subscription = {},
+    plan = freePlan,
+    planLoading = false,
+    catalogPlans = [],
+    usage = {},
+    collections = {},
+    authUser = { created_at: '2024-01-15T00:00:00.000Z' },
+  } = overrides;
+
+  mockUseBillingState.mockReturnValue({
+    kind,
+    subscription: { ...defaultSubscription, ...subscription },
+  } as ReturnType<typeof useBillingState>);
+
+  mockUsePlan.mockReturnValue({
+    data: plan,
+    loading: planLoading,
+  } as ReturnType<typeof usePlan>);
+
+  mockUsePlanCatalog.mockReturnValue({
+    plans: catalogPlans,
+  } as ReturnType<typeof usePlanCatalog>);
+
+  mockUseUsage.mockReturnValue({
+    used: usage.used ?? 1,
+    limit: usage.limit !== undefined ? usage.limit : 30,
+    remaining: 29,
+    loading: usage.loading ?? false,
+  } as ReturnType<typeof useUsage>);
+
+  mockUseDemoCollectionCount.mockReturnValue({
+    count: collections.count ?? 1,
+    maxItemsInAnyCollection: collections.maxItemsInAnyCollection ?? 2,
+    loading: collections.loading ?? false,
+    error: collections.error ?? null,
+    refresh: jest.fn(),
+  });
+
+  mockUseAuthContext.mockReturnValue({
+    user: authUser,
+  } as ReturnType<typeof useAuthContext>);
+}
+
 function renderWithNav(ui: React.ReactElement) {
   return render(<NavigationContainer>{ui}</NavigationContainer>);
 }
 
 describe('BillingOverviewScreen', () => {
-  it('shows plan name and usage stats', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupOverviewMocks();
+  });
+
+  it('shows plan name, usage stats, collections cap, and member since', () => {
     const { getByText } = renderWithNav(<BillingOverviewScreen />);
     expect(getByText(/You're on the Free plan/)).toBeTruthy();
     expect(getByText(/1 of 30 AI summaries/)).toBeTruthy();
     expect(getByText(/1 of 2/)).toBeTruthy();
+    expect(getByText('Jan 2024')).toBeTruthy();
+  });
+
+  it('shows payment failed banner', () => {
+    setupOverviewMocks({ kind: 'payment_failed' });
+    const { getByText } = renderWithNav(<BillingOverviewScreen />);
+    expect(getByText('Payment problem')).toBeTruthy();
+    expect(getByText(/Your last payment did not go through/i)).toBeTruthy();
+    expect(getByText(/Beaker Stack web app/i)).toBeTruthy();
+  });
+
+  it('shows downgrade pending banner with target plan name from catalog', () => {
+    setupOverviewMocks({
+      kind: 'downgrade_pending',
+      subscription: {
+        current_period_end: '2026-07-01T00:00:00.000Z',
+        pending_target_plan_id: 'beakerstack_free',
+      },
+      catalogPlans: [{ id: 'beakerstack_free', display_name: 'Free' }],
+    });
+    const { getByText } = renderWithNav(<BillingOverviewScreen />);
+    expect(getByText('Plan change scheduled')).toBeTruthy();
+    expect(getByText(/You'll be moved to Free on/i)).toBeTruthy();
+  });
+
+  it('shows downgrade pending banner with fallback target when catalog has no match', () => {
+    setupOverviewMocks({
+      kind: 'downgrade_pending',
+      subscription: {
+        current_period_end: '2026-07-01T00:00:00.000Z',
+        pending_target_plan_id: 'beakerstack_unknown',
+      },
+      catalogPlans: [],
+    });
+    const { getByText } = renderWithNav(<BillingOverviewScreen />);
+    expect(getByText(/You'll be moved to your next plan on/i)).toBeTruthy();
+  });
+
+  it('shows cancelled pending banner', () => {
+    setupOverviewMocks({
+      kind: 'cancelled_pending',
+      subscription: {
+        current_period_end: '2026-12-31T00:00:00.000Z',
+      },
+    });
+    const { getByText } = renderWithNav(<BillingOverviewScreen />);
+    expect(getByText('Subscription cancelled')).toBeTruthy();
+    expect(getByText(/Your subscription ends on/i)).toBeTruthy();
+  });
+
+  it('shows ActivityIndicator when billing and plan are loading', () => {
+    setupOverviewMocks({
+      kind: 'loading',
+      planLoading: true,
+      plan: null,
+    });
+    const { UNSAFE_getByType } = renderWithNav(<BillingOverviewScreen />);
+    expect(UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+  });
+
+  it('hides overview banners for loading and no_subscription states', () => {
+    setupOverviewMocks({ kind: 'loading', planLoading: true, plan: null });
+    const loadingTree = renderWithNav(<BillingOverviewScreen />);
+    expect(loadingTree.queryByText('Payment problem')).toBeNull();
+    expect(loadingTree.queryByText('Plan change scheduled')).toBeNull();
+
+    setupOverviewMocks({ kind: 'no_subscription', plan: null });
+    const noSubTree = renderWithNav(<BillingOverviewScreen />);
+    expect(noSubTree.queryByText('Subscription cancelled')).toBeNull();
+  });
+
+  it('shows unlimited usage copy when meter has no limit', () => {
+    setupOverviewMocks({
+      usage: { used: 3, limit: null },
+    });
+    const { getByText } = renderWithNav(<BillingOverviewScreen />);
+    expect(getByText('3 used (unlimited)')).toBeTruthy();
+  });
+
+  it('shows em dash for usage while loading', () => {
+    setupOverviewMocks({
+      usage: { used: 0, limit: 30, loading: true },
+    });
+    const { getAllByText } = renderWithNav(<BillingOverviewScreen />);
+    expect(getAllByText('—').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows unlimited collections when plan cap is -1', () => {
+    setupOverviewMocks({
+      plan: proPlan,
+      collections: { count: 4 },
+    });
+    const { getByText } = renderWithNav(<BillingOverviewScreen />);
+    expect(getByText('4 of unlimited')).toBeTruthy();
+  });
+
+  it('shows em dash for collections while loading', () => {
+    setupOverviewMocks({
+      collections: { count: 0, loading: true },
+    });
+    const { getAllByText } = renderWithNav(<BillingOverviewScreen />);
+    expect(getAllByText('—').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows error copy when collections fail to load', () => {
+    setupOverviewMocks({
+      collections: { count: 0, error: new Error('db') },
+    });
+    const { getByText } = renderWithNav(<BillingOverviewScreen />);
+    expect(getByText('Unable to load')).toBeTruthy();
+  });
+
+  it('treats missing collection count as zero', () => {
+    mockUseDemoCollectionCount.mockReturnValue({
+      count: undefined,
+      maxItemsInAnyCollection: 0,
+      loading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    const { getByText } = renderWithNav(<BillingOverviewScreen />);
+    expect(getByText('0 of 2')).toBeTruthy();
+  });
+
+  it('shows em dash for member since when user has no created_at', () => {
+    setupOverviewMocks({ authUser: {} });
+    const { getByText } = renderWithNav(<BillingOverviewScreen />);
+    expect(getByText('Member since')).toBeTruthy();
+    expect(getByText('—')).toBeTruthy();
+  });
+
+  it('omits plan card when current plan is unavailable', () => {
+    setupOverviewMocks({ plan: null });
+    const { queryByText } = renderWithNav(<BillingOverviewScreen />);
+    expect(queryByText(/You're on the/)).toBeNull();
   });
 });
 
 describe('BillingUsageScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupOverviewMocks();
+  });
+
   it('renders usage meters and boolean plan features from config', () => {
     const { getByText } = renderWithNav(<BillingUsageScreen />);
     expect(getByText('Plan features')).toBeTruthy();
     expect(getByText('AI summarize')).toBeTruthy();
     expect(getByText('Feature A')).toBeTruthy();
     expect(getByText('Not available')).toBeTruthy();
+  });
+
+  it('shows loading copy when plan is unavailable', () => {
+    setupOverviewMocks({ plan: null });
+    const { getByText } = renderWithNav(<BillingUsageScreen />);
+    expect(getByText('Loading plan…')).toBeTruthy();
+  });
+
+  it('shows payment failed banner', () => {
+    setupOverviewMocks({ kind: 'payment_failed' });
+    const { getByText } = renderWithNav(<BillingUsageScreen />);
+    expect(getByText(/Payment failed/i)).toBeTruthy();
+  });
+
+  it('shows demo collection error banner', () => {
+    setupOverviewMocks({
+      collections: { error: new Error('counts failed') },
+    });
+    const { getByText } = renderWithNav(<BillingUsageScreen />);
+    expect(getByText(/Could not load demo collection counts/i)).toBeTruthy();
+  });
+
+  it('shows free-tier usage reset copy', () => {
+    const { getByText } = renderWithNav(<BillingUsageScreen />);
+    expect(
+      getByText(/start of the next calendar month \(free tier\)/i)
+    ).toBeTruthy();
+  });
+
+  it('shows paid usage reset copy for active subscriptions', () => {
+    setupOverviewMocks({
+      subscription: {
+        status: 'active',
+        stripe_subscription_id: 'sub_active',
+      },
+    });
+    const { getByText } = renderWithNav(<BillingUsageScreen />);
+    expect(getByText(/next billing date/i)).toBeTruthy();
+  });
+
+  it('shows unlimited collections limit row on pro plan', () => {
+    setupOverviewMocks({ plan: proPlan });
+    const { getByText } = renderWithNav(<BillingUsageScreen />);
+    expect(getByText('1 of unlimited')).toBeTruthy();
+    expect(getByText('2 of 25')).toBeTruthy();
+  });
+
+  it('shows available boolean features when enabled on plan', () => {
+    setupOverviewMocks({ plan: proPlan });
+    const { getByText } = renderWithNav(<BillingUsageScreen />);
+    expect(getByText('Available')).toBeTruthy();
+  });
+
+  it('shows limit usage at collection cap', () => {
+    setupOverviewMocks({
+      collections: { count: 2, maxItemsInAnyCollection: 1 },
+      plan: freePlan,
+    });
+    const { getByText } = renderWithNav(<BillingUsageScreen />);
+    expect(getByText('2 of 2')).toBeTruthy();
+    expect(getByText('1 of 3')).toBeTruthy();
+  });
+
+  it('shows items limit row as unlimited when per-container cap is -1', () => {
+    setupOverviewMocks({
+      plan: {
+        ...proPlan,
+        features: {
+          ...proPlan.features,
+          items_per_container_max: -1,
+        },
+      },
+    });
+    const { getAllByText } = renderWithNav(<BillingUsageScreen />);
+    expect(getAllByText(/of unlimited/).length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/apps/mobile/__tests__/screens/profileEditorLoader.test.ts
+++ b/apps/mobile/__tests__/screens/profileEditorLoader.test.ts
@@ -1,0 +1,31 @@
+import { loadProfileEditorModule } from '../../src/screens/profileEditorLoader';
+
+function MockProfileEditor() {
+  return null;
+}
+
+jest.mock(
+  '@beakerstack/shared/components/profile/ProfileEditor.native',
+  () => ({
+    ProfileEditor: MockProfileEditor,
+  })
+);
+
+describe('profileEditorLoader', () => {
+  it('resolves the ProfileEditor module', async () => {
+    const module = await loadProfileEditorModule();
+
+    expect(module.ProfileEditor).toBe(MockProfileEditor);
+  });
+
+  it('returns a new promise on each call', async () => {
+    const first = loadProfileEditorModule();
+    const second = loadProfileEditorModule();
+
+    expect(first).not.toBe(second);
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { ProfileEditor: MockProfileEditor },
+      { ProfileEditor: MockProfileEditor },
+    ]);
+  });
+});

--- a/apps/mobile/src/components/dashboard/__tests__/CollectionDetail.test.tsx
+++ b/apps/mobile/src/components/dashboard/__tests__/CollectionDetail.test.tsx
@@ -1,0 +1,427 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { useBillingContext, useFeature, useUsage } from '@beakerstack/billing';
+import { CollectionDetail } from '../CollectionDetail';
+import type { DemoCollectionRow } from '../../../billing/useDemoCollections';
+import { supabase } from '../../../lib/supabase';
+import { randomUuid } from '../../../lib/randomUuid';
+
+jest.mock('@beakerstack/billing', () => ({
+  mapUnknownError: (e: unknown) => ({
+    kind: 'unknown' as const,
+    message:
+      e instanceof Error
+        ? e.message
+        : e &&
+            typeof e === 'object' &&
+            'message' in e &&
+            typeof (e as { message: unknown }).message === 'string'
+          ? (e as { message: string }).message
+          : String(e),
+  }),
+  defineBillingConfig: (c: unknown) => c,
+  useBillingContext: jest.fn(),
+  useUsage: jest.fn(),
+  useFeature: jest.fn(),
+}));
+
+jest.mock('../../../lib/supabase', () => ({
+  supabase: { rpc: jest.fn() },
+}));
+
+jest.mock('../../../lib/fakeAi', () => ({
+  nextFakeAiSummary: () => 'Fake AI summary text',
+}));
+
+jest.mock('../../../lib/randomUuid', () => ({
+  randomUuid: jest.fn(),
+}));
+
+const mockUseBillingContext = jest.mocked(useBillingContext);
+const mockUseUsage = jest.mocked(useUsage);
+const mockUseFeature = jest.mocked(useFeature);
+const mockRpc = jest.mocked(supabase.rpc);
+const mockRandomUuid = jest.mocked(randomUuid);
+
+const hp = {
+  usageExceeded: false,
+  usageLoading: false,
+  refreshUsage: jest.fn().mockResolvedValue(undefined),
+  maxItemsValue: 3 as number | boolean | null,
+  featLoading: false,
+  featureAEnabled: false,
+  featureALoading: false,
+  featureBEnabled: false,
+  featureBLoading: false,
+};
+
+function applyFeatureMock(key: string) {
+  if (key === 'items_per_container_max') {
+    return {
+      value: hp.maxItemsValue,
+      enabled: true,
+      loading: hp.featLoading,
+      error: null,
+    };
+  }
+  if (key === 'feature_a') {
+    return {
+      value: hp.featureAEnabled,
+      enabled: hp.featureAEnabled,
+      loading: hp.featureALoading,
+      error: null,
+    };
+  }
+  if (key === 'feature_b') {
+    return {
+      value: hp.featureBEnabled,
+      enabled: hp.featureBEnabled,
+      loading: hp.featureBLoading,
+      error: null,
+    };
+  }
+  return { value: null, enabled: false, loading: false, error: null };
+}
+
+const makeCollection = (
+  over: Partial<DemoCollectionRow> = {}
+): DemoCollectionRow => ({
+  id: 'col-abc',
+  item_count: 2,
+  ...over,
+});
+
+const onActivity = jest.fn();
+const addItem = jest.fn();
+
+function renderDetail(collection?: DemoCollectionRow, activity = onActivity) {
+  return render(
+    <CollectionDetail
+      collection={collection}
+      addItem={addItem}
+      onActivity={activity}
+    />
+  );
+}
+
+function setupMocks() {
+  mockUseBillingContext.mockReturnValue({
+    config: { productId: 'beakerstack' },
+  } as ReturnType<typeof useBillingContext>);
+
+  mockUseUsage.mockImplementation(
+    () =>
+      ({
+        exceeded: hp.usageExceeded,
+        loading: hp.usageLoading,
+        refresh: hp.refreshUsage,
+      }) as ReturnType<typeof useUsage>
+  );
+
+  mockUseFeature.mockImplementation((key: string) => applyFeatureMock(key));
+}
+
+describe('CollectionDetail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    hp.usageExceeded = false;
+    hp.usageLoading = false;
+    hp.refreshUsage.mockClear().mockResolvedValue(undefined);
+    hp.maxItemsValue = 3;
+    hp.featLoading = false;
+    hp.featureAEnabled = false;
+    hp.featureALoading = false;
+    hp.featureBEnabled = false;
+    hp.featureBLoading = false;
+    mockRpc.mockReset().mockResolvedValue({ data: null, error: null });
+    mockRandomUuid.mockReset();
+    onActivity.mockClear();
+    addItem.mockReset().mockResolvedValue(undefined);
+    setupMocks();
+  });
+
+  it('shows empty state when no collection is selected', () => {
+    const { getByText } = renderDetail(undefined);
+    expect(getByText(/select a collection above/i)).toBeTruthy();
+  });
+
+  it('renders item list when collection has items', () => {
+    const { getByText } = renderDetail(makeCollection({ item_count: 2 }));
+    expect(getByText('Item 1')).toBeTruthy();
+    expect(getByText('Item 2')).toBeTruthy();
+  });
+
+  it('shows "No items yet" when item_count is 0', () => {
+    const { getByText } = renderDetail(makeCollection({ item_count: 0 }));
+    expect(getByText(/no items yet/i)).toBeTruthy();
+  });
+
+  it('shows loading ellipsis in item cap subtitle when feature is loading', () => {
+    hp.featLoading = true;
+    const { getByText } = renderDetail(makeCollection());
+    expect(getByText('…')).toBeTruthy();
+  });
+
+  it('shows unknown cap label when max items feature is not numeric', () => {
+    hp.maxItemsValue = true;
+    const { getByText } = renderDetail(makeCollection({ item_count: 1 }));
+    expect(getByText('1 of … in this collection')).toBeTruthy();
+  });
+
+  it('replaces an existing feature toast when another feature is clicked', () => {
+    hp.featureAEnabled = true;
+    hp.featureBEnabled = true;
+    const { getByText, queryByText } = renderDetail(makeCollection());
+    fireEvent.press(getByText('Feature A'));
+    expect(getByText('Feature A action triggered')).toBeTruthy();
+    fireEvent.press(getByText('Feature B'));
+    expect(queryByText('Feature A action triggered')).toBeNull();
+    expect(getByText('Feature B action triggered')).toBeTruthy();
+  });
+
+  it('summarize success: calls RPC, refreshes usage, shows summary, fires onActivity', async () => {
+    mockRandomUuid.mockReturnValue('key-first');
+    const { getByLabelText, getByText } = renderDetail(
+      makeCollection({ item_count: 1 })
+    );
+
+    fireEvent.press(getByLabelText('Summarize'));
+
+    await waitFor(() => {
+      expect(mockRpc).toHaveBeenCalledWith('billing_record_usage_event', {
+        p_product_id: 'beakerstack',
+        p_event_type: 'ai_summarize',
+        p_quantity: 1,
+        p_metadata: {},
+        p_idempotency_key: 'key-first',
+      });
+    });
+    await waitFor(() => expect(hp.refreshUsage).toHaveBeenCalled());
+    await waitFor(() => expect(getByText('Fake AI summary text')).toBeTruthy());
+    expect(onActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ rpc: 'billing_record_usage_event' })
+    );
+  });
+
+  it('summarize failure: shows error and retains idempotency key on retry', async () => {
+    mockRandomUuid
+      .mockReturnValueOnce('key-first')
+      .mockReturnValueOnce('key-second');
+    mockRpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'RPC failed' },
+    });
+
+    const { getByLabelText, getByText } = renderDetail(
+      makeCollection({ item_count: 1 })
+    );
+    fireEvent.press(getByLabelText('Summarize'));
+
+    await waitFor(() => {
+      expect(getByText('RPC failed')).toBeTruthy();
+    });
+
+    mockRpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'RPC failed again' },
+    });
+    fireEvent.press(getByLabelText('Summarize'));
+
+    await waitFor(() => {
+      expect(mockRpc).toHaveBeenLastCalledWith(
+        'billing_record_usage_event',
+        expect.objectContaining({ p_idempotency_key: 'key-first' })
+      );
+    });
+  });
+
+  it('summarize success: clears idempotency key so next call gets a fresh UUID', async () => {
+    mockRandomUuid.mockReturnValueOnce('key-a').mockReturnValueOnce('key-b');
+
+    const { getByLabelText, getByText } = renderDetail(
+      makeCollection({ item_count: 1 })
+    );
+    fireEvent.press(getByLabelText('Summarize'));
+    await waitFor(() => expect(getByText('Fake AI summary text')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Summarize'));
+    await waitFor(() => {
+      expect(mockRpc).toHaveBeenLastCalledWith(
+        'billing_record_usage_event',
+        expect.objectContaining({ p_idempotency_key: 'key-b' })
+      );
+    });
+  });
+
+  it('disables summarize when usageExceeded', () => {
+    hp.usageExceeded = true;
+    const { getAllByLabelText } = renderDetail(
+      makeCollection({ item_count: 2 })
+    );
+    getAllByLabelText('AI summarize limit reached').forEach(btn => {
+      expect(btn.props.accessibilityState?.disabled ?? btn.props.disabled).toBe(
+        true
+      );
+    });
+  });
+
+  it('disables other summarize buttons while one is in flight', async () => {
+    let resolveRpc!: (v: { data: null; error: null }) => void;
+    mockRpc.mockReturnValue(
+      new Promise(res => {
+        resolveRpc = res;
+      })
+    );
+
+    const { getAllByLabelText } = renderDetail(
+      makeCollection({ item_count: 2 })
+    );
+    fireEvent.press(getAllByLabelText('Summarize')[0]);
+
+    await waitFor(() => {
+      expect(
+        getAllByLabelText('Another item is being summarized')[0].props
+          .accessibilityState
+      ).toEqual(expect.objectContaining({ disabled: true }));
+    });
+
+    fireEvent.press(getAllByLabelText('Another item is being summarized')[0]);
+    expect(mockRpc).toHaveBeenCalledTimes(1);
+
+    resolveRpc({ data: null, error: null });
+  });
+
+  it('resets summaries when collection changes', async () => {
+    mockRandomUuid.mockReturnValue('key-1');
+    const { getByLabelText, getByText, rerender } = renderDetail(
+      makeCollection({ id: 'col-1', item_count: 1 })
+    );
+
+    fireEvent.press(getByLabelText('Summarize'));
+    await waitFor(() => expect(getByText('Fake AI summary text')).toBeTruthy());
+
+    rerender(
+      <CollectionDetail
+        collection={makeCollection({ id: 'col-2', item_count: 1 })}
+        addItem={addItem}
+        onActivity={onActivity}
+      />
+    );
+
+    expect(() => getByText('Fake AI summary text')).toThrow();
+  });
+
+  it('add item: calls addItem and fires onActivity', async () => {
+    const { getByText } = renderDetail(makeCollection({ item_count: 1 }));
+    fireEvent.press(getByText('+ Add item'));
+    await waitFor(() => expect(addItem).toHaveBeenCalledWith('col-abc'));
+    expect(onActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ rpc: 'billing_demo_add_item' })
+    );
+  });
+
+  it('add item button shows limit reached and does not call addItem when at cap', () => {
+    hp.maxItemsValue = 2;
+    const { getByText } = renderDetail(makeCollection({ item_count: 2 }));
+    const label = getByText('Item limit reached');
+    fireEvent.press(label);
+    expect(addItem).not.toHaveBeenCalled();
+  });
+
+  it('does not call summarize RPC when usage is exceeded', () => {
+    hp.usageExceeded = true;
+    const { getAllByLabelText } = renderDetail(
+      makeCollection({ item_count: 1 })
+    );
+    fireEvent.press(getAllByLabelText('AI summarize limit reached')[0]);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('allows add item when plan has unlimited item cap (-1)', () => {
+    hp.maxItemsValue = -1;
+    const { getByText } = renderDetail(makeCollection({ item_count: 99 }));
+    expect(getByText('+ Add item').props.accessibilityState?.disabled).not.toBe(
+      true
+    );
+  });
+
+  it('shows feature toast when feature_a is enabled and clicked', () => {
+    hp.featureAEnabled = true;
+    const { getByText } = renderDetail(makeCollection());
+    fireEvent.press(getByText('Feature A'));
+    expect(getByText('Feature A action triggered')).toBeTruthy();
+  });
+
+  it('shows plan toast when feature_a is disabled and clicked', () => {
+    const { getByText } = renderDetail(makeCollection());
+    fireEvent.press(getByText('Feature A'));
+    expect(
+      getByText(
+        /Feature A is not enabled on your current plan \(useFeature returns false\)/i
+      )
+    ).toBeTruthy();
+  });
+
+  it('shows feature toast when feature_b is enabled and clicked', () => {
+    hp.featureBEnabled = true;
+    const { getByText } = renderDetail(makeCollection());
+    fireEvent.press(getByText('Feature B'));
+    expect(getByText('Feature B action triggered')).toBeTruthy();
+  });
+
+  it('shows plan toast when feature_b is disabled and clicked', () => {
+    const { getByText } = renderDetail(makeCollection());
+    fireEvent.press(getByText('Feature B'));
+    expect(
+      getByText(
+        /Feature B is not enabled on your current plan \(useFeature returns false\)/i
+      )
+    ).toBeTruthy();
+  });
+
+  it('add item error: shows alert when addItem rejects', async () => {
+    addItem.mockRejectedValue(new Error('Insert failed'));
+    const { getByText } = renderDetail(makeCollection({ item_count: 1 }));
+    fireEvent.press(getByText('+ Add item'));
+    await waitFor(() => expect(getByText('Insert failed')).toBeTruthy());
+  });
+
+  it('add item error: shows generic message for non-Error rejections', async () => {
+    addItem.mockRejectedValue('nope');
+    const { getByText } = renderDetail(makeCollection({ item_count: 1 }));
+    fireEvent.press(getByText('+ Add item'));
+    await waitFor(() => expect(getByText('Action failed.')).toBeTruthy());
+  });
+
+  it('disables summarize while usage is loading', () => {
+    hp.usageLoading = true;
+    const { getByLabelText } = renderDetail(makeCollection({ item_count: 1 }));
+    expect(getByLabelText('Summarize').props.accessibilityState).toEqual(
+      expect.objectContaining({ disabled: true })
+    );
+  });
+
+  it('clears pending toast timer on unmount', () => {
+    jest.useFakeTimers();
+    hp.featureAEnabled = true;
+    const { getByText, unmount } = renderDetail(makeCollection());
+    fireEvent.press(getByText('Feature A'));
+    expect(getByText('Feature A action triggered')).toBeTruthy();
+    unmount();
+    expect(() => jest.runOnlyPendingTimers()).not.toThrow();
+    jest.useRealTimers();
+  });
+
+  it('works without onActivity callback', async () => {
+    mockRandomUuid.mockReturnValue('key-solo');
+    const { getByLabelText, getByText } = render(
+      <CollectionDetail
+        collection={makeCollection({ item_count: 1 })}
+        addItem={addItem}
+      />
+    );
+    fireEvent.press(getByLabelText('Summarize'));
+    await waitFor(() => expect(getByText('Fake AI summary text')).toBeTruthy());
+    expect(onActivity).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/components/dashboard/__tests__/dashboardComponents.test.tsx
+++ b/apps/mobile/src/components/dashboard/__tests__/dashboardComponents.test.tsx
@@ -1,0 +1,464 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { Text, View } from 'react-native';
+import { useBillingContext, useFeature, useUsage } from '@beakerstack/billing';
+import { CollectionsGrid } from '../CollectionsGrid';
+import { BooleanFeatureTiles } from '../BooleanFeatureTiles';
+import { UsageStrip } from '../UsageStrip';
+import { AnnotatedPrimitive } from '../AnnotatedPrimitive';
+import type { DemoCollectionRow } from '../../../billing/useDemoCollections';
+import { supabase } from '../../../lib/supabase';
+import { randomUuid } from '../../../lib/randomUuid';
+
+jest.mock('@beakerstack/billing', () => ({
+  defineBillingConfig: (c: unknown) => c,
+  mapUnknownError: (e: unknown) => ({
+    kind: 'unknown' as const,
+    message:
+      e instanceof Error
+        ? e.message
+        : e &&
+            typeof e === 'object' &&
+            'message' in e &&
+            typeof (e as { message: unknown }).message === 'string'
+          ? (e as { message: string }).message
+          : String(e),
+  }),
+  useBillingContext: jest.fn(),
+  useUsage: jest.fn(),
+  useFeature: jest.fn(),
+}));
+
+jest.mock('../../../lib/supabase', () => ({
+  supabase: {
+    rpc: jest.fn(),
+    functions: { invoke: jest.fn() },
+  },
+}));
+
+jest.mock('../../../lib/fakeAi', () => ({
+  nextFakeAiSummary: () => 'Fake summary from test',
+}));
+
+jest.mock('../../../lib/randomUuid', () => ({
+  randomUuid: jest.fn(),
+}));
+
+const mockUseBillingContext = jest.mocked(useBillingContext);
+const mockUseUsage = jest.mocked(useUsage);
+const mockUseFeature = jest.mocked(useFeature);
+const mockRpc = jest.mocked(supabase.rpc);
+const mockInvoke = jest.mocked(supabase.functions.invoke);
+const mockRandomUuid = jest.mocked(randomUuid);
+
+const featureState = {
+  containersValue: 2 as number | boolean | null,
+  containersLoading: false,
+  featureAEnabled: false,
+  featureALoading: false,
+  featureBEnabled: false,
+  featureBLoading: false,
+};
+
+const usageState = {
+  used: 2,
+  limit: 10 as number | null,
+  resetsAt: '2026-06-01T00:00:00.000Z' as string | null,
+  exceeded: false,
+  loading: false,
+  error: null as { message: string } | null,
+  refresh: jest.fn().mockResolvedValue(undefined),
+};
+
+function applyFeatureMock(key: string) {
+  if (key === 'containers_per_account_max') {
+    return {
+      value: featureState.containersValue,
+      enabled: true,
+      loading: featureState.containersLoading,
+      error: null,
+    };
+  }
+  if (key === 'feature_a') {
+    return {
+      value: featureState.featureAEnabled,
+      enabled: featureState.featureAEnabled,
+      loading: featureState.featureALoading,
+      error: null,
+    };
+  }
+  if (key === 'feature_b') {
+    return {
+      value: featureState.featureBEnabled,
+      enabled: featureState.featureBEnabled,
+      loading: featureState.featureBLoading,
+      error: null,
+    };
+  }
+  return { value: null, enabled: false, loading: false, error: null };
+}
+
+const makeCol = (id: string, item_count = 0): DemoCollectionRow => ({
+  id,
+  item_count,
+});
+
+describe('CollectionsGrid', () => {
+  const onSelect = jest.fn();
+  const addCollection = jest.fn();
+  const deleteCollection = jest.fn();
+  const onActivity = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    featureState.containersValue = 2;
+    featureState.containersLoading = false;
+    mockUseFeature.mockImplementation((key: string) => applyFeatureMock(key));
+    onSelect.mockClear();
+    addCollection.mockReset().mockResolvedValue(undefined);
+    deleteCollection.mockReset().mockResolvedValue(undefined);
+    onActivity.mockClear();
+  });
+
+  function renderGrid(
+    collections: DemoCollectionRow[] = [],
+    opts: {
+      loading?: boolean;
+      error?: string | null;
+      selectedId?: string | null;
+    } = {}
+  ) {
+    return render(
+      <CollectionsGrid
+        collections={collections}
+        loading={opts.loading ?? false}
+        error={opts.error ?? null}
+        selectedId={opts.selectedId ?? null}
+        onSelect={onSelect}
+        addCollection={addCollection}
+        deleteCollection={deleteCollection}
+        onActivity={onActivity}
+      />
+    );
+  }
+
+  it('shows empty state when there are no collections', () => {
+    const { getByText } = renderGrid([]);
+    expect(getByText(/no collections yet/i)).toBeTruthy();
+  });
+
+  it('shows loading ellipsis in subtitle', () => {
+    const { getByText } = renderGrid([], { loading: true });
+    expect(getByText('…')).toBeTruthy();
+  });
+
+  it('shows collections error banner', () => {
+    const { getByText } = renderGrid([], { error: 'RPC unavailable' });
+    expect(getByText(/RPC unavailable/)).toBeTruthy();
+    expect(getByText(/demo_billing_mode/i)).toBeTruthy();
+  });
+
+  it('calls onSelect when a collection card is pressed', () => {
+    const { getByText } = renderGrid([makeCol('col-select-me', 2)]);
+    fireEvent.press(getByText('Collection'));
+    expect(onSelect).toHaveBeenCalledWith('col-select-me');
+  });
+
+  it('marks selected collection with accessibility state', () => {
+    const { getByText, UNSAFE_getAllByType } = renderGrid(
+      [makeCol('col-sel')],
+      {
+        selectedId: 'col-sel',
+      }
+    );
+    const { Pressable } = require('react-native');
+    const cards = UNSAFE_getAllByType(Pressable).filter(
+      (p: { props: { accessibilityState?: { selected?: boolean } } }) =>
+        p.props.accessibilityState?.selected === true
+    );
+    expect(cards.length).toBeGreaterThan(0);
+    expect(getByText('col-sel…')).toBeTruthy();
+  });
+
+  it('adds collection and fires onActivity', async () => {
+    const { getByLabelText } = renderGrid([]);
+    fireEvent.press(getByLabelText('New collection'));
+    await waitFor(() => expect(addCollection).toHaveBeenCalled());
+    expect(onActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ rpc: 'billing_demo_add_collection' })
+    );
+  });
+
+  it('shows generic action error for non-Error add failures', async () => {
+    addCollection.mockRejectedValue('nope');
+    const { getByLabelText, getByText } = renderGrid([]);
+    fireEvent.press(getByLabelText('New collection'));
+    await waitFor(() => expect(getByText('Action failed.')).toBeTruthy());
+  });
+
+  it('deletes collection and fires onActivity', async () => {
+    const { getByLabelText } = renderGrid([makeCol('col-del')]);
+    fireEvent.press(getByLabelText('Delete collection'));
+    await waitFor(() =>
+      expect(deleteCollection).toHaveBeenCalledWith('col-del')
+    );
+    expect(onActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ rpc: 'billing_demo_delete_collection' })
+    );
+  });
+
+  it('shows limit reached when at collection cap', () => {
+    featureState.containersValue = 1;
+    const { getByText } = renderGrid([makeCol('only-one')]);
+    expect(getByText('Limit reached')).toBeTruthy();
+  });
+
+  it('shows singular item label when count is 1', () => {
+    const { getByText } = renderGrid([makeCol('col-one', 1)]);
+    expect(getByText(/1 item$/)).toBeTruthy();
+  });
+
+  it('shows unknown cap label when max collections is not numeric', () => {
+    featureState.containersValue = true;
+    const { getByText } = renderGrid([makeCol('col-a')]);
+    expect(getByText('1 of …')).toBeTruthy();
+  });
+
+  it('allows add when plan has unlimited collection cap', () => {
+    featureState.containersValue = -1;
+    const { getByLabelText } = renderGrid(
+      Array.from({ length: 5 }, (_, i) => makeCol(`col-${i}`))
+    );
+    expect(
+      getByLabelText('New collection').props.accessibilityState?.disabled
+    ).not.toBe(true);
+  });
+});
+
+describe('BooleanFeatureTiles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    featureState.featureAEnabled = false;
+    featureState.featureALoading = false;
+    featureState.featureBEnabled = false;
+    featureState.featureBLoading = false;
+    mockUseFeature.mockImplementation((key: string) => applyFeatureMock(key));
+  });
+
+  it('shows disabled feature tiles by default', () => {
+    const { getAllByText } = render(<BooleanFeatureTiles />);
+    expect(getAllByText('✕').length).toBeGreaterThanOrEqual(2);
+    expect(getAllByText('false').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows enabled checkmarks when features are on', () => {
+    featureState.featureAEnabled = true;
+    featureState.featureBEnabled = true;
+    const { getAllByText } = render(<BooleanFeatureTiles />);
+    expect(getAllByText('✓').length).toBeGreaterThanOrEqual(2);
+    expect(getAllByText('true').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows loading placeholders while feature hooks load', () => {
+    featureState.featureALoading = true;
+    featureState.featureBLoading = true;
+    const { getAllByText } = render(<BooleanFeatureTiles />);
+    expect(getAllByText('…').length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('UsageStrip', () => {
+  const onActivity = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    usageState.used = 2;
+    usageState.limit = 10;
+    usageState.resetsAt = '2026-06-01T00:00:00.000Z';
+    usageState.exceeded = false;
+    usageState.loading = false;
+    usageState.error = null;
+    usageState.refresh.mockClear().mockResolvedValue(undefined);
+    mockUseBillingContext.mockReturnValue({
+      config: { productId: 'beakerstack' },
+    } as ReturnType<typeof useBillingContext>);
+    mockUseUsage.mockImplementation(
+      () =>
+        ({
+          used: usageState.used,
+          limit: usageState.limit,
+          remaining:
+            usageState.limit != null
+              ? Math.max(0, usageState.limit - usageState.used)
+              : null,
+          resetsAt: usageState.resetsAt,
+          exceeded: usageState.exceeded,
+          loading: usageState.loading,
+          error: usageState.error,
+          refresh: usageState.refresh,
+        }) as ReturnType<typeof useUsage>
+    );
+    mockRpc.mockReset().mockResolvedValue({ data: null, error: null });
+    mockInvoke.mockReset().mockResolvedValue({ data: null, error: null });
+    mockRandomUuid.mockReturnValue('usage-key-1');
+    onActivity.mockClear();
+    process.env.EXPO_PUBLIC_DEMO_USE_REAL_AI = '';
+  });
+
+  it('shows loading placeholder in cap line', () => {
+    usageState.loading = true;
+    const { getByText } = render(<UsageStrip />);
+    expect(getByText('…')).toBeTruthy();
+  });
+
+  it('shows unlimited usage copy when limit is null', () => {
+    usageState.limit = null;
+    const { getByText } = render(<UsageStrip />);
+    expect(getByText(/unlimited/i)).toBeTruthy();
+  });
+
+  it('shows em dash when resetsAt is missing', () => {
+    usageState.resetsAt = null;
+    const { getByText } = render(<UsageStrip />);
+    expect(getByText(/resets —/)).toBeTruthy();
+  });
+
+  it('shows limit reached UI when exceeded', () => {
+    usageState.exceeded = true;
+    const { getByText, queryByText } = render(<UsageStrip />);
+    expect(getByText('Limit reached')).toBeTruthy();
+    expect(getByText(/Monthly limit reached/i)).toBeTruthy();
+    expect(queryByText('Simulate AI summarize')).toBeNull();
+  });
+
+  it('shows usage hook error', () => {
+    usageState.error = { message: 'Usage unavailable' };
+    const { getByText } = render(<UsageStrip />);
+    expect(getByText('Usage unavailable')).toBeTruthy();
+  });
+
+  it('records usage, shows result, and fires onActivity', async () => {
+    const { getByText } = render(<UsageStrip onActivity={onActivity} />);
+    fireEvent.press(getByText('Simulate AI summarize'));
+
+    await waitFor(() => {
+      expect(mockRpc).toHaveBeenCalledWith(
+        'billing_record_usage_event',
+        expect.objectContaining({
+          p_idempotency_key: 'usage-key-1',
+        })
+      );
+    });
+    await waitFor(() =>
+      expect(getByText('Fake summary from test')).toBeTruthy()
+    );
+    expect(onActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ rpc: 'billing_record_usage_event' })
+    );
+  });
+
+  it('retains idempotency key on RPC failure then retry', async () => {
+    mockRandomUuid
+      .mockReturnValueOnce('retry-key')
+      .mockReturnValueOnce('new-key');
+    mockRpc
+      .mockResolvedValueOnce({ data: null, error: { message: 'cap exceeded' } })
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'cap exceeded' },
+      });
+
+    const { getByText } = render(<UsageStrip />);
+    fireEvent.press(getByText('Simulate AI summarize'));
+    await waitFor(() => expect(getByText('cap exceeded')).toBeTruthy());
+
+    fireEvent.press(getByText('Simulate AI summarize'));
+    await waitFor(() => {
+      expect(mockRpc).toHaveBeenLastCalledWith(
+        'billing_record_usage_event',
+        expect.objectContaining({ p_idempotency_key: 'retry-key' })
+      );
+    });
+  });
+
+  it('uses edge function text when EXPO_PUBLIC_DEMO_USE_REAL_AI is true', async () => {
+    process.env.EXPO_PUBLIC_DEMO_USE_REAL_AI = 'true';
+    mockInvoke.mockResolvedValue({
+      data: { text: '  Edge summary  ' },
+      error: null,
+    });
+
+    const { getByText } = render(<UsageStrip />);
+    fireEvent.press(getByText('Simulate AI summarize'));
+
+    await waitFor(() => expect(getByText('Edge summary')).toBeTruthy());
+  });
+
+  it('falls back to fake AI when edge function invoke throws', async () => {
+    process.env.EXPO_PUBLIC_DEMO_USE_REAL_AI = 'true';
+    mockInvoke.mockRejectedValue(new Error('offline'));
+
+    const { getByText } = render(<UsageStrip />);
+    fireEvent.press(getByText('Simulate AI summarize'));
+
+    await waitFor(() =>
+      expect(getByText('Fake summary from test')).toBeTruthy()
+    );
+  });
+
+  it('falls back when edge function returns an error object', async () => {
+    process.env.EXPO_PUBLIC_DEMO_USE_REAL_AI = 'true';
+    mockInvoke.mockResolvedValue({
+      data: null,
+      error: { message: 'function error' },
+    });
+
+    const { getByText } = render(<UsageStrip />);
+    fireEvent.press(getByText('Simulate AI summarize'));
+
+    await waitFor(() =>
+      expect(getByText('Fake summary from test')).toBeTruthy()
+    );
+  });
+});
+
+describe('AnnotatedPrimitive', () => {
+  it('renders tag without tooltip', () => {
+    const { getByText, queryByText } = render(
+      <AnnotatedPrimitive tag='useUsage' variant='usage'>
+        <Text>Child</Text>
+      </AnnotatedPrimitive>
+    );
+    expect(getByText('useUsage')).toBeTruthy();
+    expect(getByText('Child')).toBeTruthy();
+    expect(queryByText(/—/)).toBeNull();
+  });
+
+  it('renders tooltip and sets accessibility hint', () => {
+    const { getByText, getByLabelText } = render(
+      <AnnotatedPrimitive
+        tag='useFeature'
+        variant='gate'
+        tooltip='Gate explanation'
+      >
+        <View>
+          <Text>Inner</Text>
+        </View>
+      </AnnotatedPrimitive>
+    );
+    expect(getByText('Gate explanation')).toBeTruthy();
+    expect(getByLabelText('useFeature').props.accessibilityHint).toBe(
+      'useFeature — Gate explanation'
+    );
+  });
+
+  it('supports feature variant styling', () => {
+    const { getByText } = render(
+      <AnnotatedPrimitive tag='feature cap' variant='feature'>
+        <Text>Cap block</Text>
+      </AnnotatedPrimitive>
+    );
+    expect(getByText('feature cap')).toBeTruthy();
+    expect(getByText('Cap block')).toBeTruthy();
+  });
+});

--- a/apps/mobile/src/lib/__tests__/randomUuid.test.ts
+++ b/apps/mobile/src/lib/__tests__/randomUuid.test.ts
@@ -14,15 +14,22 @@ describe('randomUuid', () => {
   });
 
   it('returns a valid v4 UUID via getRandomValues when randomUUID is absent (path 2)', () => {
-    const saved = globalThis.crypto?.randomUUID;
+    const savedCrypto = globalThis.crypto;
+    const getRandomValues = jest.fn((arr: Uint8Array) => {
+      for (let i = 0; i < arr.length; i += 1) {
+        arr[i] = (i * 17) % 256;
+      }
+      return arr;
+    });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (globalThis.crypto as any).randomUUID;
+    (globalThis as any).crypto = { getRandomValues };
     try {
-      expect(randomUuid()).toMatch(UUID_RE);
+      const id = randomUuid();
+      expect(getRandomValues).toHaveBeenCalledWith(expect.any(Uint8Array));
+      expect(id).toMatch(UUID_RE);
     } finally {
-      if (saved)
-        (globalThis.crypto as unknown as Record<string, unknown>).randomUUID =
-          saved;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).crypto = savedCrypto;
     }
   });
 

--- a/apps/mobile/src/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen.tsx
@@ -23,6 +23,7 @@ import { ProfileStats } from '@beakerstack/shared/components/profile/ProfileStat
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - Dynamic imports are supported by Metro, TypeScript error is a false positive
 import type { ProfileEditorProps } from '@beakerstack/shared/components/profile/ProfileEditor.native';
+import { loadProfileEditorModule } from './profileEditorLoader';
 let ProfileEditor: React.ComponentType<ProfileEditorProps> | null = null;
 
 type RootStackParamList = {
@@ -89,10 +90,7 @@ function ProfileScreenContent({ navigation: _navigation }: Props) {
   // Lazy load ProfileEditor only when editing
   useEffect(() => {
     if (isEditing && !componentsLoaded) {
-      // Dynamic imports are supported by Metro bundler
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore - TypeScript doesn't recognize dynamic imports but Metro supports them
-      import('@beakerstack/shared/components/profile/ProfileEditor.native')
+      loadProfileEditorModule()
         .then(module => {
           ProfileEditor = module.ProfileEditor;
           setComponentsLoaded(true);

--- a/apps/mobile/src/screens/profileEditorLoader.ts
+++ b/apps/mobile/src/screens/profileEditorLoader.ts
@@ -1,0 +1,18 @@
+import type { ProfileEditorProps } from '@beakerstack/shared/components/profile/ProfileEditor.native';
+import type { ComponentType } from 'react';
+
+export type ProfileEditorModule = {
+  ProfileEditor: ComponentType<ProfileEditorProps>;
+};
+
+/**
+ * Loads ProfileEditor lazily on first call. Uses async require so Metro can
+ * defer the module until edit mode (same timing as dynamic import()).
+ */
+export function loadProfileEditorModule(): Promise<ProfileEditorModule> {
+  return Promise.resolve().then(
+    () =>
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      require('@beakerstack/shared/components/profile/ProfileEditor.native') as ProfileEditorModule
+  );
+}

--- a/apps/web/src/components/dashboard/__tests__/CollectionDetail.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/CollectionDetail.test.tsx
@@ -120,6 +120,48 @@ describe('CollectionDetail', () => {
     expect(screen.getByText(/no items yet/i)).toBeInTheDocument();
   });
 
+  it('shows loading ellipsis in item cap subtitle when feature is loading', () => {
+    hp.featLoading = true;
+    renderDetail(makeCollection());
+    expect(screen.getByText('…')).toBeInTheDocument();
+  });
+
+  it('disables summarize while usage is loading', () => {
+    hp.usageLoading = true;
+    renderDetail(makeCollection({ item_count: 1 }));
+    expect(screen.getByRole('button', { name: /summarize/i })).toBeDisabled();
+  });
+
+  it('allows add item when plan has unlimited item cap (-1)', () => {
+    hp.maxItemsValue = -1;
+    renderDetail(makeCollection({ item_count: 99 }));
+    expect(
+      screen.getByRole('button', { name: /add item/i })
+    ).not.toBeDisabled();
+  });
+
+  it('add item error: shows generic message for non-Error rejections', async () => {
+    const user = userEvent.setup();
+    addItem.mockRejectedValue('nope');
+    renderDetail(makeCollection({ item_count: 1 }));
+
+    await user.click(screen.getByRole('button', { name: /add item/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Action failed.')
+    );
+  });
+
+  it('summarize failure: surfaces RPC error object message', async () => {
+    const user = userEvent.setup();
+    mockRpc.mockResolvedValue({ error: { message: 'Quota exceeded' } });
+    renderDetail(makeCollection({ item_count: 1 }));
+
+    await user.click(screen.getAllByRole('button', { name: /summarize/i })[0]);
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Quota exceeded')
+    );
+  });
+
   it('summarize success: calls RPC, refreshes usage, shows summary, fires onActivity', async () => {
     const user = userEvent.setup();
     renderDetail(makeCollection({ item_count: 1 }));

--- a/packages/billing/src/utils/launchStripeCheckout.native.test.ts
+++ b/packages/billing/src/utils/launchStripeCheckout.native.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { launchStripeCheckout } from './launchStripeCheckout.native.js';
+import * as openExternalUrlModule from './openExternalUrl.native.js';
+
+describe('launchStripeCheckout (native)', () => {
+  const startCheckout = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(openExternalUrlModule, 'openExternalUrl').mockResolvedValue(
+      undefined
+    );
+  });
+
+  it('returns false when checkout session is missing', async () => {
+    startCheckout.mockResolvedValue(null);
+
+    const ok = await launchStripeCheckout(startCheckout, 'plan_pro');
+
+    expect(ok).toBe(false);
+    expect(openExternalUrlModule.openExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns false when checkoutUrl is empty', async () => {
+    startCheckout.mockResolvedValue({ checkoutUrl: '' });
+
+    const ok = await launchStripeCheckout(startCheckout, 'plan_pro');
+
+    expect(ok).toBe(false);
+    expect(openExternalUrlModule.openExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it('opens checkout URL and returns true on success', async () => {
+    startCheckout.mockResolvedValue({
+      checkoutUrl: 'https://checkout.stripe.test/cs_test',
+    });
+
+    const ok = await launchStripeCheckout(
+      startCheckout,
+      'plan_pro',
+      'annual',
+      14
+    );
+
+    expect(ok).toBe(true);
+    expect(startCheckout).toHaveBeenCalledWith('plan_pro', 'annual', 14);
+    expect(openExternalUrlModule.openExternalUrl).toHaveBeenCalledWith(
+      'https://checkout.stripe.test/cs_test'
+    );
+  });
+
+  it('defaults cadence to monthly when omitted', async () => {
+    startCheckout.mockResolvedValue({
+      checkoutUrl: 'https://checkout.stripe.test/cs_test',
+    });
+
+    await launchStripeCheckout(startCheckout, 'plan_starter');
+
+    expect(startCheckout).toHaveBeenCalledWith(
+      'plan_starter',
+      'monthly',
+      undefined
+    );
+  });
+});

--- a/packages/shared-tests/__tests__/components/primitives/Button.native.test.tsx
+++ b/packages/shared-tests/__tests__/components/primitives/Button.native.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Text } from 'react-native';
+import { Button } from '@beakerstack/shared/components/primitives/Button.native';
+
+describe('Button (Native)', () => {
+  it('renders string children and handles press', () => {
+    const onPress = jest.fn();
+    render(<Button onPress={onPress}>Save</Button>);
+    fireEvent.click(screen.getByText('Save'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders loading state without the label text', () => {
+    const { queryByText } = render(<Button loading>Save</Button>);
+    expect(queryByText('Save')).toBeNull();
+  });
+
+  it('does not call onPress when disabled', () => {
+    const onPress = jest.fn();
+    render(
+      <Button disabled onPress={onPress}>
+        Save
+      </Button>
+    );
+    fireEvent.click(screen.getByText('Save'));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('renders non-string children', () => {
+    render(
+      <Button>
+        <Text>Custom child</Text>
+      </Button>
+    );
+    expect(screen.getByText('Custom child')).toBeTruthy();
+  });
+
+  it.each([
+    ['primary', 'Primary'],
+    ['secondary', 'Secondary'],
+    ['destructive', 'Destructive'],
+    ['ghost', 'Ghost'],
+  ] as const)('renders %s variant', (variant, label) => {
+    render(<Button variant={variant}>{label}</Button>);
+    expect(screen.getByText(label)).toBeTruthy();
+  });
+
+  it.each(['sm', 'md', 'lg'] as const)('renders %s size', size => {
+    render(<Button size={size}>Sized</Button>);
+    expect(screen.getByText('Sized')).toBeTruthy();
+  });
+
+  it('supports not full width layout', () => {
+    render(<Button fullWidth={false}>Compact</Button>);
+    expect(screen.getByText('Compact')).toBeTruthy();
+  });
+});

--- a/packages/shared-tests/__tests__/components/profile/AvatarUpload.test.tsx
+++ b/packages/shared-tests/__tests__/components/profile/AvatarUpload.test.tsx
@@ -157,6 +157,52 @@ describe('AvatarUpload', () => {
     expect(screen.getByText('Upload failed')).toBeInTheDocument();
   });
 
+  it('clears preview when upload throws', async () => {
+    mockUploadAvatar.mockRejectedValueOnce(new Error('Upload failed'));
+
+    render(
+      <AvatarUpload
+        currentAvatarUrl={null}
+        onUploadComplete={mockOnUploadComplete}
+        onRemove={mockOnRemove}
+        userId='user-id-1'
+        supabaseClient={mockSupabaseClient}
+      />
+    );
+
+    const fileInput = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    const file = new File(['content'], 'avatar.jpg', { type: 'image/jpeg' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(mockUploadAvatar).toHaveBeenCalledWith(file);
+    });
+    expect(mockOnUploadComplete).not.toHaveBeenCalled();
+  });
+
+  it('does not call onRemove when removeAvatar throws', async () => {
+    mockRemoveAvatar.mockRejectedValueOnce(new Error('Remove failed'));
+
+    render(
+      <AvatarUpload
+        currentAvatarUrl='https://example.com/avatar.jpg'
+        onUploadComplete={mockOnUploadComplete}
+        onRemove={mockOnRemove}
+        userId='user-id-1'
+        supabaseClient={mockSupabaseClient}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Remove'));
+
+    await waitFor(() => {
+      expect(mockRemoveAvatar).toHaveBeenCalled();
+    });
+    expect(mockOnRemove).not.toHaveBeenCalled();
+  });
+
   it('handles remove avatar', async () => {
     render(
       <AvatarUpload

--- a/packages/shared-tests/__tests__/components/profile/ProfileAvatar.native.test.tsx
+++ b/packages/shared-tests/__tests__/components/profile/ProfileAvatar.native.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
+import renderer, { act as rendererAct } from 'react-test-renderer';
+import { Image } from 'react-native';
 import '@testing-library/jest-dom';
 import { Platform } from 'react-native';
 import { ProfileAvatar } from '@beakerstack/shared/components/profile/ProfileAvatar.native';
@@ -176,5 +178,49 @@ describe('ProfileAvatar (Native)', () => {
         value: prev,
       });
     }
+  });
+
+  it('falls back to initials when the image fails to load', () => {
+    const profile: UserProfile = {
+      id: '1',
+      user_id: 'user-1',
+      username: 'testuser',
+      display_name: 'Test User',
+      avatar_url: 'https://example.com/avatar.jpg',
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+    };
+
+    let tree!: renderer.ReactTestRenderer;
+    rendererAct(() => {
+      tree = renderer.create(<ProfileAvatar profile={profile} />);
+    });
+    const image = tree.root.findByType(Image);
+    rendererAct(() => {
+      image.props.onError?.({ nativeEvent: { error: 'Network error' } });
+    });
+    expect(JSON.stringify(tree.toJSON())).toContain('TU');
+  });
+
+  it('handles successful image load event', () => {
+    const profile: UserProfile = {
+      id: '1',
+      user_id: 'user-1',
+      username: 'testuser',
+      display_name: 'Test User',
+      avatar_url: 'https://example.com/avatar.jpg',
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+    };
+
+    let tree!: renderer.ReactTestRenderer;
+    rendererAct(() => {
+      tree = renderer.create(<ProfileAvatar profile={profile} />);
+    });
+    const image = tree.root.findByType(Image);
+    rendererAct(() => {
+      image.props.onLoad?.();
+    });
+    expect(tree.root.findByType(Image)).toBeTruthy();
   });
 });

--- a/packages/shared-tests/__tests__/hooks/useAuth.native.test.ts
+++ b/packages/shared-tests/__tests__/hooks/useAuth.native.test.ts
@@ -819,4 +819,85 @@ describe('Google Sign-In and configureGoogleSignIn', () => {
       'UNKNOWN_CODE'
     );
   });
+
+  it('should request password reset with mobile deep link', async () => {
+    const { mockClient } = createMockSupabaseClient();
+    mockClient.auth.resetPasswordForEmail = jest.fn().mockResolvedValue({
+      data: {},
+      error: null,
+    });
+    const { result } = renderHook(() => useAuth(mockClient));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.requestPasswordReset('user@example.com');
+    });
+
+    expect(mockClient.auth.resetPasswordForEmail).toHaveBeenCalledWith(
+      'user@example.com',
+      { redirectTo: 'beaker-stack://auth/callback' }
+    );
+  });
+
+  it('should throw when native password reset fails', async () => {
+    const { mockClient } = createMockSupabaseClient();
+    mockClient.auth.resetPasswordForEmail = jest.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'Reset failed' },
+    });
+    const { result } = renderHook(() => useAuth(mockClient));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.requestPasswordReset('user@example.com');
+      })
+    ).rejects.toThrow('Reset failed');
+  });
+
+  it('should update password successfully on native', async () => {
+    const { mockClient } = createMockSupabaseClient();
+    mockClient.auth.updateUser = jest.fn().mockResolvedValue({
+      data: { user: {} },
+      error: null,
+    });
+    const { result } = renderHook(() => useAuth(mockClient));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.updatePassword('new-password-1');
+    });
+
+    expect(mockClient.auth.updateUser).toHaveBeenCalledWith({
+      password: 'new-password-1',
+    });
+  });
+
+  it('should throw when native update password fails', async () => {
+    const { mockClient } = createMockSupabaseClient();
+    mockClient.auth.updateUser = jest.fn().mockResolvedValue({
+      data: { user: null },
+      error: { message: 'Weak password' },
+    });
+    const { result } = renderHook(() => useAuth(mockClient));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.updatePassword('short');
+      })
+    ).rejects.toThrow('Weak password');
+  });
 });

--- a/packages/shared-tests/__tests__/hooks/useAuth.test.ts
+++ b/packages/shared-tests/__tests__/hooks/useAuth.test.ts
@@ -384,4 +384,85 @@ describe('useAuth', () => {
     expect(thrownError).not.toBeNull();
     expect(thrownError?.message).toBe(errorMessage);
   });
+
+  it('should request password reset with redirect URL', async () => {
+    const { mockClient } = createMockSupabaseClient();
+    mockClient.auth.resetPasswordForEmail = jest.fn().mockResolvedValue({
+      data: {},
+      error: null,
+    });
+    const { result } = renderHook(() => useAuth(mockClient));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.requestPasswordReset('user@example.com');
+    });
+
+    expect(mockClient.auth.resetPasswordForEmail).toHaveBeenCalledWith(
+      'user@example.com',
+      { redirectTo: 'http://localhost/auth/callback' }
+    );
+  });
+
+  it('should throw when password reset fails', async () => {
+    const { mockClient } = createMockSupabaseClient();
+    mockClient.auth.resetPasswordForEmail = jest.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'Reset failed' },
+    });
+    const { result } = renderHook(() => useAuth(mockClient));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.requestPasswordReset('user@example.com');
+      })
+    ).rejects.toThrow('Reset failed');
+  });
+
+  it('should update password successfully', async () => {
+    const { mockClient } = createMockSupabaseClient();
+    mockClient.auth.updateUser = jest.fn().mockResolvedValue({
+      data: { user: {} },
+      error: null,
+    });
+    const { result } = renderHook(() => useAuth(mockClient));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.updatePassword('new-password-1');
+    });
+
+    expect(mockClient.auth.updateUser).toHaveBeenCalledWith({
+      password: 'new-password-1',
+    });
+  });
+
+  it('should throw when update password fails', async () => {
+    const { mockClient } = createMockSupabaseClient();
+    mockClient.auth.updateUser = jest.fn().mockResolvedValue({
+      data: { user: null },
+      error: { message: 'Weak password' },
+    });
+    const { result } = renderHook(() => useAuth(mockClient));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.updatePassword('short');
+      })
+    ).rejects.toThrow('Weak password');
+  });
 });

--- a/packages/shared-tests/jest.native.cjs
+++ b/packages/shared-tests/jest.native.cjs
@@ -38,6 +38,11 @@ module.exports = {
     '!<rootDir>/packages/shared/src/**/index.web.ts',
     '!<rootDir>/packages/shared/src/**/index.native.ts',
     '!<rootDir>/packages/shared/src/types/**',
+    // Pure data files — auto-generated or constant objects with no logic to test
+    '!<rootDir>/packages/shared/src/generated/**',
+    '!<rootDir>/packages/shared/src/config/legal.ts',
+    '!<rootDir>/packages/shared/src/config/auth.ts',
+    '!<rootDir>/packages/shared/src/constants/auth.ts',
   ],
   coveragePathIgnorePatterns: ['/node_modules/', '/__tests__/', '/__mocks__/'],
   coverageDirectory: path.join(__dirname, 'coverage'),

--- a/packages/shared-tests/jest.web.cjs
+++ b/packages/shared-tests/jest.web.cjs
@@ -37,6 +37,8 @@ module.exports = {
     // Pure data files — auto-generated or constant objects with no logic to test
     '!<rootDir>/packages/shared/src/generated/**',
     '!<rootDir>/packages/shared/src/config/legal.ts',
+    '!<rootDir>/packages/shared/src/config/auth.ts',
+    '!<rootDir>/packages/shared/src/constants/auth.ts',
   ],
   coveragePathIgnorePatterns: ['/node_modules/', '/__tests__/', '/__mocks__/'],
   coverageDirectory: path.join(__dirname, 'coverage'),


### PR DESCRIPTION
## Summary
- Expands unit tests for mobile screens (Profile, billing, dashboard, auth callback) and shared profile/auth primitives to reach high line coverage on targeted modules.
- Adds `profileEditorLoader` so ProfileEditor lazy loading is testable in Jest, plus dedicated tests for `launchStripeCheckout.native`.
- Excludes trivial shared `auth.ts` constant files from shared-test coverage collection.

## Test plan
- [x] `cd apps/mobile && npm test -- --testPathPattern='ProfileScreen|profileEditorLoader|BillingScreens|CollectionDetail|dashboardComponents|AuthCallback|randomUuid|DashboardScreen'`
- [x] `cd packages/shared-tests && npm run test:coverage`
- [x] `cd packages/billing && npm test`
- [ ] Confirm CI passes on this PR (mobile type-check may need follow-up on a few test mocks)