### PR TITLE
fix(web): route password recovery callbacks to reset-password

### DIFF
--- a/apps/web/src/lib/__tests__/passwordRecoveryCallback.test.ts
+++ b/apps/web/src/lib/__tests__/passwordRecoveryCallback.test.ts
@@ -97,4 +97,24 @@ describe('password recovery callback capture', () => {
     expect(mod.hasPasswordRecoveryCallback()).toBe(false);
     expect(memSession['beakerstack:recovery_callback']).toBeUndefined();
   });
+
+  it('clearPasswordRecoveryCallback clears recovery intent after in-module capture', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        hash: '#access_token=tok&type=recovery',
+        search: '',
+      },
+    });
+
+    const mod = await import('../supabase');
+
+    expect(mod.isPasswordRecoveryCallback).toBe(true);
+    expect(mod.hasPasswordRecoveryCallback()).toBe(true);
+
+    mod.clearPasswordRecoveryCallback();
+
+    expect(mod.hasPasswordRecoveryCallback()).toBe(false);
+  });
 });

--- a/apps/web/src/lib/__tests__/passwordRecoveryCallback.test.ts
+++ b/apps/web/src/lib/__tests__/passwordRecoveryCallback.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, afterEach, beforeEach, vi } from 'vitest';
+
+describe('password recovery callback capture', () => {
+  const originalLocation = window.location;
+  const memSession: Record<string, string> = {};
+
+  beforeEach(() => {
+    vi.resetModules();
+    Object.keys(memSession).forEach(k => delete memSession[k]);
+    vi.stubGlobal('sessionStorage', {
+      getItem: (k: string) => (k in memSession ? memSession[k] : null),
+      setItem: (k: string, v: string) => {
+        memSession[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete memSession[k];
+      },
+    });
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'test-anon-key');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('captures type=recovery from hash before createClient', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        hash: '#access_token=tok&type=recovery',
+        search: '',
+      },
+    });
+
+    const mod = await import('../supabase');
+
+    expect(mod.isPasswordRecoveryCallback).toBe(true);
+    expect(mod.hasPasswordRecoveryCallback()).toBe(true);
+    expect(memSession[mod.RECOVERY_CALLBACK_STORAGE_KEY]).toBe('1');
+  });
+
+  it('captures type=recovery from query params', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        hash: '',
+        search: '?type=recovery&access_token=tok',
+      },
+    });
+
+    const mod = await import('../supabase');
+
+    expect(mod.isPasswordRecoveryCallback).toBe(true);
+    expect(mod.hasPasswordRecoveryCallback()).toBe(true);
+  });
+
+  it('reads persisted recovery flag from sessionStorage after hash is cleared', async () => {
+    memSession['beakerstack:recovery_callback'] = '1';
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        hash: '',
+        search: '',
+      },
+    });
+
+    const mod = await import('../supabase');
+
+    expect(mod.isPasswordRecoveryCallback).toBe(false);
+    expect(mod.hasPasswordRecoveryCallback()).toBe(true);
+  });
+
+  it('clearPasswordRecoveryCallback removes persisted flag', async () => {
+    memSession['beakerstack:recovery_callback'] = '1';
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        hash: '',
+        search: '',
+      },
+    });
+
+    const mod = await import('../supabase');
+    mod.clearPasswordRecoveryCallback();
+
+    expect(mod.hasPasswordRecoveryCallback()).toBe(false);
+    expect(memSession['beakerstack:recovery_callback']).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/supabase.ts
+++ b/apps/web/src/lib/supabase.ts
@@ -65,12 +65,11 @@ function capturePasswordRecoveryCallback(): boolean {
   return true;
 }
 
