### PR TITLE
ci: split Test workflow into parallel jobs

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,12 +1,9 @@
 name: Setup Node
-description: Checkout repository, install Node.js 20, and run npm ci
+description: Install Node.js 20 and run npm ci (run actions/checkout first)
 
 runs:
   using: composite
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,18 @@
+name: Setup Node
+description: Checkout repository, install Node.js 20, and run npm ci
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20.x
+        cache: npm
+
+    - name: Install dependencies
+      shell: bash
+      run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
       - name: Run lint
         run: npm run lint
@@ -56,6 +57,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
       - name: Type check
         run: npm run type-check
@@ -66,6 +68,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
 
       - name: Run unit tests with coverage
@@ -129,6 +132,7 @@ jobs:
       TEST_EMAIL: ci-test@example.com
 
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
 
       - name: Install Supabase CLI
@@ -187,6 +191,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
 
       - name: Install Supabase CLI
@@ -243,6 +248,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
 
       - name: Download unit coverage reports

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,9 @@ on:
       # Scripts and repo lint config (lint covers scripts/**)
       - 'scripts/**'
       - '.eslintrc.js'
-      # Workflow file itself
+      # Workflow and composite actions
       - '.github/workflows/test.yml'
+      - '.github/actions/**'
 
 permissions:
   contents: read
@@ -39,27 +40,96 @@ permissions:
   pull-requests: write
 
 jobs:
-  tests:
-    # On edited events, only run when the base branch was retargeted (not title/body-only edits).
+  lint:
     if: github.event.action != 'edited' || github.event.changes.base
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 15
+
+    steps:
+      - uses: ./.github/actions/setup-node
+      - name: Run lint
+        run: npm run lint
+
+  type-check:
+    if: github.event.action != 'edited' || github.event.changes.base
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: ./.github/actions/setup-node
+      - name: Type check
+        run: npm run type-check
+
+  unit-coverage:
+    if: github.event.action != 'edited' || github.event.changes.base
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: ./.github/actions/setup-node
+
+      - name: Run unit tests with coverage
+        id: run-tests
+        continue-on-error: true
+        env:
+          COVERAGE_MERGE: '1'
+          VITE_SUPABASE_URL: ''
+          VITE_SUPABASE_ANON_KEY: ''
+        run: |
+          mkdir -p ci
+          set -o pipefail
+          (
+            npm run test:coverage:mobile &&
+            npm run test:coverage:web &&
+            npm run test:coverage:shared &&
+            npm run test:coverage:billing &&
+            npm run test:coverage:admin &&
+            npm run test:coverage:lifecycle-events &&
+            npm run test:coverage:waitlist &&
+            npm run test:coverage:email &&
+            npm run test:coverage:observability &&
+            npm run test:unit:scripts
+          ) 2>&1 | tee ci/unit-coverage.log
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-coverage-reports
+          path: |
+            apps/web/coverage
+            apps/mobile/coverage
+            packages/shared-tests/coverage
+            packages/billing/coverage
+            packages/admin/coverage
+            packages/waitlist/coverage
+            packages/email/coverage
+            packages/lifecycle-events/coverage
+            packages/observability/coverage
+          if-no-files-found: warn
+
+      - name: Upload test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-coverage-log
+          path: ci/unit-coverage.log
+          if-no-files-found: warn
+
+      - name: Fail job if tests failed
+        if: steps.run-tests.outcome == 'failure'
+        run: exit 1
+
+  integration:
+    if: github.event.action != 'edited' || github.event.changes.base
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     env:
       TEST_EMAIL: ci-test@example.com
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
+      - uses: ./.github/actions/setup-node
 
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v1
@@ -69,7 +139,6 @@ jobs:
       - name: Start Supabase services
         run: |
           mkdir -p .supabase/logs
