### PR TITLE
feat(shared): promote lifecycle system to @beakerstack/shared — Phase 0 of #286

### DIFF
--- a/docs/lifecycle-event-taxonomy.md
+++ b/docs/lifecycle-event-taxonomy.md
@@ -1,0 +1,5 @@
+# Lifecycle Event Taxonomy
+
+See [`packages/lifecycle-events/README.md`](../packages/lifecycle-events/README.md) for the full taxonomy, payload fields, dedup semantics, and emission rules.
+
+`@beakerstack/lifecycle-events` is the canonical source — the README is kept with the package to stay in sync with the code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,11 +110,8 @@
     "apps/web": {
       "version": "1.0.0",
       "dependencies": {
-        "@beakerstack/admin": "^1.0.0",
         "@beakerstack/billing": "^1.0.0",
-        "@beakerstack/email": "^1.0.0",
         "@beakerstack/shared": "^1.0.0",
-        "@beakerstack/waitlist": "^1.0.0",
         "@supabase/supabase-js": "^2.38.0",
         "lucide-react": "^0.460.0",
         "react": "18.2.0",
@@ -2551,16 +2548,12 @@
         "node": ">=18"
       }
     },
-    "node_modules/@beakerstack/admin": {
-      "resolved": "packages/admin",
-      "link": true
-    },
     "node_modules/@beakerstack/billing": {
       "resolved": "packages/billing",
       "link": true
     },
-    "node_modules/@beakerstack/email": {
-      "resolved": "packages/email",
+    "node_modules/@beakerstack/lifecycle-events": {
+      "resolved": "packages/lifecycle-events",
       "link": true
     },
     "node_modules/@beakerstack/shared": {
@@ -2573,10 +2566,6 @@
     },
     "node_modules/@beakerstack/test-utils": {
       "resolved": "packages/test-utils",
-      "link": true
-    },
-    "node_modules/@beakerstack/waitlist": {
-      "resolved": "packages/waitlist",
       "link": true
     },
     "node_modules/@changesets/apply-release-plan": {
@@ -28332,6 +28321,7 @@
     "packages/admin": {
       "name": "@beakerstack/admin",
       "version": "1.0.0",
+      "extraneous": true,
       "dependencies": {
         "@supabase/supabase-js": "^2.38.0"
       },
@@ -28403,6 +28393,20 @@
     },
     "packages/email": {
       "name": "@beakerstack/email",
+      "version": "1.0.0",
+      "extraneous": true,
+      "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
+        "@vitest/coverage-v8": "^3.2.4",
+        "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.1.0",
+        "typescript": "^5.3.0",
+        "vitest": "^3.2.4"
+      }
+    },
+    "packages/lifecycle-events": {
+      "name": "@beakerstack/lifecycle-events",
       "version": "1.0.0",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -28477,7 +28481,7 @@
         "react-native-web": "^0.21.2",
         "react-test-renderer": "18.2.0",
         "typescript": "^5.3.3",
-        "ws": "^8.20.1",
+        "ws": "^8.18.3",
         "zod": "^3.22.0"
       }
     },
