### PR TITLE
Fix merged coverage reporting for lines and Jest branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "test:coverage:waitlist": "cd packages/waitlist && npm run test:coverage",
     "test:coverage:email": "cd packages/email && npm run test:coverage",
     "test:coverage:merge": "node scripts/merge-coverage.js",
-    "test:unit:scripts": "node --test scripts/__tests__/rename-project.test.mjs scripts/__tests__/detect-repo-identity.test.mjs scripts/__tests__/setup-aws-discover.test.mjs scripts/__tests__/setup-dotenv.test.mjs scripts/__tests__/setup-manifest-github-sync.test.mjs scripts/__tests__/setup-secret-input.test.mjs scripts/__tests__/setup-supabase-pick-recommend.test.mjs scripts/__tests__/billing-webhook-guards.test.mjs scripts/__tests__/setup-stripe.test.mjs scripts/__tests__/ensure-stripe-webhook.test.mjs && ./scripts/pr-preview/check-preview-deploy-needed.sh --self-test",
+    "test:unit:scripts": "node --test scripts/__tests__/rename-project.test.mjs scripts/__tests__/detect-repo-identity.test.mjs scripts/__tests__/setup-aws-discover.test.mjs scripts/__tests__/setup-dotenv.test.mjs scripts/__tests__/setup-manifest-github-sync.test.mjs scripts/__tests__/setup-secret-input.test.mjs scripts/__tests__/setup-supabase-pick-recommend.test.mjs scripts/__tests__/billing-webhook-guards.test.mjs scripts/__tests__/setup-stripe.test.mjs scripts/__tests__/ensure-stripe-webhook.test.mjs scripts/__tests__/merge-coverage.test.mjs && ./scripts/pr-preview/check-preview-deploy-needed.sh --self-test",
     "lint": "npm run lint:mobile; npm run lint:web; npm run lint:shared; npm run lint:billing; npm run lint:admin; npm run lint:repo",
     "lint:mobile": "eslint apps/mobile/src --ext ts,tsx --report-unused-disable-directives",
     "lint:web": "eslint apps/web/src --ext ts,tsx --report-unused-disable-directives",

--- a/scripts/__tests__/merge-coverage.test.mjs
+++ b/scripts/__tests__/merge-coverage.test.mjs
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  lineCoverageFromFile,
+  branchCoverageFromFile,
+  aggregateCoverageStats,
+  pct,
+} = require('../lib/coverage-stats.js');
+
+test('lineCoverageFromFile uses native l map when present (Jest)', () => {
+  const stats = lineCoverageFromFile({
+    s: { 0: 1, 1: 0 },
+    l: { 1: 1, 2: 0, 3: 5 },
+  });
+
+  assert.deepEqual(stats, { total: 3, covered: 2 });
+});
+
+test('lineCoverageFromFile derives from statementMap with non-sequential ids (Vitest v8)', () => {
+  const stats = lineCoverageFromFile({
+    s: { 1: 3, 9: 0, 10: 1, 11: 0 },
+    statementMap: {
+      1: { start: { line: 10 } },
+      9: { start: { line: 11 } },
+      10: { start: { line: 12 } },
+      11: { start: { line: 13 } },
+    },
+  });
+
+  assert.deepEqual(stats, { total: 4, covered: 2 });
+});
+
+test('lineCoverageFromFile marks a line covered when any statement on it hits', () => {
+  const stats = lineCoverageFromFile({
+    s: { a: 1, b: 0 },
+    statementMap: {
+      a: { start: { line: 4 } },
+      b: { start: { line: 4 } },
+    },
+  });
+
+  assert.deepEqual(stats, { total: 1, covered: 1 });
+});
+
+test('branchCoverageFromFile flattens multi-path branch hit arrays (Jest)', () => {
+  const stats = branchCoverageFromFile({
+    b: {
+      0: [1, 0],
+      1: [5, 5],
+      2: [0, 0, 3],
+    },
+  });
+
+  assert.deepEqual(stats, { total: 7, covered: 4 });
+});
+
+test('branchCoverageFromFile handles single-path branch arrays (Vitest v8)', () => {
+  const stats = branchCoverageFromFile({
+    b: {
+      0: [2],
+      1: [0],
+    },
+  });
+
+  assert.deepEqual(stats, { total: 2, covered: 1 });
+});
+
+test('aggregateCoverageStats matches statement and line totals for sparse ids', () => {
+  const stats = aggregateCoverageStats({
+    'file.ts': {
+      s: { 1: 1, 9: 0 },
+      b: { 0: [1, 0] },
+      f: { 0: 1 },
+      statementMap: {
+        1: { start: { line: 1 } },
+        9: { start: { line: 2 } },
+      },
+    },
+  });
+
+  assert.equal(stats.statements.total, 2);
+  assert.equal(stats.statements.covered, 1);
+  assert.equal(stats.lines.total, 2);
+  assert.equal(stats.lines.covered, 1);
+  assert.equal(pct(stats.lines), 50);
+});