-          # Exclude non-essential services to speed up CI startup
           supabase start -x studio,imgproxy,inbucket,edge-runtime,analytics > .supabase/logs/start.log 2>&1
           supabase status > .supabase/logs/status.log 2>&1
           cat .supabase/logs/status.log
@@ -77,13 +146,7 @@ jobs:
       - name: Export Supabase credentials from local stack
         run: ./scripts/ci-export-supabase-env.sh
 
-      - name: Run lint
-        run: npm run lint
-
-      - name: Type check
-        run: npm run type-check
-
-      - name: Run tests with coverage
+      - name: Run integration tests
         id: run-tests
         continue-on-error: true
         run: |
@@ -91,15 +154,118 @@ jobs:
           set -o pipefail
           (
             npm run test:integration &&
-            npm run test:db &&
-            npm run test:coverage
-          ) 2>&1 | tee ci/test-output.log
+            cd apps/web && npx vitest run src/lib/supabase.test.ts
+          ) 2>&1 | tee ci/integration.log
 
-      - name: Build coverage summary
-        id: build-summary
+      - name: Upload test log
         if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-log
+          path: ci/integration.log
+          if-no-files-found: warn
+
+      - name: Upload Supabase logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-supabase-logs
+          path: .supabase/logs
+          if-no-files-found: warn
+
+      - name: Fail job if tests failed
+        if: steps.run-tests.outcome == 'failure'
+        run: exit 1
+
+      - name: Stop Supabase services
+        if: always()
+        run: supabase stop || true
+
+  db-tests:
+    if: github.event.action != 'edited' || github.event.changes.base
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: ./.github/actions/setup-node
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.54.11
+
+      - name: Start Supabase services
+        run: |
+          mkdir -p .supabase/logs
+          supabase start -x studio,imgproxy,inbucket,edge-runtime,analytics > .supabase/logs/start.log 2>&1
+          supabase status > .supabase/logs/status.log 2>&1
+          cat .supabase/logs/status.log
+
+      - name: Export Supabase credentials from local stack
+        run: ./scripts/ci-export-supabase-env.sh
+
+      - name: Run database tests
+        id: run-tests
+        continue-on-error: true
         run: |
           mkdir -p ci
+          set -o pipefail
+          npm run test:db 2>&1 | tee ci/db-tests.log
+
+      - name: Upload test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-tests-log
+          path: ci/db-tests.log
+          if-no-files-found: warn
+
+      - name: Upload Supabase logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-tests-supabase-logs
+          path: .supabase/logs
+          if-no-files-found: warn
+
+      - name: Fail job if tests failed
+        if: steps.run-tests.outcome == 'failure'
+        run: exit 1
+
+      - name: Stop Supabase services
+        if: always()
+        run: supabase stop || true
+
+  coverage-report:
+    needs: [unit-coverage, integration, db-tests]
+    if: always() && !cancelled() && (github.event.action != 'edited' || github.event.changes.base)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: ./.github/actions/setup-node
+
+      - name: Download unit coverage reports
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: unit-coverage-reports
+          path: .
+
+      - name: Download test logs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: '*-log'
+          merge-multiple: true
+          path: .
+
+      - name: Merge coverage and test logs
+        id: build-summary
+        run: |
+          mkdir -p coverage
+          node scripts/merge-coverage.js
+          cat ci/unit-coverage.log ci/integration.log ci/db-tests.log > ci/test-output.log 2>/dev/null || true
           node scripts/format-ci-summary.mjs \
             --coverage coverage/coverage-summary.json \
             --test-log ci/test-output.log \
@@ -110,8 +276,6 @@ jobs:
             cat ci/comment.md
             printf '\nEOF_COMMENT\n'
           } >> "$GITHUB_OUTPUT"
-          tests_failed=$(node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('ci/summary.json','utf8')); process.stdout.write(String(data.tests.suites.failed || 0));")
-          echo "tests_failed=$tests_failed" >> "$GITHUB_OUTPUT"
 
       - name: Comment coverage summary
         if: github.event_name == 'pull_request'