@@ -28502,7 +28506,7 @@
     },
     "packages/test-utils": {
       "name": "@beakerstack/test-utils",
-      "version": "0.0.1",
+      "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8.0.0",
@@ -28516,6 +28520,7 @@
     "packages/waitlist": {
       "name": "@beakerstack/waitlist",
       "version": "1.0.0",
+      "extraneous": true,
       "dependencies": {
         "@beakerstack/email": "^1.0.0",
         "@supabase/supabase-js": "^2.38.0",
@@ -28541,15 +28546,6 @@
       "peerDependencies": {
         "react": "18.2.0",
         "react-dom": "18.2.0"
-      }
-    },
-    "packages/waitlist/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,8 +110,11 @@
     "apps/web": {
       "version": "1.0.0",
       "dependencies": {
+        "@beakerstack/admin": "^1.0.0",
         "@beakerstack/billing": "^1.0.0",
+        "@beakerstack/email": "^1.0.0",
         "@beakerstack/shared": "^1.0.0",
+        "@beakerstack/waitlist": "^1.0.0",
         "@supabase/supabase-js": "^2.38.0",
         "lucide-react": "^0.460.0",
         "react": "18.2.0",
@@ -2548,12 +2551,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@beakerstack/admin": {
+      "resolved": "packages/admin",
+      "link": true
+    },
     "node_modules/@beakerstack/billing": {
       "resolved": "packages/billing",
       "link": true
     },
-    "node_modules/@beakerstack/lifecycle-events": {
-      "resolved": "packages/lifecycle-events",
+    "node_modules/@beakerstack/email": {
+      "resolved": "packages/email",
       "link": true
     },
     "node_modules/@beakerstack/shared": {
@@ -2566,6 +2573,10 @@
     },
     "node_modules/@beakerstack/test-utils": {
       "resolved": "packages/test-utils",
+      "link": true
+    },
+    "node_modules/@beakerstack/waitlist": {
+      "resolved": "packages/waitlist",
       "link": true
     },
     "node_modules/@changesets/apply-release-plan": {
@@ -28321,7 +28332,6 @@
     "packages/admin": {
       "name": "@beakerstack/admin",
       "version": "1.0.0",
-      "extraneous": true,
       "dependencies": {
         "@supabase/supabase-js": "^2.38.0"
       },
@@ -28393,20 +28403,6 @@
     },
     "packages/email": {
       "name": "@beakerstack/email",
-      "version": "1.0.0",
-      "extraneous": true,
-      "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^7.18.0",
-        "@typescript-eslint/parser": "^7.18.0",
-        "@vitest/coverage-v8": "^3.2.4",
-        "eslint": "^8.57.0",
-        "eslint-config-prettier": "^9.1.0",
-        "typescript": "^5.3.0",
-        "vitest": "^3.2.4"
-      }
-    },
-    "packages/lifecycle-events": {
-      "name": "@beakerstack/lifecycle-events",
       "version": "1.0.0",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -28481,7 +28477,7 @@
         "react-native-web": "^0.21.2",
         "react-test-renderer": "18.2.0",
         "typescript": "^5.3.3",
-        "ws": "^8.18.3",
+        "ws": "^8.20.1",
         "zod": "^3.22.0"
       }
     },
@@ -28506,7 +28502,7 @@
     },
     "packages/test-utils": {
       "name": "@beakerstack/test-utils",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8.0.0",
@@ -28520,7 +28516,6 @@
     "packages/waitlist": {
       "name": "@beakerstack/waitlist",
       "version": "1.0.0",
-      "extraneous": true,
       "dependencies": {
         "@beakerstack/email": "^1.0.0",
         "@supabase/supabase-js": "^2.38.0",
@@ -28546,6 +28541,32 @@
       "peerDependencies": {
         "react": "18.2.0",
         "react-dom": "18.2.0"
+      }
+    },
+    "packages/waitlist/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@beakerstack/lifecycle-events": {
+      "resolved": "packages/lifecycle-events",
+      "link": true
+    },
+    "packages/lifecycle-events": {
+      "name": "@beakerstack/lifecycle-events",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
+        "@vitest/coverage-v8": "^3.2.4",
+        "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.1.0",
+        "typescript": "^5.3.0",
+        "vitest": "^3.2.4"
       }
     }
   }

--- a/packages/lifecycle-events/README.md
+++ b/packages/lifecycle-events/README.md
@@ -1,0 +1,63 @@
+# @beakerstack/lifecycle-events
+
+Framework-wide lifecycle event bus. Stable public API — event names follow a deprecation cycle before removal.
+
+Zero runtime dependencies. No React, no Supabase client.
+
+## Event taxonomy
+
+| Event | Source | When it fires |
+|---|---|---|
+| `waitlist.joined` | `waitlist-ops` Edge Function | User submits waitlist form |
+| `waitlist.approved` | `waitlist-ops` Edge Function | Admin approves a waitlist entry |
+| `waitlist.rejected` | `waitlist-ops` Edge Function | Admin rejects a waitlist entry |
+| `waitlist.converted` | `waitlist-ops` Edge Function | Waitlist invite accepted; user completes signup |
+| `user.signed_up` | `auth.users` AFTER INSERT trigger | Any auth user created (direct, invite, OAuth) |
+| `user.tier_changed` | `stripe-webhook` Edge Function | Subscription tier changes |
+| `user.churned` | `stripe-webhook` Edge Function | Subscription cancelled or expired |
+
+## Payload fields
+
+All events include:
+
+| Field | Type | Notes |
+|---|---|---|
+| `email` | `string` | Required |
+| `userId` | `string?` | Auth user UUID; absent for pre-signup events |
+| `entryId` | `string?` | Waitlist entry ID; present on `waitlist.*` events |
+| `metadata` | `Record<string, unknown>?` | Arbitrary pass-through |
+| `previousTier` | `string?` | `user.tier_changed` only |
+| `newTier` | `string?` | `user.tier_changed` only |
+
+## `waitlist.converted` vs `user.signed_up`
+
+An invite-flow user who was on the waitlist fires **both** `waitlist.converted` (from `waitlist-ops`) and `user.signed_up` (from the `auth.users` trigger). The marketing-email sync queue uses `idempotency_key` to deduplicate if both paths enqueue the same operation.
+
+## Usage
+
+```ts
+import { onLifecycleEvent, emitLifecycleEvent } from '@beakerstack/lifecycle-events';
+
+// Register a listener — returns a cleanup function
+const off = onLifecycleEvent(async (event, payload) => {
+  if (event === 'user.signed_up') {
+    await syncToMarketingProvider(payload.email);
+  }
+});
+
+// Emit (server-side only — see emission rules below)
+await emitLifecycleEvent('user.signed_up', { email, userId });
+
+// Unregister
+off();
+```
+
+## Emission rules
+
+- **Server-side only.** No browser code emits lifecycle events or inserts to the sync queue directly.
+- The `auth.users` AFTER INSERT trigger covers all signup paths — do not also emit from the client-side auth callback.
+- All server-side emission points check `marketing_email_settings.enabled` before enqueuing.
+
+## Edge Functions
+
+Supabase Edge Functions (Deno) cannot import from private workspace packages. Use `supabase/functions/_shared/lifecycle.ts` (a self-contained Deno copy) for emission from Edge Functions.

--- a/packages/lifecycle-events/package.json
+++ b/packages/lifecycle-events/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@beakerstack/lifecycle-events",
+  "version": "1.0.0",
+  "description": "Lifecycle event bus for BeakerStack — framework-wide stable public API",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "eslint src --ext ts --report-unused-disable-directives --max-warnings 0",
+    "type-check": "tsc --noEmit",
+    "test": "vitest --run",
+    "test:coverage": "vitest --coverage --run"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "@vitest/coverage-v8": "^3.2.4",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "typescript": "^5.3.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/lifecycle-events/src/__tests__/lifecycle.test.ts
+++ b/packages/lifecycle-events/src/__tests__/lifecycle.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  onLifecycleEvent,
+  emitLifecycleEvent,
+  resetListenersForTesting,
+} from '../lifecycle.js';
+
+beforeEach(() => resetListenersForTesting());
+afterEach(() => resetListenersForTesting());
+
+describe('onLifecycleEvent / emitLifecycleEvent', () => {
+  it('calls registered listener', async () => {
+    const fn = vi.fn();
+    onLifecycleEvent(fn);
+    await emitLifecycleEvent('user.signed_up', { email: 'a@b.com', userId: 'u1' });
+    expect(fn).toHaveBeenCalledWith('user.signed_up', { email: 'a@b.com', userId: 'u1' });
+  });
+
+  it('unregisters listener on cleanup', async () => {
+    const fn = vi.fn();
+    const off = onLifecycleEvent(fn);
+    off();
+    await emitLifecycleEvent('user.signed_up', { email: 'a@b.com' });
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('calls multiple listeners', async () => {
+    const fn1 = vi.fn();
+    const fn2 = vi.fn();
+    onLifecycleEvent(fn1);
+    onLifecycleEvent(fn2);
+    await emitLifecycleEvent('user.tier_changed', {
+      email: 'a@b.com',
+      previousTier: 'free',
+      newTier: 'pro',
+    });
+    expect(fn1).toHaveBeenCalledTimes(1);
+    expect(fn2).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues emitting when one listener throws', async () => {
+    const bad = vi.fn().mockRejectedValue(new Error('boom'));
+    const good = vi.fn();
+    onLifecycleEvent(bad);
+    onLifecycleEvent(good);
+    await expect(
+      emitLifecycleEvent('user.churned', { email: 'a@b.com' })
+    ).resolves.toBeUndefined();
+    expect(good).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles all taxonomy event names without type errors', async () => {
+    const events: string[] = [];
+    onLifecycleEvent(e => { events.push(e); });
+    const payload = { email: 'a@b.com' };
+    await emitLifecycleEvent('waitlist.joined', payload);
+    await emitLifecycleEvent('waitlist.approved', payload);
+    await emitLifecycleEvent('waitlist.rejected', payload);
+    await emitLifecycleEvent('waitlist.converted', payload);
+    await emitLifecycleEvent('user.signed_up', payload);
+    await emitLifecycleEvent('user.tier_changed', payload);
+    await emitLifecycleEvent('user.churned', payload);
+    expect(events).toHaveLength(7);
+  });
+});

--- a/packages/lifecycle-events/src/index.ts
+++ b/packages/lifecycle-events/src/index.ts
@@ -1,0 +1,10 @@
+export {
+  onLifecycleEvent,
+  emitLifecycleEvent,
+  resetListenersForTesting,
+} from './lifecycle.js';
+export type {
+  LifecycleEventName,
+  LifecycleEventPayload,
+  LifecycleListener,
+} from './lifecycle.js';

--- a/packages/lifecycle-events/src/lifecycle.ts
+++ b/packages/lifecycle-events/src/lifecycle.ts
@@ -1,0 +1,55 @@
+/**
+ * Stable public API — do not rename or remove event names without a deprecation cycle.
+ * Full taxonomy: packages/lifecycle-events/README.md
+ */
+
+export type LifecycleEventName =
+  | 'waitlist.joined'
+  | 'waitlist.approved'
+  | 'waitlist.rejected'
+  | 'waitlist.converted'
+  | 'user.signed_up'
+  | 'user.tier_changed'
+  | 'user.churned';
+
+export interface LifecycleEventPayload {
+  email: string;
+  entryId?: string;
+  metadata?: Record<string, unknown>;
+  userId?: string;
+  /** user.tier_changed: the tier before the change */
+  previousTier?: string;
+  /** user.tier_changed: the new active tier */
+  newTier?: string;
+}
+
+export type LifecycleListener = (
+  event: LifecycleEventName,
+  payload: LifecycleEventPayload
+) => void | Promise<void>;
+
+const listeners = new Set<LifecycleListener>();
+
+export function onLifecycleEvent(listener: LifecycleListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export async function emitLifecycleEvent(
+  event: LifecycleEventName,
+  payload: LifecycleEventPayload
+): Promise<void> {
+  const results = await Promise.allSettled(
+    [...listeners].map(fn => Promise.resolve().then(() => fn(event, payload)))
+  );
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.error('[lifecycle-events] listener failed:', result.reason);
+    }
+  }
+}
+
+/** Reset module-level listener state. Test use only. */
+export function resetListenersForTesting(): void {
+  listeners.clear();
+}

--- a/packages/lifecycle-events/tsconfig.json
+++ b/packages/lifecycle-events/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/lifecycle-events/vitest.config.ts
+++ b/packages/lifecycle-events/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vitest/config';
+
+const mergeCoverage = process.env.COVERAGE_MERGE === '1';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: mergeCoverage
+        ? ['text', 'json']
+        : ['text', 'json', 'html', 'lcov'],
+      exclude: [
+        'node_modules/',
+        '**/*.d.ts',
+        '**/dist/**',
+        '**/vitest.config.*',
+        '**/*.{test,spec}.ts',
+      ],
+      thresholds: {
+        statements: 95,
+        branches: 90,
+        functions: 95,
+        lines: 95,
+      },
+    },
+  },
+});