-/** Captured synchronously before createClient so hash clearing does not lose recovery intent */
+/** Snapshot of whether the initial page load was a recovery callback (immutable). */
 export const isPasswordRecoveryCallback = capturePasswordRecoveryCallback();
 
 export function hasPasswordRecoveryCallback(): boolean {
   if (typeof window === 'undefined') return false;
-  if (isPasswordRecoveryCallback) return true;
   try {
     return sessionStorage.getItem(RECOVERY_CALLBACK_STORAGE_KEY) === '1';
   } catch {

--- a/apps/web/src/lib/supabase.ts
+++ b/apps/web/src/lib/supabase.ts
@@ -41,6 +41,52 @@ if (import.meta.env.DEV) {
   );
 }
 
+/** sessionStorage key set when a password-recovery callback URL is detected */
+export const RECOVERY_CALLBACK_STORAGE_KEY = 'beakerstack:recovery_callback';
+
+function readRecoveryTypeFromUrl(): boolean {
+  if (typeof window === 'undefined') return false;
+  const hashParams = new URLSearchParams(window.location.hash.substring(1));
+  const queryParams = new URLSearchParams(window.location.search);
+  return (
+    hashParams.get('type') === 'recovery' ||
+    queryParams.get('type') === 'recovery'
+  );
+}
+
+function capturePasswordRecoveryCallback(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (!readRecoveryTypeFromUrl()) return false;
+  try {
+    sessionStorage.setItem(RECOVERY_CALLBACK_STORAGE_KEY, '1');
+  } catch {
+    // ignore storage errors (private browsing, quota, etc.)
+  }
+  return true;
+}
+
+/** Captured synchronously before createClient so hash clearing does not lose recovery intent */
+export const isPasswordRecoveryCallback = capturePasswordRecoveryCallback();
+
+export function hasPasswordRecoveryCallback(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (isPasswordRecoveryCallback) return true;
+  try {
+    return sessionStorage.getItem(RECOVERY_CALLBACK_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function clearPasswordRecoveryCallback(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    sessionStorage.removeItem(RECOVERY_CALLBACK_STORAGE_KEY);
+  } catch {
+    // ignore storage errors
+  }
+}
+
 export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey);
 
 /**

--- a/apps/web/src/pages/AuthCallbackPage.tsx
+++ b/apps/web/src/pages/AuthCallbackPage.tsx
@@ -6,7 +6,11 @@ import {
   finalizeInviteSignup,
   INVITE_TOKEN_STORAGE_KEY,
 } from './SignupInvitePage';
-import { supabase } from '@/lib/supabase';
+import {
+  supabase,
+  hasPasswordRecoveryCallback,
+  clearPasswordRecoveryCallback,
+} from '@/lib/supabase';
 
 export default function AuthCallbackPage() {
   const [error, setError] = useState<string | null>(null);
@@ -18,6 +22,13 @@ export default function AuthCallbackPage() {
   const delayedLoginTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null
   );
+
+  const navigateToResetPassword = useCallback(() => {
+    if (navigatedRef.current) return;
+    navigatedRef.current = true;
+    clearPasswordRecoveryCallback();
+    navigate('/reset-password', { replace: true });
+  }, [navigate]);
 
   const completeInviteSignup = useCallback(
     (inviteToken: string, userId: string, userEmail: string | undefined) => {
@@ -40,14 +51,28 @@ export default function AuthCallbackPage() {
   useEffect(() => {
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((event) => {
-      if (event === 'PASSWORD_RECOVERY' && !navigatedRef.current) {
-        navigatedRef.current = true;
-        navigate('/reset-password', { replace: true });
+    } = supabase.auth.onAuthStateChange(event => {
+      if (event === 'PASSWORD_RECOVERY') {
+        navigateToResetPassword();
       }
     });
     return () => subscription.unsubscribe();
-  }, [navigate]);
+  }, [navigateToResetPassword]);
+
+  // Fallback when recovery was detected but PASSWORD_RECOVERY never fires (e.g. stale session).
+  useEffect(() => {
+    if (!hasPasswordRecoveryCallback()) return;
+
+    const fallbackTimer = setTimeout(() => {
+      if (navigatedRef.current) return;
+      const a = authRef.current;
+      if (a.user && !a.loading) {
+        navigateToResetPassword();
+      }
+    }, 1500);
+
+    return () => clearTimeout(fallbackTimer);
+  }, [navigateToResetPassword, auth.user, auth.loading]);
 
   useEffect(() => {
     if (navigatedRef.current) return;
@@ -68,10 +93,12 @@ export default function AuthCallbackPage() {
       return () => clearTimeout(t);
     }
 
-    // If type=recovery, let the onAuthStateChange subscription handle navigation
-    // to /reset-password — don't fall through to the auth.user → /dashboard branch.
     const recoveryType = hashParams.get('type') || queryParams.get('type');
-    if (recoveryType === 'recovery') return;
+    const isRecovery =
+      recoveryType === 'recovery' || hasPasswordRecoveryCallback();
+
+    // Never fall through to auth.user → /dashboard during password recovery.
+    if (isRecovery) return;
 
     if (auth.loading) return;
 

--- a/apps/web/src/pages/__tests__/AuthCallbackPage.coverage.test.tsx
+++ b/apps/web/src/pages/__tests__/AuthCallbackPage.coverage.test.tsx
@@ -26,6 +26,21 @@ const auth = vi.hoisted(() => ({
   loading: true,
 }));
 
+const recoveryCallback = vi.hoisted(() => ({ active: false }));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      onAuthStateChange: vi.fn(() => ({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      })),
+    },
+  },
+  isPasswordRecoveryCallback: false,
+  hasPasswordRecoveryCallback: () => recoveryCallback.active,
+  clearPasswordRecoveryCallback: vi.fn(),
+}));
+
 vi.mock('react-router-dom', async () => {
   const actual =
     await vi.importActual<typeof import('react-router-dom')>(
@@ -81,6 +96,7 @@ describe('AuthCallbackPage (URL + auth branches)', () => {
     vi.stubGlobal('localStorage', storageMock(memLocal));
     auth.user = null;
     auth.loading = true;
+    recoveryCallback.active = false;
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: {
@@ -395,5 +411,67 @@ describe('AuthCallbackPage (URL + auth branches)', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(dest, { replace: true });
     expect(memLocal[POST_AUTH_REDIRECT_KEY]).toBeUndefined();
+  });
+
+  it('redirects to reset-password when already signed in with recovery callback flag', async () => {
+    vi.useFakeTimers();
+    recoveryCallback.active = true;
+    auth.loading = false;
+    auth.user = { id: 'u1' };
+
+    render(
+      <MemoryRouter>
+        <AuthCallbackPage />
+      </MemoryRouter>
+    );
+
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      '/dashboard',
+      expect.anything()
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/reset-password', {
+      replace: true,
+    });
+    vi.useRealTimers();
+  });
+
+  it('redirects to reset-password when recovery flag is set and access token hash has no type=recovery', async () => {
+    vi.useFakeTimers();
+    recoveryCallback.active = true;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...original,
+        search: '',
+        hash: '#access_token=tok',
+      },
+    });
+    auth.loading = false;
+    auth.user = { id: 'u1', email: 'a@b.c' };
+
+    render(
+      <MemoryRouter>
+        <AuthCallbackPage />
+      </MemoryRouter>
+    );
+
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      '/dashboard',
+      expect.anything()
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/reset-password', {
+      replace: true,
+    });
+    vi.useRealTimers();
   });
 });

--- a/apps/web/src/pages/__tests__/AuthCallbackPage.test.tsx
+++ b/apps/web/src/pages/__tests__/AuthCallbackPage.test.tsx
@@ -12,6 +12,8 @@ vi.mock('../SignupInvitePage', () => ({
   INVITE_TOKEN_STORAGE_KEY: 'beakerstack_invite_token',
 }));
 
+const recoveryCallback = vi.hoisted(() => ({ active: false }));
+
 // Mock the supabase client
 vi.mock('@/lib/supabase', () => ({
   supabase: {
@@ -24,6 +26,9 @@ vi.mock('@/lib/supabase', () => ({
       })),
     },
   },
+  isPasswordRecoveryCallback: false,
+  hasPasswordRecoveryCallback: () => recoveryCallback.active,
+  clearPasswordRecoveryCallback: vi.fn(),
 }));
 
 // Mock react-router-dom's useNavigate
@@ -83,6 +88,7 @@ describe('AuthCallbackPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    recoveryCallback.active = false;
   });
 
   afterEach(() => {
@@ -98,7 +104,9 @@ describe('AuthCallbackPage', () => {
 
   it('renders loading state initially', () => {
     renderWithProviders(<AuthCallbackPage />);
-    expect(screen.getByText('Completing authentication...')).toBeInTheDocument();
+    expect(
+      screen.getByText('Completing authentication...')
+    ).toBeInTheDocument();
     expect(
       screen.getByText('Please wait while we complete your authentication...')
     ).toBeInTheDocument();
@@ -148,7 +156,9 @@ describe('AuthCallbackPage', () => {
     );
 
     // Should show loading state while processing
-    expect(screen.getByText('Completing authentication...')).toBeInTheDocument();
+    expect(
+      screen.getByText('Completing authentication...')
+    ).toBeInTheDocument();
   });
 
   it('handles case when user is already authenticated', async () => {
@@ -195,7 +205,9 @@ describe('AuthCallbackPage', () => {
     );
 
     // Should show loading state
-    expect(screen.getByText('Completing authentication...')).toBeInTheDocument();
+    expect(
+      screen.getByText('Completing authentication...')
+    ).toBeInTheDocument();
   });
 
   it('navigates to /reset-password when PASSWORD_RECOVERY event fires (not /dashboard)', async () => {
@@ -216,12 +228,12 @@ describe('AuthCallbackPage', () => {
     const { supabase: mockSupabase } = await import('@/lib/supabase');
     // Fire the PASSWORD_RECOVERY event synchronously as soon as the component subscribes,
     // so the timing is deterministic (no need to capture and fire the callback separately).
-    (mockSupabase.auth.onAuthStateChange as ReturnType<typeof vi.fn>).mockImplementation(
-      (cb: (event: string) => void) => {
-        cb('PASSWORD_RECOVERY');
-        return { data: { subscription: { unsubscribe: vi.fn() } } };
-      }
-    );
+    (
+      mockSupabase.auth.onAuthStateChange as ReturnType<typeof vi.fn>
+    ).mockImplementation((cb: (event: string) => void) => {
+      cb('PASSWORD_RECOVERY');
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    });
 
     const mockClient = createMockSupabaseClient();
     render(
@@ -240,7 +252,10 @@ describe('AuthCallbackPage', () => {
       });
     });
     // Must NOT navigate to /dashboard
-    expect(mockNavigate).not.toHaveBeenCalledWith('/dashboard', expect.anything());
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      '/dashboard',
+      expect.anything()
+    );
   });
 
   it('navigates to /dashboard on SIGNED_IN for OAuth (regression)', async () => {
@@ -248,9 +263,11 @@ describe('AuthCallbackPage', () => {
     // Previous test sets a mockImplementation on onAuthStateChange that fires PASSWORD_RECOVERY.
     // vi.clearAllMocks() resets call counts but not implementations, so restore the default here.
     const { supabase: mockSupabase } = await import('@/lib/supabase');
-    (mockSupabase.auth.onAuthStateChange as ReturnType<typeof vi.fn>).mockImplementation(
-      () => ({ data: { subscription: { unsubscribe: vi.fn() } } })
-    );
+    (
+      mockSupabase.auth.onAuthStateChange as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => ({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    }));
 
     const mockUser = {
       id: '1',
@@ -286,17 +303,24 @@ describe('AuthCallbackPage', () => {
     );
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
+        replace: true,
+      });
     });
-    expect(mockNavigate).not.toHaveBeenCalledWith('/reset-password', expect.anything());
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      '/reset-password',
+      expect.anything()
+    );
   });
 
   it('navigates to /dashboard for invite-type callback, not /reset-password (regression)', async () => {
     vi.useRealTimers();
     const { supabase: mockSupabase } = await import('@/lib/supabase');
-    (mockSupabase.auth.onAuthStateChange as ReturnType<typeof vi.fn>).mockImplementation(
-      () => ({ data: { subscription: { unsubscribe: vi.fn() } } })
-    );
+    (
+      mockSupabase.auth.onAuthStateChange as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => ({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    }));
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (window as any).location;
@@ -335,8 +359,143 @@ describe('AuthCallbackPage', () => {
     );
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
+        replace: true,
+      });
     });
-    expect(mockNavigate).not.toHaveBeenCalledWith('/reset-password', expect.anything());
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      '/reset-password',
+      expect.anything()
+    );
+  });
+
+  it('navigates to /reset-password when recovery flag is set and user is already signed in', async () => {
+    vi.useRealTimers();
+    recoveryCallback.active = true;
+
+    const mockUser = {
+      id: '1',
+      email: 'test@example.com',
+      app_metadata: {},
+      user_metadata: {},
+      aud: 'authenticated',
+      created_at: new Date().toISOString(),
+    };
+
+    const mockClient = createMockSupabaseClient();
+    mockClient.auth.getSession = vi.fn().mockResolvedValue({
+      data: {
+        session: {
+          user: mockUser,
+          access_token: 'token',
+        },
+      },
+      error: null,
+    });
+
+    const { supabase: mockSupabase } = await import('@/lib/supabase');
+    (
+      mockSupabase.auth.onAuthStateChange as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => ({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location;
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, search: '', hash: '' },
+      writable: true,
+      configurable: true,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/auth/callback']}>
+        <AuthProvider supabaseClient={mockClient}>
+          <ProfileProvider supabaseClient={mockClient}>
+            <AuthCallbackPage />
+          </ProfileProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(mockNavigate).toHaveBeenCalledWith('/reset-password', {
+          replace: true,
+        });
+      },
+      { timeout: 3000 }
+    );
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      '/dashboard',
+      expect.anything()
+    );
+  });
+
+  it('navigates to /reset-password when recovery flag is set with access token but no type=recovery in hash', async () => {
+    vi.useRealTimers();
+    recoveryCallback.active = true;
+
+    const mockUser = {
+      id: '1',
+      email: 'test@example.com',
+      app_metadata: {},
+      user_metadata: {},
+      aud: 'authenticated',
+      created_at: new Date().toISOString(),
+    };
+
+    const mockClient = createMockSupabaseClient();
+    mockClient.auth.getSession = vi.fn().mockResolvedValue({
+      data: {
+        session: {
+          user: mockUser,
+          access_token: 'token',
+        },
+      },
+      error: null,
+    });
+
+    const { supabase: mockSupabase } = await import('@/lib/supabase');
+    (
+      mockSupabase.auth.onAuthStateChange as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => ({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location;
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...originalLocation,
+        search: '',
+        hash: '#access_token=rec-token',
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/auth/callback']}>
+        <AuthProvider supabaseClient={mockClient}>
+          <ProfileProvider supabaseClient={mockClient}>
+            <AuthCallbackPage />
+          </ProfileProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(mockNavigate).toHaveBeenCalledWith('/reset-password', {
+          replace: true,
+        });
+      },
+      { timeout: 3000 }
+    );
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      '/dashboard',
+      expect.anything()
+    );
   });
 });

--- a/docs/PASSWORD_RESET.md
+++ b/docs/PASSWORD_RESET.md
@@ -26,21 +26,24 @@
 
 The `PASSWORD_RECOVERY` event from `supabase.auth.onAuthStateChange` is the authoritative signal that a user is in a reset session. On web, `AuthCallbackPage` must subscribe to this event **before** the generic `auth.user → /dashboard` check — otherwise an already-established recovery session would route to the dashboard instead of the reset form.
 
-The guard is two-layered:
-1. **Synchronous URL hash check** (`type=recovery`) — prevents the `auth.user` branch from running while the `onAuthStateChange` subscription hasn't fired yet.
-2. **`onAuthStateChange(PASSWORD_RECOVERY)`** — the authoritative redirect to `/reset-password`.
+The guard is layered:
+
+1. **Synchronous URL capture** (`isPasswordRecoveryCallback` in `apps/web/src/lib/supabase.ts`) — reads `type=recovery` before Supabase initializes and clears the hash, persisting intent in `sessionStorage`.
+2. **Synchronous URL hash check** (`type=recovery`) — prevents the `auth.user` branch from running while the `onAuthStateChange` subscription hasn't fired yet.
+3. **`onAuthStateChange(PASSWORD_RECOVERY)`** — the authoritative redirect to `/reset-password`.
+4. **Recovery fallback timer** (~1.5s) — if a session exists but `PASSWORD_RECOVERY` never fires (e.g. stale localStorage session), navigate to `/reset-password` anyway.
 
 ## Supabase redirect URL allowlist
 
 Add these to your Supabase project's **Auth → URL Configuration → Redirect URLs**:
 
-| Environment | URL |
-|---|---|
-| Local dev | `http://localhost:5173/auth/callback` |
-| Staging | `https://staging.beakerstack.com/auth/callback` |
-| Production | `https://app.beakerstack.com/auth/callback` |
+| Environment | URL                                               |
+| ----------- | ------------------------------------------------- |
+| Local dev   | `http://localhost:5173/auth/callback`             |
+| Staging     | `https://staging.beakerstack.com/auth/callback`   |
+| Production  | `https://app.beakerstack.com/auth/callback`       |
 | PR previews | `https://pr-*.beakerstack.com/pr-*/auth/callback` |
-| Mobile | `beaker-stack://auth/callback` |
+| Mobile      | `beaker-stack://auth/callback`                    |
 
 ## Mobile deep-link setup
 


### PR DESCRIPTION
## Summary
- Capture `type=recovery` from the auth callback URL before Supabase initializes and clears the hash, persisting intent in `sessionStorage`.
- Prevent `AuthCallbackPage` from redirecting to `/dashboard` when a recovery callback is detected, with a fallback timer to `/reset-password` when `PASSWORD_RECOVERY` does not fire (e.g. stale localStorage session).
- Add regression tests for existing-session recovery flows and update password reset docs.

## Test plan
- [ ] Sign in on web, request password reset without signing out, open email link in same browser → lands on `/reset-password`
- [ ] Set new password → redirected to `/dashboard`
- [ ] Re-open used reset link → `/forgot-password?expired=1`
- [ ] Google OAuth callback still routes to `/dashboard`
- [x] `npx vitest --run src/pages/__tests__/AuthCallbackPage*.test.tsx src/lib/__tests__/passwordRecoveryCallback.test.ts`