### PR TITLE
ci: run PR preview mobile deploy in parallel with web

### DIFF
--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -337,7 +337,7 @@ jobs:
 
   deploy-preview-mobile:
     if: github.event.action != 'closed' && needs.preview-scope.outputs.run_deploy == 'true' && (github.base_ref != 'develop' || github.head_ref != 'main') && vars.MOBILE_ENABLED != 'false'
-    needs: [preview-scope, deploy-preview]
+    needs: [preview-scope]
     runs-on: ubuntu-latest
     outputs:
       mobile-channel: ${{ steps.mobile.outputs.PREVIEW_MOBILE_CHANNEL }}


### PR DESCRIPTION
## Summary

- Remove `deploy-preview` from `deploy-preview-mobile` job dependencies so mobile starts right after `preview-scope` instead of waiting for the full web/backend deploy (~2–3 min).
- Web and mobile preview deploys now run in parallel; `comment` and `lighthouse` keep their existing dependencies.

## Test plan

- [ ] Open or sync a PR into `develop` and confirm `deploy-preview` and `deploy-preview-mobile` start together after `preview-scope`.
- [ ] Confirm the preview comment still posts web + mobile status after both jobs finish.
- [ ] Confirm `lighthouse` still runs after web deploy when not using signed-cookies.
- [ ] With `MOBILE_ENABLED=false`, confirm mobile is skipped and `comment` still runs.