--- a/scripts/lib/coverage-stats.js
+++ b/scripts/lib/coverage-stats.js
@@ -1,0 +1,134 @@
+'use strict';
+
+/**
+ * Count covered vs total for a hit-count map (statements, functions, lines).
+ * @param {Record<string, number> | undefined} hits
+ */
+function countHits(hits) {
+  const values = Object.values(hits || {});
+  return {
+    total: values.length,
+    covered: values.filter(v => v > 0).length,
+  };
+}
+
+/**
+ * Compute line coverage for an Istanbul coverage file entry.
+ * Vitest v8 omits `l`; derive from statementMap. Jest provides `l` directly.
+ * A line is covered when any statement on that line was executed.
+ *
+ * @param {{ s?: Record<string, number>, l?: Record<string, number>, statementMap?: Record<string, { start: { line: number } }> }} file
+ */
+function lineCoverageFromFile(file) {
+  if (!file || typeof file !== 'object') {
+    return { total: 0, covered: 0 };
+  }
+
+  if (file.l && Object.keys(file.l).length > 0) {
+    return countHits(file.l);
+  }
+
+  if (!file.s || !file.statementMap) {
+    return { total: 0, covered: 0 };
+  }
+
+  /** @type {Map<number, boolean>} */
+  const lineHits = new Map();
+  for (const [stmtId, loc] of Object.entries(file.statementMap)) {
+    const line = loc.start.line;
+    if (!lineHits.has(line)) {
+      lineHits.set(line, false);
+    }
+    if (file.s[stmtId] > 0) {
+      lineHits.set(line, true);
+    }
+  }
+
+  const hits = [...lineHits.values()];
+  return {
+    total: hits.length,
+    covered: hits.filter(Boolean).length,
+  };
+}
+
+/**
+ * Count branch coverage for an Istanbul coverage file entry.
+ * Each branch location maps to an array of hit counts (one per path).
+ *
+ * @param {{ b?: Record<string, number | number[]> }} file
+ */
+function branchCoverageFromFile(file) {
+  const branchValues = Object.values(file?.b || {});
+  let total = 0;
+  let covered = 0;
+
+  for (const hits of branchValues) {
+    if (Array.isArray(hits)) {
+      total += hits.length;
+      covered += hits.filter(h => h > 0).length;
+    } else {
+      total += 1;
+      if (hits > 0) {
+        covered += 1;
+      }
+    }
+  }
+
+  return { total, covered };
+}
+
+/**
+ * @param {{ s?: Record<string, number>, b?: Record<string, number[]>, f?: Record<string, number>, l?: Record<string, number>, statementMap?: Record<string, { start: { line: number } }> }} file
+ */
+function fileCoverageStats(file) {
+  if (!file || typeof file !== 'object' || !file.s) {
+    return null;
+  }
+
+  const statements = countHits(file.s);
+  const functions = countHits(file.f);
+  const lines = lineCoverageFromFile(file);
+  const branches = branchCoverageFromFile(file);
+
+  return { statements, branches, functions, lines };
+}
+
+/**
+ * @param {Record<string, unknown>} coverageData
+ */
+function aggregateCoverageStats(coverageData) {
+  const stats = {
+    statements: { total: 0, covered: 0 },
+    branches: { total: 0, covered: 0 },
+    functions: { total: 0, covered: 0 },
+    lines: { total: 0, covered: 0 },
+  };
+
+  for (const file of Object.values(coverageData)) {
+    const fileStats = fileCoverageStats(file);
+    if (!fileStats) {
+      continue;
+    }
+
+    for (const key of Object.keys(stats)) {
+      stats[key].total += fileStats[key].total;
+      stats[key].covered += fileStats[key].covered;
+    }
+  }
+
+  return stats;
+}
+
+/** @param {{ total: number, covered: number }} metric */
+function pct(metric) {
+  return metric.total > 0 ? (metric.covered / metric.total) * 100 : 0;
+}
+
+module.exports = {
+  countHits,
+  lineCoverageFromFile,
+  branchCoverageFromFile,
+  fileCoverageStats,
+  aggregateCoverageStats,
+  pct,
+};