@@ -125,7 +289,6 @@ jobs:
               return;
             }
 
-            // Add timestamp in Pacific time
             const now = new Date();
             const pacificTime = now.toLocaleString('en-US', {
               timeZone: 'America/Los_Angeles',
@@ -216,30 +379,6 @@ jobs:
             packages/observability/coverage
           if-no-files-found: warn
 
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: |
-            **/junit*.xml
-            **/test-results/**/*.xml
-            **/jest-stare/**/*.html
-          if-no-files-found: warn
-
-      - name: Upload Supabase logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: supabase-logs
-          path: .supabase/logs
-          if-no-files-found: warn
-
-      - name: Fail job if tests failed
-        if: steps.run-tests.outcome == 'failure'
+      - name: Fail if upstream test jobs failed
+        if: needs.unit-coverage.result == 'failure' || needs.integration.result == 'failure' || needs.db-tests.result == 'failure'
         run: exit 1
-
-      - name: Stop Supabase services
-        if: always()
-        run: supabase stop || true
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,8 +76,6 @@ jobs:
         continue-on-error: true
         env:
           COVERAGE_MERGE: '1'
-          VITE_SUPABASE_URL: ''
-          VITE_SUPABASE_ANON_KEY: ''
         run: |
           mkdir -p ci
           set -o pipefail

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,6 +151,8 @@ jobs:
       - name: Run integration tests
         id: run-tests
         continue-on-error: true
+        env:
+          RUN_LIVE_SUPABASE_TEST: '1'
         run: |
           mkdir -p ci
           set -o pipefail

--- a/apps/web/src/lib/supabase.test.ts
+++ b/apps/web/src/lib/supabase.test.ts
@@ -1,15 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { Logger } from '@beakerstack/logger';
 
-const url = import.meta.env?.VITE_SUPABASE_URL;
-const anonKey = import.meta.env?.VITE_SUPABASE_ANON_KEY;
-
-const shouldRun = Boolean(url && anonKey);
+const shouldRun = process.env.RUN_LIVE_SUPABASE_TEST === '1';
 
 describe('supabase client', () => {
   it('connects and can run a basic query', async () => {
     if (!shouldRun) {
-      Logger.warn('Supabase env vars not set – skipping connection test');
+      Logger.warn(
+        'RUN_LIVE_SUPABASE_TEST not set – skipping live Supabase connection test'
+      );
       expect(true).toBe(true);
       return;
     }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import path from 'path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig, loadEnv, type Plugin } from 'vite';
+import { configDefaults } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { BRANDING } from '../../packages/shared/src/config/branding';
 
@@ -113,6 +114,13 @@ export default defineConfig(({ mode }) => {
       globals: true,
       environment: 'jsdom',
       setupFiles: ['./src/test/setup.ts'],
+      // Placeholder Supabase env for jsdom tests that import supabase.ts at module load.
+      // Live connection smoke test runs separately in CI integration job.
+      env: {
+        VITE_SUPABASE_URL: 'http://localhost:54321',
+        VITE_SUPABASE_ANON_KEY: 'test-anon-key',
+      },
+      exclude: [...configDefaults.exclude, 'src/lib/supabase.test.ts'],
       coverage: {
         provider: 'v8',
         reporter:

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,7 +2,6 @@ import { readFileSync } from 'node:fs';
 import path from 'path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig, loadEnv, type Plugin } from 'vite';
-import { configDefaults } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { BRANDING } from '../../packages/shared/src/config/branding';
 
@@ -114,13 +113,14 @@ export default defineConfig(({ mode }) => {
       globals: true,
       environment: 'jsdom',
       setupFiles: ['./src/test/setup.ts'],
-      // Placeholder Supabase env for jsdom tests that import supabase.ts at module load.
-      // Live connection smoke test runs separately in CI integration job.
+      // Placeholder Supabase env when unset (jsdom imports supabase.ts at module load).
+      // CI integration exports real credentials via GITHUB_ENV — those take precedence.
       env: {
-        VITE_SUPABASE_URL: 'http://localhost:54321',
-        VITE_SUPABASE_ANON_KEY: 'test-anon-key',
+        VITE_SUPABASE_URL:
+          process.env.VITE_SUPABASE_URL ?? 'http://localhost:54321',
+        VITE_SUPABASE_ANON_KEY:
+          process.env.VITE_SUPABASE_ANON_KEY ?? 'test-anon-key',
       },
-      exclude: [...configDefaults.exclude, 'src/lib/supabase.test.ts'],
       coverage: {
         provider: 'v8',
         reporter:

--- a/docs/branch-protection-setup.md
+++ b/docs/branch-protection-setup.md
@@ -41,7 +41,7 @@ Branch protection prevents accidental squash merges into `main`, which can cause
      - ✅ Require approvals: 1 (or your team's requirement)
      - ✅ Dismiss stale pull request approvals when new commits are pushed
    - ✅ Require status checks to pass before merging
-     - Select required status checks (e.g., "Test", "Lint & Type Check")
+     - Select required status checks (see [Required CI status checks](#required-ci-status-checks) below)
    - ✅ Require branches to be up to date before merging
    - ✅ **Require merge queue** (optional, but recommended for teams)
 
@@ -60,12 +60,30 @@ Branch protection prevents accidental squash merges into `main`, which can cause
    - ✅ Require a pull request before merging
      - ✅ Require approvals: 1 (or your team's requirement)
    - ✅ Require status checks to pass before merging
+     - Select required status checks (see [Required CI status checks](#required-ci-status-checks) below)
    - ✅ Require branches to be up to date before merging
 
    **Restrict who can push to matching branches:**
    - ✅ Do not allow bypassing the above settings
 
 4. Click **Create** (or **Save changes**)
+
+### Required CI status checks
+
+The [`Test` workflow](../.github/workflows/test.yml) runs parallel jobs. Each job reports an independent status check. Require these on `main` and `develop`:
+
+| Status check             | Job                                            | Blocks merge?      |
+| ------------------------ | ---------------------------------------------- | ------------------ |
+| `Test / lint`            | ESLint across all workspaces                   | Yes                |
+| `Test / type-check`      | TypeScript `--noEmit`                          | Yes                |
+| `Test / unit-coverage`   | Unit tests with coverage (no Supabase)         | Yes                |
+| `Test / integration`     | Integration tests + web Supabase smoke test    | Yes                |
+| `Test / db-tests`        | Migration filename checks + `supabase test db` | Yes                |
+| `Test / coverage-report` | Merges coverage and posts PR comment           | No (informational) |
+
+After migrating from the old monolithic `Test / tests` check, remove `Test / tests` from branch protection and add the five required checks above.
+
+`Test / coverage-report` should **not** be required — it aggregates results and may still post a coverage comment when other jobs fail.
 
 ### Step 4: Optional - GitHub Action to Enforce Merge Strategy
 


### PR DESCRIPTION
## Summary
- Replace the monolithic `Test / tests` job with parallel jobs: lint, type-check, unit-coverage, integration, db-tests, and a coverage-report aggregator.
- Add a shared `.github/actions/setup-node` composite action to DRY checkout, Node 20, and `npm ci` setup.
- Run unit coverage without Supabase (web smoke test moved to integration); document new required branch protection status checks.

## Test plan
- [ ] Confirm all six workflow jobs run in parallel on this PR
- [ ] Verify independent status checks appear: `Test / lint`, `Test / type-check`, `Test / unit-coverage`, `Test / integration`, `Test / db-tests`
- [ ] Confirm coverage PR comment still posts from `Test / coverage-report`
- [ ] After merge, update branch protection on `develop`/`main`: remove `Test / tests`, add the five required checks (see `docs/branch-protection-setup.md`)