### PR TITLE
ci: run unit tests in parallel matrix shards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,16 +121,18 @@ jobs:
       - name: Stage coverage for upload
         if: always() && matrix.coverage_path != ''
         run: |
-          mkdir -p ".coverage-artifact/${{ matrix.coverage_path }}"
-          cp -a "${{ matrix.coverage_path }}/." ".coverage-artifact/${{ matrix.coverage_path }}/"
+          staging="coverage-artifact-staging/${{ matrix.coverage_path }}"
+          mkdir -p "$staging"
+          cp -a "${{ matrix.coverage_path }}/." "$staging/"
+          test -f "$staging/coverage-final.json"
 
       - name: Upload coverage reports
         if: always() && matrix.coverage_path != ''
         uses: actions/upload-artifact@v4
         with:
           name: unit-coverage-reports-${{ matrix.shard }}
-          path: .coverage-artifact/
-          if-no-files-found: warn
+          path: coverage-artifact-staging/
+          if-no-files-found: error
 
       - name: Upload test log
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -298,14 +298,44 @@ jobs:
           merge-multiple: true
           path: .
 
-      # merge-multiple extracts each artifact into a named subdirectory; flatten
-      # so merge-coverage.js finds apps/*/coverage and logs land under ci/
+      # merge-multiple nests artifacts under unit-coverage-reports-*; each upload
+      # contains only the coverage/ directory contents (not apps/.../coverage).
       - name: Restore layout from downloaded artifacts
         run: |
           shopt -s nullglob