--- a/scripts/merge-coverage.js
+++ b/scripts/merge-coverage.js
@@ -13,6 +13,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { aggregateCoverageStats, pct } = require('./lib/coverage-stats');
 
 const coverageDirs = [
   { name: 'web', path: 'apps/web/coverage' },
@@ -34,14 +35,12 @@ if (!fs.existsSync(outputDir)) {
 
 // Read coverage-final.json from each source
 const coverageData = {};
-let totalStatements = 0;
-let totalBranches = 0;
-let totalFunctions = 0;
-let totalLines = 0;
-let coveredStatements = 0;
-let coveredBranches = 0;
-let coveredFunctions = 0;
-let coveredLines = 0;
+const totalStats = {
+  statements: { total: 0, covered: 0 },
+  branches: { total: 0, covered: 0 },
+  functions: { total: 0, covered: 0 },
+  lines: { total: 0, covered: 0 },
+};
 
 coverageDirs.forEach(({ name, path: coveragePath }) => {
   const coverageFile = path.join(
@@ -56,26 +55,11 @@ coverageDirs.forEach(({ name, path: coveragePath }) => {
       const data = JSON.parse(fs.readFileSync(coverageFile, 'utf8'));
       coverageData[name] = data;
 
-      // Calculate totals
-      Object.values(data).forEach(file => {
-        if (file && typeof file === 'object' && file.s) {
-          totalStatements += Object.keys(file.s).length;
-          totalBranches += Object.keys(file.b || {}).length;
-          totalFunctions += Object.keys(file.f || {}).length;
-          totalLines += Object.keys(file.statementMap || {}).length;
-
-          coveredStatements += Object.values(file.s).filter(v => v > 0).length;
-          coveredBranches += Object.values(file.b || {}).filter(
-            v => v > 0
-          ).length;
-          coveredFunctions += Object.values(file.f || {}).filter(
-            v => v > 0
-          ).length;
-          coveredLines += Object.values(file.statementMap || {})
-            .map((_, i) => (file.s[i] > 0 ? 1 : 0))
-            .filter(v => v > 0).length;
-        }
-      });
+      const packageStats = aggregateCoverageStats(data);
+      for (const key of Object.keys(totalStats)) {
+        totalStats[key].total += packageStats[key].total;
+        totalStats[key].covered += packageStats[key].covered;
+      }
 
       console.log(`✓ Loaded coverage from ${name}`);
     } catch (error) {
@@ -91,90 +75,34 @@ coverageDirs.forEach(({ name, path: coveragePath }) => {
   }
 });
 
-// Calculate percentages
-const statementsPct =
-  totalStatements > 0 ? (coveredStatements / totalStatements) * 100 : 0;
-const branchesPct =
-  totalBranches > 0 ? (coveredBranches / totalBranches) * 100 : 0;
-const functionsPct =
-  totalFunctions > 0 ? (coveredFunctions / totalFunctions) * 100 : 0;
-const linesPct = totalLines > 0 ? (coveredLines / totalLines) * 100 : 0;
+const statementsPct = pct(totalStats.statements);
+const branchesPct = pct(totalStats.branches);
+const functionsPct = pct(totalStats.functions);
+const linesPct = pct(totalStats.lines);
 
 // Create summary
 const summary = {
   total: {
-    statements: {
-      total: totalStatements,
-      covered: coveredStatements,
-      pct: statementsPct,
-    },
-    branches: {
-      total: totalBranches,
-      covered: coveredBranches,
-      pct: branchesPct,
-    },
-    functions: {
-      total: totalFunctions,
-      covered: coveredFunctions,
-      pct: functionsPct,
-    },
-    lines: { total: totalLines, covered: coveredLines, pct: linesPct },
+    statements: { ...totalStats.statements, pct: statementsPct },
+    branches: { ...totalStats.branches, pct: branchesPct },
+    functions: { ...totalStats.functions, pct: functionsPct },
+    lines: { ...totalStats.lines, pct: linesPct },
   },
   byPackage: {},
 };
 
 // Calculate per-package stats
 Object.entries(coverageData).forEach(([name, data]) => {
-  let pkgStatements = 0;
-  let pkgBranches = 0;
-  let pkgFunctions = 0;
-  let pkgLines = 0;
-  let pkgCoveredStatements = 0;
-  let pkgCoveredBranches = 0;
-  let pkgCoveredFunctions = 0;
-  let pkgCoveredLines = 0;
-
-  Object.values(data).forEach(file => {
-    if (file && typeof file === 'object' && file.s) {
-      pkgStatements += Object.keys(file.s).length;
-      pkgBranches += Object.keys(file.b || {}).length;
-      pkgFunctions += Object.keys(file.f || {}).length;
-      pkgLines += Object.keys(file.statementMap || {}).length;
-
-      pkgCoveredStatements += Object.values(file.s).filter(v => v > 0).length;
-      pkgCoveredBranches += Object.values(file.b || {}).filter(
-        v => v > 0
-      ).length;
-      pkgCoveredFunctions += Object.values(file.f || {}).filter(
-        v => v > 0
-      ).length;
-      pkgCoveredLines += Object.values(file.statementMap || {})
-        .map((_, i) => (file.s[i] > 0 ? 1 : 0))
-        .filter(v => v > 0).length;
-    }
-  });
+  const packageStats = aggregateCoverageStats(data);
 
   summary.byPackage[name] = {
     statements: {
-      total: pkgStatements,
-      covered: pkgCoveredStatements,
-      pct: pkgStatements > 0 ? (pkgCoveredStatements / pkgStatements) * 100 : 0,
+      ...packageStats.statements,
+      pct: pct(packageStats.statements),
     },
-    branches: {
-      total: pkgBranches,
-      covered: pkgCoveredBranches,
-      pct: pkgBranches > 0 ? (pkgCoveredBranches / pkgBranches) * 100 : 0,
-    },
-    functions: {
-      total: pkgFunctions,
-      covered: pkgCoveredFunctions,
-      pct: pkgFunctions > 0 ? (pkgCoveredFunctions / pkgFunctions) * 100 : 0,
-    },
-    lines: {
-      total: pkgLines,
-      covered: pkgCoveredLines,
-      pct: pkgLines > 0 ? (pkgCoveredLines / pkgLines) * 100 : 0,
-    },
+    branches: { ...packageStats.branches, pct: pct(packageStats.branches) },
+    functions: { ...packageStats.functions, pct: pct(packageStats.functions) },
+    lines: { ...packageStats.lines, pct: pct(packageStats.lines) },
   };
 });
 
@@ -185,16 +113,16 @@ fs.writeFileSync(outputFile, JSON.stringify(summary, null, 2));
 console.log('\n📊 Integrated Coverage Summary\n');
 console.log('Overall Coverage:');
 console.log(
-  `  Statements: ${coveredStatements}/${totalStatements} (${statementsPct.toFixed(2)}%)`
+  `  Statements: ${totalStats.statements.covered}/${totalStats.statements.total} (${statementsPct.toFixed(2)}%)`
 );
 console.log(
-  `  Branches:    ${coveredBranches}/${totalBranches} (${branchesPct.toFixed(2)}%)`
+  `  Branches:    ${totalStats.branches.covered}/${totalStats.branches.total} (${branchesPct.toFixed(2)}%)`
 );
 console.log(
-  `  Functions:   ${coveredFunctions}/${totalFunctions} (${functionsPct.toFixed(2)}%)`
+  `  Functions:   ${totalStats.functions.covered}/${totalStats.functions.total} (${functionsPct.toFixed(2)}%)`
 );
 console.log(
-  `  Lines:       ${coveredLines}/${totalLines} (${linesPct.toFixed(2)}%)`
+  `  Lines:       ${totalStats.lines.covered}/${totalStats.lines.total} (${linesPct.toFixed(2)}%)`
 );
 
 console.log('\nBy Package:');


### PR DESCRIPTION
## Summary
- Fix line coverage in the merged summary by deriving hits from `statementMap` with correct statement IDs (Vitest v8 omits `file.l`) and using Jest's native line map when present
- Fix branch coverage for Jest/mobile by flattening Istanbul branch path arrays instead of comparing array values to zero
- Extract shared logic into `scripts/lib/coverage-stats.js` with unit tests

## Test plan
- [x] `node --test scripts/__tests__/merge-coverage.test.mjs`
- [x] `npm run test:coverage:merge` — billing lines ~98% (was ~71%), mobile branches ~94% (was ~2%)
- [ ] CI coverage comment reflects corrected totals