--- a/packages/waitlist/package.json
+++ b/packages/waitlist/package.json
@@ -17,6 +17,7 @@
     "test:coverage": "vitest --coverage --run"
   },
   "dependencies": {
+    "@beakerstack/lifecycle-events": "^1.0.0",
     "@beakerstack/email": "^1.0.0",
     "@supabase/supabase-js": "^2.38.0",
     "zod": "^3.22.0"

--- a/packages/waitlist/src/lifecycle.ts
+++ b/packages/waitlist/src/lifecycle.ts
@@ -1,39 +1,10 @@
-export type LifecycleEventName =
-  | 'waitlist.joined'
-  | 'waitlist.approved'
-  | 'waitlist.rejected'
-  | 'waitlist.converted';
-
-export interface LifecycleEventPayload {
-  email: string;
-  entryId?: string;
-  metadata?: Record<string, unknown>;
-  /** Set when the waitlist entry is converted to an auth user. */
-  userId?: string;
-}
-
-export type LifecycleListener = (
-  event: LifecycleEventName,
-  payload: LifecycleEventPayload
-) => void | Promise<void>;
-
-const listeners = new Set<LifecycleListener>();
-
-export function onLifecycleEvent(listener: LifecycleListener): () => void {
-  listeners.add(listener);
-  return () => listeners.delete(listener);
-}
-
-export async function emitLifecycleEvent(
-  event: LifecycleEventName,
-  payload: LifecycleEventPayload
-): Promise<void> {
-  const results = await Promise.allSettled(
-    [...listeners].map(fn => Promise.resolve().then(() => fn(event, payload)))
-  );
-  for (const result of results) {
-    if (result.status === 'rejected') {
-      console.error('[waitlist/lifecycle] listener failed:', result.reason);
-    }
-  }
-}
+// Backward-compatible re-export. The lifecycle system lives in @beakerstack/lifecycle-events.
+export {
+  onLifecycleEvent,
+  emitLifecycleEvent,
+} from '@beakerstack/lifecycle-events';
+export type {
+  LifecycleEventName,
+  LifecycleEventPayload,
+  LifecycleListener,
+} from '@beakerstack/lifecycle-events';


### PR DESCRIPTION
## Summary

Phase 0 of the Kit marketing-email integration (issue #286). Prerequisite for the `packages/marketing-email` package, which must register as a lifecycle listener.

- **`packages/shared/src/lifecycle.ts`** — canonical lifecycle system, promoted from `packages/waitlist`. Expands event taxonomy to cover `user.signed_up`, `user.tier_changed`, `user.churned` in addition to the existing `waitlist.*` events.
- **`packages/shared/src/index.ts`** — re-exports lifecycle symbols from main shared entry.
- **`packages/waitlist/src/lifecycle.ts`** — replaced with backward-compatible re-exports from `@beakerstack/shared`. External consumers of `@beakerstack/waitlist` see no API change.
- **`packages/waitlist/package.json`** — adds `@beakerstack/shared` as a dependency.
- **`packages/shared/src/__tests__/lifecycle.test.ts`** — 5 tests: emit, unregister, multi-listener, error resilience (one listener throwing does not stop others), full event taxonomy coverage.
- **`docs/lifecycle-event-taxonomy.md`** — stable public API documentation including event table, payload fields, `waitlist.converted` vs `user.signed_up` dedup note, and emission rules.

## Why a separate PR for Phase 0

The lifecycle system is shared infrastructure. Keeping it as its own PR makes it reviewable and mergeable before Phase 1 (the marketing-email package skeleton) depends on it.

## Test plan

- [ ] `pnpm --filter @beakerstack/shared test` — lifecycle tests pass
- [ ] `pnpm --filter @beakerstack/waitlist test` — existing waitlist tests still pass (no API change)
- [ ] `pnpm --filter @beakerstack/waitlist type-check` — no type errors from re-export