-          for dir in unit-coverage-reports-* unit-coverage-log-* integration-log db-tests-log; do
-            if [ -d "$dir" ]; then
-              cp -a "$dir"/. .
+          declare -A COVERAGE_PATHS=(
+            [mobile]=apps/mobile/coverage
+            [web]=apps/web/coverage
+            [shared]=packages/shared-tests/coverage
+            [billing]=packages/billing/coverage
+            [admin]=packages/admin/coverage
+            [lifecycle-events]=packages/lifecycle-events/coverage
+            [waitlist]=packages/waitlist/coverage
+            [email]=packages/email/coverage
+            [marketing-email]=packages/marketing-email/coverage
+            [observability]=packages/observability/coverage
+          )
+          for dir in unit-coverage-reports-*; do
+            shard="${dir#unit-coverage-reports-}"
+            target="${COVERAGE_PATHS[$shard]:-}"
+            if [ -n "$target" ]; then
+              mkdir -p "$target"
+              cp -a "$dir"/. "$target/"
+            fi
+          done
+          mkdir -p ci
+          for dir in unit-coverage-log-*; do
+            if [ -f "$dir"/*.log ]; then
+              cp -a "$dir"/*.log ci/
+            elif [ -d "$dir/ci" ]; then
+              cp -a "$dir"/ci/. ci/
+            fi
+          done
+          for dir in integration-log db-tests-log; do
+            if [ -f "$dir"/*.log ]; then
+              cp -a "$dir"/*.log ci/
+            elif [ -d "$dir/ci" ]; then
+              cp -a "$dir"/ci/. ci/
             fi
           done
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,11 +160,21 @@ jobs:
             exit 1
           fi
 
-  integration:
-    # TEMP: disabled while debugging parallel unit coverage + coverage-report merge
-    if: false
+  migration-filenames:
+    if: github.event.action != 'edited' || github.event.changes.base
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-node
+      - name: Check SQL migration filenames
+        run: node --test scripts/__tests__/db-migration-filenames.test.mjs
+
+  supabase-tests:
+    if: github.event.action != 'edited' || github.event.changes.base
+    runs-on: ubuntu-latest
+    timeout-minutes: 18
 
     env:
       TEST_EMAIL: ci-test@example.com
@@ -173,35 +183,50 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
 
+      - name: Cache Supabase CLI and Docker state
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.supabase
+          key: supabase-${{ runner.os }}-${{ hashFiles('supabase/config.toml') }}
+          restore-keys: |
+            supabase-${{ runner.os }}-
+
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v1
         with:
           version: 2.54.11
 
       - name: Start Supabase services
-        run: |
-          mkdir -p .supabase/logs
-          supabase start -x studio,imgproxy,inbucket,edge-runtime,analytics > .supabase/logs/start.log 2>&1
-          supabase status > .supabase/logs/status.log 2>&1
-          cat .supabase/logs/status.log
+        run: ./scripts/ci-supabase-start.sh
 
       - name: Export Supabase credentials from local stack
         run: ./scripts/ci-export-supabase-env.sh
 
-      - name: Run integration tests
+      - name: Run database and integration tests
         id: run-tests
         continue-on-error: true
         env:
           RUN_LIVE_SUPABASE_TEST: '1'
         run: |
           mkdir -p ci
-          set -o pipefail
+          failed=0
+          ( npm run test:db:pgtap ) 2>&1 | tee ci/db-tests.log || failed=1
           (
             npm run test:integration &&
             cd apps/web && npx vitest run src/lib/supabase.test.ts
-          ) 2>&1 | tee ci/integration.log
+          ) 2>&1 | tee ci/integration.log || failed=1
+          exit $failed
 
-      - name: Upload test log
+      - name: Upload database test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-tests-log
+          path: ci/db-tests.log
+          if-no-files-found: warn
+
+      - name: Upload integration test log
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -213,7 +238,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: integration-supabase-logs
+          name: supabase-tests-supabase-logs
           path: .supabase/logs
           if-no-files-found: warn
 
@@ -225,62 +250,37 @@ jobs:
         if: always()
         run: supabase stop || true
 
-  db-tests:
-    # TEMP: disabled while debugging parallel unit coverage + coverage-report merge
-    if: false
+  integration:
+    needs: supabase-tests
+    if: always() && !cancelled() && (github.event.action != 'edited' || github.event.changes.base)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 2
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-node
-
-      - name: Install Supabase CLI
-        uses: supabase/setup-cli@v1
-        with:
-          version: 2.54.11
-
-      - name: Start Supabase services
+      - name: Verify Supabase integration tests passed
         run: |
-          mkdir -p .supabase/logs
-          supabase start -x studio,imgproxy,inbucket,edge-runtime,analytics > .supabase/logs/start.log 2>&1
-          supabase status > .supabase/logs/status.log 2>&1
-          cat .supabase/logs/status.log
+          if [ "${{ needs.supabase-tests.result }}" != "success" ]; then
+            echo "supabase-tests failed (includes integration suite)"
+            exit 1
+          fi
 
-      - name: Export Supabase credentials from local stack
-        run: ./scripts/ci-export-supabase-env.sh
+  db-tests:
+    needs: [migration-filenames, supabase-tests]
+    if: always() && !cancelled() && (github.event.action != 'edited' || github.event.changes.base)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
 
-      - name: Run database tests
-        id: run-tests
-        continue-on-error: true
+    steps:
+      - name: Verify migration filenames and pgTAP tests passed
         run: |
-          mkdir -p ci
-          set -o pipefail
-          npm run test:db 2>&1 | tee ci/db-tests.log
-
-      - name: Upload test log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: db-tests-log
-          path: ci/db-tests.log
-          if-no-files-found: warn
-
-      - name: Upload Supabase logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: db-tests-supabase-logs
-          path: .supabase/logs
-          if-no-files-found: warn
-
-      - name: Fail job if tests failed
-        if: steps.run-tests.outcome == 'failure'
-        run: exit 1
-
-      - name: Stop Supabase services
-        if: always()
-        run: supabase stop || true
+          if [ "${{ needs.migration-filenames.result }}" != "success" ]; then
+            echo "migration-filenames failed"
+            exit 1
+          fi
+          if [ "${{ needs.supabase-tests.result }}" != "success" ]; then
+            echo "supabase-tests failed (includes pgTAP suite)"
+            exit 1
+          fi
 
   coverage-report:
     needs: [unit-coverage-shard, unit-coverage]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,16 +62,53 @@ jobs:
       - name: Type check
         run: npm run type-check
 
-  unit-coverage:
+  unit-coverage-shard:
     if: github.event.action != 'edited' || github.event.changes.base
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: mobile
+            script: test:coverage:mobile
+            coverage_path: apps/mobile/coverage
+          - shard: web
+            script: test:coverage:web
+            coverage_path: apps/web/coverage
+          - shard: shared
+            script: test:coverage:shared
+            coverage_path: packages/shared-tests/coverage
+          - shard: billing
+            script: test:coverage:billing
+            coverage_path: packages/billing/coverage
+          - shard: admin
+            script: test:coverage:admin
+            coverage_path: packages/admin/coverage
+          - shard: lifecycle-events
+            script: test:coverage:lifecycle-events
+            coverage_path: packages/lifecycle-events/coverage
+          - shard: waitlist
+            script: test:coverage:waitlist
+            coverage_path: packages/waitlist/coverage
+          - shard: email
+            script: test:coverage:email
+            coverage_path: packages/email/coverage
+          - shard: marketing-email
+            script: test:coverage:marketing-email
+            coverage_path: packages/marketing-email/coverage
+          - shard: observability
+            script: test:coverage:observability
+            coverage_path: packages/observability/coverage
+          - shard: scripts
+            script: test:unit:scripts
+            coverage_path: ''
 
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
 
-      - name: Run unit tests with coverage
+      - name: Run unit tests (${{ matrix.shard }})
         id: run-tests
         continue-on-error: true
         env:
@@ -79,49 +116,41 @@ jobs:
         run: |
           mkdir -p ci
           set -o pipefail
-          (
-            npm run test:coverage:mobile &&
-            npm run test:coverage:web &&
-            npm run test:coverage:shared &&
-            npm run test:coverage:billing &&
-            npm run test:coverage:admin &&
-            npm run test:coverage:lifecycle-events &&
-            npm run test:coverage:waitlist &&
-            npm run test:coverage:email &&
-            npm run test:coverage:marketing-email &&
-            npm run test:coverage:observability &&
-            npm run test:unit:scripts
-          ) 2>&1 | tee ci/unit-coverage.log
+          npm run ${{ matrix.script }} 2>&1 | tee ci/unit-coverage-${{ matrix.shard }}.log
 
       - name: Upload coverage reports
-        if: always()
+        if: always() && matrix.coverage_path != ''
         uses: actions/upload-artifact@v4
         with:
-          name: unit-coverage-reports
-          path: |
-            apps/web/coverage
-            apps/mobile/coverage
-            packages/shared-tests/coverage
-            packages/billing/coverage
-            packages/admin/coverage
-            packages/waitlist/coverage
-            packages/email/coverage
-            packages/marketing-email/coverage
-            packages/lifecycle-events/coverage
-            packages/observability/coverage
+          name: unit-coverage-reports-${{ matrix.shard }}
+          path: ${{ matrix.coverage_path }}
           if-no-files-found: warn
 
       - name: Upload test log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: unit-coverage-log
-          path: ci/unit-coverage.log
+          name: unit-coverage-log-${{ matrix.shard }}
+          path: ci/unit-coverage-${{ matrix.shard }}.log
           if-no-files-found: warn
 
       - name: Fail job if tests failed
         if: steps.run-tests.outcome == 'failure'
         run: exit 1
+
+  unit-coverage:
+    needs: unit-coverage-shard
+    if: always() && !cancelled() && (github.event.action != 'edited' || github.event.changes.base)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Verify all unit test shards passed
+        run: |
+          if [ "${{ needs.unit-coverage-shard.result }}" != "success" ]; then
+            echo "One or more unit-coverage-shard jobs failed"
+            exit 1
+          fi
 
   integration:
     if: github.event.action != 'edited' || github.event.changes.base
@@ -244,7 +273,7 @@ jobs:
         run: supabase stop || true
 
   coverage-report:
-    needs: [unit-coverage, integration, db-tests]
+    needs: [unit-coverage-shard, unit-coverage, integration, db-tests]
     if: always() && !cancelled() && (github.event.action != 'edited' || github.event.changes.base)
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -257,7 +286,8 @@ jobs:
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          name: unit-coverage-reports
+          pattern: unit-coverage-reports-*
+          merge-multiple: true
           path: .
 
       - name: Download test logs
@@ -273,7 +303,7 @@ jobs:
         run: |
           mkdir -p coverage
           node scripts/merge-coverage.js
-          cat ci/unit-coverage.log ci/integration.log ci/db-tests.log > ci/test-output.log 2>/dev/null || true
+          cat ci/unit-coverage-*.log ci/integration.log ci/db-tests.log > ci/test-output.log 2>/dev/null || true
           node scripts/format-ci-summary.mjs \
             --coverage coverage/coverage-summary.json \
             --test-log ci/test-output.log \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,7 +159,8 @@ jobs:
           fi
 
   integration:
-    if: github.event.action != 'edited' || github.event.changes.base
+    # TEMP: disabled while debugging parallel unit coverage + coverage-report merge
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -223,7 +224,8 @@ jobs:
         run: supabase stop || true
 
   db-tests:
-    if: github.event.action != 'edited' || github.event.changes.base
+    # TEMP: disabled while debugging parallel unit coverage + coverage-report merge
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -279,7 +281,7 @@ jobs:
         run: supabase stop || true
 
   coverage-report:
-    needs: [unit-coverage-shard, unit-coverage, integration, db-tests]
+    needs: [unit-coverage-shard, unit-coverage]
     if: always() && !cancelled() && (github.event.action != 'edited' || github.event.changes.base)
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -288,31 +290,35 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
 
+      # merge-multiple flattens single-file artifacts to workspace root; download each
+      # shard into its own directory so staged apps/.../coverage paths restore correctly.
       - name: Download unit coverage reports
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          pattern: unit-coverage-reports-*
-          merge-multiple: true
-          path: .
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          shards=(mobile web shared billing admin lifecycle-events waitlist email marketing-email observability)
+          for shard in "${shards[@]}"; do
+            echo "Downloading unit-coverage-reports-${shard}"
+            gh run download "${GITHUB_RUN_ID}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              -n "unit-coverage-reports-${shard}" \
+              -D "unit-coverage-reports-${shard}"
+          done
 
       - name: Download unit test logs
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          pattern: unit-coverage-log-*
-          merge-multiple: true
-          path: .
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          shards=(mobile web shared billing admin lifecycle-events waitlist email marketing-email observability scripts)
+          for shard in "${shards[@]}"; do
+            gh run download "${GITHUB_RUN_ID}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              -n "unit-coverage-log-${shard}" \
+              -D "unit-coverage-log-${shard}" || true
+          done
 
-      - name: Download integration and db test logs
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          pattern: '*-log'
-          merge-multiple: true
-          path: .
-
-      # Artifacts are staged with repo-relative paths (apps/.../coverage) before upload.
       - name: Restore layout from downloaded artifacts
         run: |
           shopt -s nullglob
@@ -321,21 +327,19 @@ jobs:
             cp -a "$dir"/. .
           done
           mkdir -p ci
-          for dir in unit-coverage-log-* integration-log db-tests-log; do
+          for dir in unit-coverage-log-*; do
             [ -d "$dir" ] || continue
             while IFS= read -r -d '' logfile; do
               cp -a "$logfile" "ci/$(basename "$logfile")"
             done < <(find "$dir" -type f -name '*.log' -print0)
           done
-          # Fail fast if merge-coverage will have nothing to read
-          found=0
-          for f in apps/web/coverage/coverage-final.json packages/billing/coverage/coverage-final.json; do
-            [ -f "$f" ] && found=1
+          for f in unit-coverage-*.log; do
+            [ -f "$f" ] && cp -a "$f" ci/
           done
-          if [ "$found" -eq 0 ]; then
+          if [ ! -f apps/web/coverage/coverage-final.json ] && [ ! -f packages/billing/coverage/coverage-final.json ]; then
             echo "::error::No coverage-final.json under expected paths after restore"
             ls -la
-            ls -la unit-coverage-reports-* 2>/dev/null || true
+            ls -laR unit-coverage-reports-* 2>/dev/null || true
             exit 1
           fi
 
@@ -344,7 +348,7 @@ jobs:
         run: |
           mkdir -p coverage ci
           node scripts/merge-coverage.js
-          cat ci/unit-coverage-*.log ci/integration.log ci/db-tests.log > ci/test-output.log 2>/dev/null || touch ci/test-output.log
+          cat ci/unit-coverage-*.log > ci/test-output.log 2>/dev/null || touch ci/test-output.log
           node scripts/format-ci-summary.mjs \
             --coverage coverage/coverage-summary.json \
             --test-log ci/test-output.log \
@@ -460,5 +464,5 @@ jobs:
           if-no-files-found: warn
 
       - name: Fail if upstream test jobs failed
-        if: needs.unit-coverage.result == 'failure' || needs.integration.result == 'failure' || needs.db-tests.result == 'failure'
+        if: needs.unit-coverage.result == 'failure'
         run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -290,7 +290,15 @@ jobs:
           merge-multiple: true
           path: .
 
-      - name: Download test logs
+      - name: Download unit test logs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: unit-coverage-log-*
+          merge-multiple: true
+          path: .
+
+      - name: Download integration and db test logs
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
@@ -324,19 +332,11 @@ jobs:
             fi
           done
           mkdir -p ci
-          for dir in unit-coverage-log-*; do
-            if [ -f "$dir"/*.log ]; then
-              cp -a "$dir"/*.log ci/
-            elif [ -d "$dir/ci" ]; then
-              cp -a "$dir"/ci/. ci/
-            fi
-          done
-          for dir in integration-log db-tests-log; do
-            if [ -f "$dir"/*.log ]; then
-              cp -a "$dir"/*.log ci/
-            elif [ -d "$dir/ci" ]; then
-              cp -a "$dir"/ci/. ci/
-            fi
+          for dir in unit-coverage-log-* integration-log db-tests-log; do
+            [ -d "$dir" ] || continue
+            while IFS= read -r -d '' logfile; do
+              cp -a "$logfile" "ci/$(basename "$logfile")"
+            done < <(find "$dir" -type f -name '*.log' -print0)
           done
 
       - name: Merge coverage and test logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -298,12 +298,23 @@ jobs:
           merge-multiple: true
           path: .
 
+      # merge-multiple extracts each artifact into a named subdirectory; flatten
+      # so merge-coverage.js finds apps/*/coverage and logs land under ci/
+      - name: Restore layout from downloaded artifacts
+        run: |
+          shopt -s nullglob
+          for dir in unit-coverage-reports-* unit-coverage-log-* integration-log db-tests-log; do
+            if [ -d "$dir" ]; then
+              cp -a "$dir"/. .
+            fi
+          done
+
       - name: Merge coverage and test logs
         id: build-summary
         run: |
-          mkdir -p coverage
+          mkdir -p coverage ci
           node scripts/merge-coverage.js
-          cat ci/unit-coverage-*.log ci/integration.log ci/db-tests.log > ci/test-output.log 2>/dev/null || true
+          cat ci/unit-coverage-*.log ci/integration.log ci/db-tests.log > ci/test-output.log 2>/dev/null || touch ci/test-output.log
           node scripts/format-ci-summary.mjs \
             --coverage coverage/coverage-summary.json \
             --test-log ci/test-output.log \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,12 +118,18 @@ jobs:
           set -o pipefail
           npm run ${{ matrix.script }} 2>&1 | tee ci/unit-coverage-${{ matrix.shard }}.log
 
+      - name: Stage coverage for upload
+        if: always() && matrix.coverage_path != ''
+        run: |
+          mkdir -p ".coverage-artifact/${{ matrix.coverage_path }}"
+          cp -a "${{ matrix.coverage_path }}/." ".coverage-artifact/${{ matrix.coverage_path }}/"
+
       - name: Upload coverage reports
         if: always() && matrix.coverage_path != ''
         uses: actions/upload-artifact@v4
         with:
           name: unit-coverage-reports-${{ matrix.shard }}
-          path: ${{ matrix.coverage_path }}
+          path: .coverage-artifact/
           if-no-files-found: warn
 
       - name: Upload test log
@@ -306,30 +312,13 @@ jobs:
           merge-multiple: true
           path: .
 
-      # merge-multiple nests artifacts under unit-coverage-reports-*; each upload
-      # contains only the coverage/ directory contents (not apps/.../coverage).
+      # Artifacts are staged with repo-relative paths (apps/.../coverage) before upload.
       - name: Restore layout from downloaded artifacts
         run: |
           shopt -s nullglob
-          declare -A COVERAGE_PATHS=(
-            [mobile]=apps/mobile/coverage
-            [web]=apps/web/coverage
-            [shared]=packages/shared-tests/coverage
-            [billing]=packages/billing/coverage
-            [admin]=packages/admin/coverage
-            [lifecycle-events]=packages/lifecycle-events/coverage
-            [waitlist]=packages/waitlist/coverage
-            [email]=packages/email/coverage
-            [marketing-email]=packages/marketing-email/coverage
-            [observability]=packages/observability/coverage
-          )
           for dir in unit-coverage-reports-*; do
-            shard="${dir#unit-coverage-reports-}"
-            target="${COVERAGE_PATHS[$shard]:-}"
-            if [ -n "$target" ]; then
-              mkdir -p "$target"
-              cp -a "$dir"/. "$target/"
-            fi
+            [ -d "$dir" ] || continue
+            cp -a "$dir"/. .
           done
           mkdir -p ci
           for dir in unit-coverage-log-* integration-log db-tests-log; do
@@ -338,6 +327,17 @@ jobs:
               cp -a "$logfile" "ci/$(basename "$logfile")"
             done < <(find "$dir" -type f -name '*.log' -print0)
           done
+          # Fail fast if merge-coverage will have nothing to read
+          found=0
+          for f in apps/web/coverage/coverage-final.json packages/billing/coverage/coverage-final.json; do
+            [ -f "$f" ] && found=1
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::error::No coverage-final.json under expected paths after restore"
+            ls -la
+            ls -la unit-coverage-reports-* 2>/dev/null || true
+            exit 1
+          fi
 
       - name: Merge coverage and test logs
         id: build-summary

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -831,7 +831,7 @@ appId: ${WEB_URL}
 
 Tests are automatically run in CI/CD:
 
-- **On every PR:** Unit tests, integration tests, database tests
+- **On every PR:** Unit tests (parallel `unit-coverage-shard` matrix per workspace in `.github/workflows/test.yml`), integration tests, database tests
 - **After PR preview deployment:** E2E tests against preview environment
 - **On merge to develop:** All tests + staging E2E tests
 - **On merge to main:** All tests + production smoke tests

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -165,7 +165,7 @@ Jest integration tests live in `tests/integration/` and run against a **real loc
 | `admin-access.test.ts`            | `admin_is_admin`, `admin_list_users`, audit log, revoke            |
 | `storage-avatars.test.ts`         | Avatars bucket upload RLS, profile `avatar_url` sync               |
 
-Tier 1 runs in the main [Test workflow](../.github/workflows/test.yml) after `supabase start` (Edge runtime excluded for speed).
+Tier 1 runs in the main [Test workflow](../.github/workflows/test.yml) in the `supabase-tests` job (one minimal `supabase start` via [`scripts/ci-supabase-start.sh`](../scripts/ci-supabase-start.sh); migration filename lint runs in parallel as `migration-filenames`). Edge runtime excluded for speed.
 
 ### Tier 2 — Edge + Stripe (optional)
 

--- a/docs/branch-protection-setup.md
+++ b/docs/branch-protection-setup.md
@@ -72,18 +72,20 @@ Branch protection prevents accidental squash merges into `main`, which can cause
 
 The [`Test` workflow](../.github/workflows/test.yml) runs parallel jobs. Each job reports an independent status check. Require these on `main` and `develop`:
 
-| Status check             | Job                                            | Blocks merge?      |
-| ------------------------ | ---------------------------------------------- | ------------------ |
-| `Test / lint`            | ESLint across all workspaces                   | Yes                |
-| `Test / type-check`      | TypeScript `--noEmit`                          | Yes                |
-| `Test / unit-coverage`   | Unit tests with coverage (no Supabase)         | Yes                |
-| `Test / integration`     | Integration tests + web Supabase smoke test    | Yes                |
-| `Test / db-tests`        | Migration filename checks + `supabase test db` | Yes                |
-| `Test / coverage-report` | Merges coverage and posts PR comment           | No (informational) |
+| Status check             | Job                                                                                        | Blocks merge?      |
+| ------------------------ | ------------------------------------------------------------------------------------------ | ------------------ |
+| `Test / lint`            | ESLint across all workspaces                                                               | Yes                |
+| `Test / type-check`      | TypeScript `--noEmit`                                                                      | Yes                |
+| `Test / unit-coverage`   | Gate: all `unit-coverage-shard` matrix legs passed (unit tests with coverage, no Supabase) | Yes                |
+| `Test / integration`     | Integration tests + web Supabase smoke test                                                | Yes                |
+| `Test / db-tests`        | Migration filename checks + `supabase test db`                                             | Yes                |
+| `Test / coverage-report` | Merges coverage and posts PR comment                                                       | No (informational) |
 
 After migrating from the old monolithic `Test / tests` check, remove `Test / tests` from branch protection and add the five required checks above.
 
 `Test / coverage-report` should **not** be required — it aggregates results and may still post a coverage comment when other jobs fail.
+
+Unit tests run in parallel via the `unit-coverage-shard` matrix (one leg per workspace: web, mobile, billing, etc.). GitHub also reports informational checks such as `Test / unit-coverage-shard (web)` — do **not** add those to required checks; only require `Test / unit-coverage`, which fails if any shard fails.
 
 ### Step 4: Optional - GitHub Action to Enforce Merge Strategy
 

--- a/docs/branch-protection-setup.md
+++ b/docs/branch-protection-setup.md
@@ -77,8 +77,8 @@ The [`Test` workflow](../.github/workflows/test.yml) runs parallel jobs. Each jo
 | `Test / lint`            | ESLint across all workspaces                                                               | Yes                |
 | `Test / type-check`      | TypeScript `--noEmit`                                                                      | Yes                |
 | `Test / unit-coverage`   | Gate: all `unit-coverage-shard` matrix legs passed (unit tests with coverage, no Supabase) | Yes                |
-| `Test / integration`     | Integration tests + web Supabase smoke test                                                | Yes                |
-| `Test / db-tests`        | Migration filename checks + `supabase test db`                                             | Yes                |
+| `Test / integration`     | Gate: `supabase-tests` job (integration + web Supabase smoke)                              | Yes                |
+| `Test / db-tests`        | Gate: `migration-filenames` + `supabase-tests` (pgTAP)                                     | Yes                |
 | `Test / coverage-report` | Merges coverage and posts PR comment                                                       | No (informational) |
 
 After migrating from the old monolithic `Test / tests` check, remove `Test / tests` from branch protection and add the five required checks above.
@@ -86,6 +86,8 @@ After migrating from the old monolithic `Test / tests` check, remove `Test / tes
 `Test / coverage-report` should **not** be required — it aggregates results and may still post a coverage comment when other jobs fail.
 
 Unit tests run in parallel via the `unit-coverage-shard` matrix (one leg per workspace: web, mobile, billing, etc.). GitHub also reports informational checks such as `Test / unit-coverage-shard (web)` — do **not** add those to required checks; only require `Test / unit-coverage`, which fails if any shard fails.
+
+`Test / coverage-report` does not wait on `integration` or `db-tests`; it only merges unit-test coverage. Supabase tests run in one `supabase-tests` job (single `supabase start`) with `migration-filenames` in parallel; `Test / integration` and `Test / db-tests` are lightweight gates preserving existing required check names.
 
 ### Step 4: Optional - GitHub Action to Enforce Merge Strategy
 

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "test:integration": "jest --config tests/jest.integration.config.js --forceExit",
     "test:integration:edge": "./scripts/run-integration-edge-tests.sh",
     "test:db": "node --test scripts/__tests__/db-migration-filenames.test.mjs && supabase test db",
+    "test:db:pgtap": "supabase test db",
     "test:e2e": "npm run test:e2e:web && npm run test:e2e:mobile",
     "test:e2e:web": "export PATH=\"$PATH:$HOME/.maestro/bin\" && E2E_PW=\"${TEST_PASSWORD:-E2e_$(openssl rand -hex 16)_Aa1}\" && maestro test tests/e2e/web/flows/home.yaml --env WEB_URL=\"${WEB_URL:-http://localhost:5173}\" --env TEST_EMAIL=\"${TEST_EMAIL:-e2e-test-$(date +%s)@example.com}\" --env TEST_PASSWORD=\"$E2E_PW\"",
     "test:e2e:mobile": "export PATH=\"$PATH:$HOME/.maestro/bin\" && E2E_PW=\"${TEST_PASSWORD:-E2e_$(openssl rand -hex 16)_Aa1}\" && maestro test tests/e2e/mobile/flows/home.yaml --env MOBILE_APP_ID=\"${MOBILE_APP_ID:-com.anonymous.beakerstack}\" --env TEST_EMAIL=\"${TEST_EMAIL:-e2e-test-$(date +%s)@example.com}\" --env TEST_PASSWORD=\"$E2E_PW\"",

--- a/scripts/ci-supabase-start.sh
+++ b/scripts/ci-supabase-start.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Start a minimal local Supabase stack for Tier 1 CI (integration + pgTAP).
+set -euo pipefail
+
+mkdir -p .supabase/logs
+
+# Excludes UI, edge, analytics, mail, pooler, and other services tests do not need.
+supabase start \
+  -x studio,imgproxy,edge-runtime,analytics,mailpit,logflare,vector,supavisor,postgres-meta \
+  > .supabase/logs/start.log 2>&1
+
+supabase status > .supabase/logs/status.log 2>&1
+cat .supabase/logs/status.log


### PR DESCRIPTION
## Summary
- Split the monolithic `unit-coverage` job into an 11-way `unit-coverage-shard` matrix (one leg per workspace).
- Add a `unit-coverage` gate job so the required `Test / unit-coverage` branch protection check name is unchanged.
- Update `coverage-report` to download and merge per-shard coverage artifacts and logs.

## Test plan
- [ ] Confirm all 11 `unit-coverage-shard (*)` jobs run in parallel on CI
- [ ] Confirm `Test / unit-coverage` gate fails when any shard fails
- [ ] Confirm `coverage-report` PR comment and merged coverage totals look correct
- [ ] Compare workflow wall-clock vs. previous sequential `unit-coverage` run