### PR TITLE
feat(kit): Phase 2 — DB schema + lifecycle event emission

### DIFF
--- a/supabase/functions/_shared/marketingEmailQueue.ts
+++ b/supabase/functions/_shared/marketingEmailQueue.ts
@@ -8,35 +8,39 @@ export type LifecycleEventType =
   | 'user.tier_changed'
   | 'user.churned';
 
+// Fire-and-forget: failures are logged but never thrown so marketing email never
+// blocks user-facing flows. A transient failure permanently drops the event —
+// Phase 3's worker has no backfill path for unqueued events.
 export async function enqueueMarketingEmail(
   supabase: SupabaseClient,
   productId: string,
   eventType: LifecycleEventType,
   email: string,
   payload: Record<string, unknown>,
-  idempotencyKey?: string
+  idempotencyKey: string
 ): Promise<void> {
   const { data: settings, error: settingsErr } = await supabase
     .from('marketing_email_settings')
     .select('enabled')
     .eq('product_id', productId)
-    .eq('enabled', true)
     .maybeSingle();
 
   if (settingsErr) {
     console.error('enqueueMarketingEmail: settings lookup failed', settingsErr.message);
     return;
   }
-  if (!settings) return;
+  if (!settings?.enabled) return;
 
   const { error } = await supabase.from('marketing_email_sync_queue').insert({
     product_id: productId,
     event_type: eventType,
     email,
     payload,
-    idempotency_key: idempotencyKey ?? null,
+    idempotency_key: idempotencyKey,
   });
 
+  // '23505' is the Postgres unique_violation code surfaced by PostgREST.
+  // Swallow it so callers are naturally idempotent without extra bookkeeping.
   if (error && error.code !== '23505') {
     console.error('enqueueMarketingEmail error', error.message);
   }

--- a/supabase/functions/_shared/marketingEmailQueue.ts
+++ b/supabase/functions/_shared/marketingEmailQueue.ts
@@ -1,4 +1,4 @@
-import { createClient } from 'npm:@supabase/supabase-js@2.45.0';
+import type { SupabaseClient } from 'npm:@supabase/supabase-js@2.45.0';
 
 export type LifecycleEventType =
   | 'user.signed_up'
@@ -9,22 +9,28 @@ export type LifecycleEventType =
   | 'user.churned';
 
 export async function enqueueMarketingEmail(
-  supabase: ReturnType<typeof createClient>,
+  supabase: SupabaseClient,
+  productId: string,
   eventType: LifecycleEventType,
   email: string,
   payload: Record<string, unknown>,
   idempotencyKey?: string
 ): Promise<void> {
-  const { data: settings } = await supabase
+  const { data: settings, error: settingsErr } = await supabase
     .from('marketing_email_settings')
     .select('enabled')
+    .eq('product_id', productId)
     .eq('enabled', true)
-    .limit(1)
     .maybeSingle();
 
+  if (settingsErr) {
+    console.error('enqueueMarketingEmail: settings lookup failed', settingsErr.message);
+    return;
+  }
   if (!settings) return;
 
   const { error } = await supabase.from('marketing_email_sync_queue').insert({
+    product_id: productId,
     event_type: eventType,
     email,
     payload,

--- a/supabase/functions/_shared/marketingEmailQueue.ts
+++ b/supabase/functions/_shared/marketingEmailQueue.ts
@@ -1,0 +1,37 @@
+import { createClient } from 'npm:@supabase/supabase-js@2.45.0';
+
+export type LifecycleEventType =
+  | 'user.signed_up'
+  | 'waitlist.joined'
+  | 'waitlist.approved'
+  | 'waitlist.converted'
+  | 'user.tier_changed'
+  | 'user.churned';
+
+export async function enqueueMarketingEmail(
+  supabase: ReturnType<typeof createClient>,
+  eventType: LifecycleEventType,
+  email: string,
+  payload: Record<string, unknown>,
+  idempotencyKey?: string
+): Promise<void> {
+  const { data: settings } = await supabase
+    .from('marketing_email_settings')
+    .select('enabled')
+    .eq('enabled', true)
+    .limit(1)
+    .maybeSingle();
+
+  if (!settings) return;
+
+  const { error } = await supabase.from('marketing_email_sync_queue').insert({
+    event_type: eventType,
+    email,
+    payload,
+    idempotency_key: idempotencyKey ?? null,
+  });
+
+  if (error && error.code !== '23505') {
+    console.error('enqueueMarketingEmail error', error.message);
+  }
+}

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -381,19 +381,28 @@ async function processStripeEvent(
         .eq('stripe_subscription_id', stripeSub.id);
       if (error) throw asErrorFromSupabase(error);
 
-      const { data: authUser } = await supabase.auth.admin.getUserById(
-        row.user_id
-      );
-      const userEmail = authUser.user?.email;
-      if (userEmail) {
-        const lifecycleEvent = isCanceled ? 'user.churned' : 'user.tier_changed';
-        await enqueueMarketingEmail(
-          supabase,
-          lifecycleEvent,
-          userEmail,
-          { user_id: row.user_id, plan_id: finalPlanId, status: finalStatus },
-          `${lifecycleEvent}:${event.id}`
+      const { data: authUser, error: authUserErr } =
+        await supabase.auth.admin.getUserById(row.user_id);
+      if (authUserErr) {
+        console.error(
+          'getUserById failed for marketing email enqueue',
+          authUserErr.message
         );
+      } else {
+        const userEmail = authUser.user?.email;
+        if (userEmail) {
+          const lifecycleEvent = isCanceled
+            ? 'user.churned'
+            : 'user.tier_changed';
+          await enqueueMarketingEmail(
+            supabase,
+            row.product_id,
+            lifecycleEvent,
+            userEmail,
+            { user_id: row.user_id, plan_id: finalPlanId, status: finalStatus },
+            `${lifecycleEvent}:${event.id}`
+          );
+        }
       }
 
       return {

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -381,27 +381,33 @@ async function processStripeEvent(
         .eq('stripe_subscription_id', stripeSub.id);
       if (error) throw asErrorFromSupabase(error);
 
-      const { data: authUser, error: authUserErr } =
-        await supabase.auth.admin.getUserById(row.user_id);
-      if (authUserErr) {
-        console.error(
-          'getUserById failed for marketing email enqueue',
-          authUserErr.message
-        );
-      } else {
-        const userEmail = authUser.user?.email;
-        if (userEmail) {
-          const lifecycleEvent = isCanceled
-            ? 'user.churned'
-            : 'user.tier_changed';
-          await enqueueMarketingEmail(
-            supabase,
-            row.product_id,
-            lifecycleEvent,
-            userEmail,
-            { user_id: row.user_id, plan_id: finalPlanId, status: finalStatus },
-            `${lifecycleEvent}:${event.id}`
+      // Emit lifecycle event only when the plan meaningfully changed (churn always qualifies).
+      // Metadata-only updates, cancel_at_period_end toggles with no plan change, etc. are skipped
+      // to avoid noisy no-op syncs in the Phase 3 worker.
+      const planChanged = finalPlanId !== row.plan_id;
+      if (isCanceled || planChanged) {
+        const { data: authUser, error: authUserErr } =
+          await supabase.auth.admin.getUserById(row.user_id);
+        if (authUserErr) {
+          console.error(
+            'getUserById failed for marketing email enqueue',
+            authUserErr.message
           );
+        } else {
+          const userEmail = authUser.user?.email;
+          if (userEmail) {
+            const lifecycleEvent = isCanceled
+              ? 'user.churned'
+              : 'user.tier_changed';
+            await enqueueMarketingEmail(
+              supabase,
+              row.product_id,
+              lifecycleEvent,
+              userEmail,
+              { user_id: row.user_id, plan_id: finalPlanId, status: finalStatus },
+              `${lifecycleEvent}:${event.id}`
+            );
+          }
         }
       }
 

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -10,6 +10,7 @@ import {
   type ClassifyDecision,
   type OwnedSubscriptionRow,
 } from '../_shared/billing-webhook-guards.ts';
+import { enqueueMarketingEmail } from '../_shared/marketingEmailQueue.ts';
 
 type ProcessResult =
   | {
@@ -379,6 +380,22 @@ async function processStripeEvent(
         })
         .eq('stripe_subscription_id', stripeSub.id);
       if (error) throw asErrorFromSupabase(error);
+
+      const { data: authUser } = await supabase.auth.admin.getUserById(
+        row.user_id
+      );
+      const userEmail = authUser.user?.email;
+      if (userEmail) {
+        const lifecycleEvent = isCanceled ? 'user.churned' : 'user.tier_changed';
+        await enqueueMarketingEmail(
+          supabase,
+          lifecycleEvent,
+          userEmail,
+          { user_id: row.user_id, plan_id: finalPlanId, status: finalStatus },
+          `${lifecycleEvent}:${event.id}`
+        );
+      }
+
       return {
         status: 'processed',
         clearStripeIdsFor: isCanceled

--- a/supabase/functions/waitlist-capture/index.ts
+++ b/supabase/functions/waitlist-capture/index.ts
@@ -3,6 +3,7 @@ import {
   corsHeadersForWaitlist,
   jsonResponse,
 } from '../_shared/waitlist-origins.ts';
+import { enqueueMarketingEmail } from '../_shared/marketingEmailQueue.ts';
 
 type Body = {
   email?: string;
@@ -74,6 +75,14 @@ Deno.serve(async req => {
       req
     );
   }
+
+  await enqueueMarketingEmail(
+    admin,
+    'waitlist.joined',
+    email,
+    { metadata: body.metadata ?? {} },
+    `waitlist.joined:${email}`
+  );
 
   return jsonResponse(data ?? { ok: true }, 200, req);
 });

--- a/supabase/functions/waitlist-capture/index.ts
+++ b/supabase/functions/waitlist-capture/index.ts
@@ -76,8 +76,11 @@ Deno.serve(async req => {
     );
   }
 
-  const productId =
-    Deno.env.get('WAITLIST_PRODUCT_ID') || 'beakerstack';
+  const envProductId = Deno.env.get('WAITLIST_PRODUCT_ID');
+  if (!envProductId) {
+    console.warn('WAITLIST_PRODUCT_ID is not set; defaulting to "beakerstack"');
+  }
+  const productId = envProductId || 'beakerstack';
 
   await enqueueMarketingEmail(
     admin,

--- a/supabase/functions/waitlist-capture/index.ts
+++ b/supabase/functions/waitlist-capture/index.ts
@@ -55,7 +55,7 @@ Deno.serve(async req => {
     );
   }
 
-  const email = body.email?.trim();
+  const email = body.email?.trim().toLowerCase();
   if (!email) {
     return jsonResponse({ error: 'invalid_email' }, 400, req);
   }
@@ -76,8 +76,12 @@ Deno.serve(async req => {
     );
   }
 
+  const productId =
+    Deno.env.get('WAITLIST_PRODUCT_ID') || 'beakerstack';
+
   await enqueueMarketingEmail(
     admin,
+    productId,
     'waitlist.joined',
     email,
     { metadata: body.metadata ?? {} },

--- a/supabase/functions/waitlist-ops/index.ts
+++ b/supabase/functions/waitlist-ops/index.ts
@@ -88,10 +88,13 @@ Deno.serve(async req => {
   }
 
   const admin = createClient(supabaseUrl, serviceKey);
-  const productId =
-    body.productId?.trim() ||
-    Deno.env.get('WAITLIST_PRODUCT_ID') ||
-    'beakerstack';
+
+  // Marketing email product is always server-controlled — never caller-supplied.
+  const envProductId = Deno.env.get('WAITLIST_PRODUCT_ID');
+  if (!envProductId) {
+    console.warn('WAITLIST_PRODUCT_ID is not set; defaulting to "beakerstack"');
+  }
+  const marketingProductId = envProductId || 'beakerstack';
 
   if (body.action === 'validate') {
     const token = body.token?.trim();
@@ -154,10 +157,15 @@ Deno.serve(async req => {
 
     if (consumeResult.ok && !consumeResult.already_converted) {
       if (consumeResult.default_plan_id) {
+        // Billing productId may be caller-supplied (admin choosing product for billing).
+        const billingProductId =
+          body.productId?.trim() ||
+          Deno.env.get('WAITLIST_PRODUCT_ID') ||
+          'beakerstack';
         const { error: planErr } = await admin.rpc(
           'billing_ensure_subscription_plan',
           {
-            p_product_id: productId,
+            p_product_id: billingProductId,
             p_plan_id: consumeResult.default_plan_id,
             p_user_id: userId,
           }
@@ -168,11 +176,13 @@ Deno.serve(async req => {
         }
       }
 
-      const consumeEmail = body.userEmail ?? user.email ?? null;
+      // Use the JWT-verified email only — never the caller-supplied userEmail,
+      // which could route the Kit event to an arbitrary address.
+      const consumeEmail = user.email?.toLowerCase().trim() ?? null;
       if (consumeEmail) {
         await enqueueMarketingEmail(
           admin,
-          productId,
+          marketingProductId,
           'waitlist.converted',
           consumeEmail,
           { user_id: userId },
@@ -195,7 +205,10 @@ Deno.serve(async req => {
       return jsonResponse({ error: 'invalid_request' }, 400, req);
     }
 
-    const { data: entryData, error: entryErr } = await admin.rpc(
+    // Use authClient (carries admin JWT) — admin_get_waitlist_entry checks
+    // auth.uid() + admin_is_admin() internally, so the service-role client
+    // would return { error: 'not_found' } because auth.uid() is NULL.
+    const { data: entryData, error: entryErr } = await authClient.rpc(
       'admin_get_waitlist_entry',
       { p_id: body.entryId }
     );
@@ -217,7 +230,7 @@ Deno.serve(async req => {
     if (entryEmail) {
       await enqueueMarketingEmail(
         admin,
-        productId,
+        marketingProductId,
         'waitlist.approved',
         entryEmail,
         { entry_id: body.entryId },

--- a/supabase/functions/waitlist-ops/index.ts
+++ b/supabase/functions/waitlist-ops/index.ts
@@ -88,6 +88,10 @@ Deno.serve(async req => {
   }
 
   const admin = createClient(supabaseUrl, serviceKey);
+  const productId =
+    body.productId?.trim() ||
+    Deno.env.get('WAITLIST_PRODUCT_ID') ||
+    'beakerstack';
 
   if (body.action === 'validate') {
     const token = body.token?.trim();
@@ -150,10 +154,6 @@ Deno.serve(async req => {
 
     if (consumeResult.ok && !consumeResult.already_converted) {
       if (consumeResult.default_plan_id) {
-        const productId =
-          body.productId?.trim() ||
-          Deno.env.get('WAITLIST_PRODUCT_ID') ||
-          'beakerstack';
         const { error: planErr } = await admin.rpc(
           'billing_ensure_subscription_plan',
           {
@@ -172,6 +172,7 @@ Deno.serve(async req => {
       if (consumeEmail) {
         await enqueueMarketingEmail(
           admin,
+          productId,
           'waitlist.converted',
           consumeEmail,
           { user_id: userId },
@@ -194,9 +195,13 @@ Deno.serve(async req => {
       return jsonResponse({ error: 'invalid_request' }, 400, req);
     }
 
-    const { data: entryData } = await admin.rpc('admin_get_waitlist_entry', {
-      p_id: body.entryId,
-    });
+    const { data: entryData, error: entryErr } = await admin.rpc(
+      'admin_get_waitlist_entry',
+      { p_id: body.entryId }
+    );
+    if (entryErr) {
+      console.error('admin_get_waitlist_entry error', entryErr.message);
+    }
     const entryEmail = (entryData as { email?: string } | null)?.email;
 
     const { data, error } = await authClient.rpc(
@@ -212,6 +217,7 @@ Deno.serve(async req => {
     if (entryEmail) {
       await enqueueMarketingEmail(
         admin,
+        productId,
         'waitlist.approved',
         entryEmail,
         { entry_id: body.entryId },

--- a/supabase/functions/waitlist-ops/index.ts
+++ b/supabase/functions/waitlist-ops/index.ts
@@ -3,6 +3,7 @@ import {
   corsHeadersForWaitlist,
   jsonResponse,
 } from '../_shared/waitlist-origins.ts';
+import { enqueueMarketingEmail } from '../_shared/marketingEmailQueue.ts';
 
 type Body = {
   action:
@@ -147,26 +148,35 @@ Deno.serve(async req => {
       return jsonResponse({ error: consumeResult.error }, 400, req);
     }
 
-    if (
-      consumeResult.ok &&
-      !consumeResult.already_converted &&
-      consumeResult.default_plan_id
-    ) {
-      const productId =
-        body.productId?.trim() ||
-        Deno.env.get('WAITLIST_PRODUCT_ID') ||
-        'beakerstack';
-      const { error: planErr } = await admin.rpc(
-        'billing_ensure_subscription_plan',
-        {
-          p_product_id: productId,
-          p_plan_id: consumeResult.default_plan_id,
-          p_user_id: userId,
+    if (consumeResult.ok && !consumeResult.already_converted) {
+      if (consumeResult.default_plan_id) {
+        const productId =
+          body.productId?.trim() ||
+          Deno.env.get('WAITLIST_PRODUCT_ID') ||
+          'beakerstack';
+        const { error: planErr } = await admin.rpc(
+          'billing_ensure_subscription_plan',
+          {
+            p_product_id: productId,
+            p_plan_id: consumeResult.default_plan_id,
+            p_user_id: userId,
+          }
+        );
+        if (planErr) {
+          console.error('billing_ensure_subscription_plan', planErr.message);
+          return jsonResponse({ error: 'plan_provision_failed' }, 500, req);
         }
-      );
-      if (planErr) {
-        console.error('billing_ensure_subscription_plan', planErr.message);
-        return jsonResponse({ error: 'plan_provision_failed' }, 500, req);
+      }
+
+      const consumeEmail = body.userEmail ?? user.email ?? null;
+      if (consumeEmail) {
+        await enqueueMarketingEmail(
+          admin,
+          'waitlist.converted',
+          consumeEmail,
+          { user_id: userId },
+          `waitlist.converted:${userId}`
+        );
       }
     }
 
@@ -183,6 +193,12 @@ Deno.serve(async req => {
     if (!body.entryId) {
       return jsonResponse({ error: 'invalid_request' }, 400, req);
     }
+
+    const { data: entryData } = await admin.rpc('admin_get_waitlist_entry', {
+      p_id: body.entryId,
+    });
+    const entryEmail = (entryData as { email?: string } | null)?.email;
+
     const { data, error } = await authClient.rpc(
       'admin_approve_waitlist_entry',
       {
@@ -192,6 +208,17 @@ Deno.serve(async req => {
     if (error) {
       return jsonResponse({ error: error.message }, 400, req);
     }
+
+    if (entryEmail) {
+      await enqueueMarketingEmail(
+        admin,
+        'waitlist.approved',
+        entryEmail,
+        { entry_id: body.entryId },
+        `waitlist.approved:${body.entryId}`
+      );
+    }
+
     return jsonResponse(data, 200, req);
   }
 

--- a/supabase/migrations/20260520200000_marketing_email_v1.sql
+++ b/supabase/migrations/20260520200000_marketing_email_v1.sql
@@ -1,0 +1,74 @@
+-- marketing_email_settings: feature flag + config per product
+CREATE TABLE marketing_email_settings (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  product_id  text        NOT NULL UNIQUE,
+  enabled     boolean     NOT NULL DEFAULT false,
+  provider    text        NOT NULL DEFAULT 'kit',
+  config      jsonb       NOT NULL DEFAULT '{}',
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE marketing_email_settings ENABLE ROW LEVEL SECURITY;
+
+-- marketing_email_sync_queue: lifecycle events waiting to sync to the email provider
+CREATE TABLE marketing_email_sync_queue (
+  id                bigserial   PRIMARY KEY,
+  event_type        text        NOT NULL,
+  email             text        NOT NULL,
+  payload           jsonb       NOT NULL DEFAULT '{}',
+  idempotency_key   text        UNIQUE,
+  status            text        NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'processing', 'done', 'failed')),
+  attempts          int         NOT NULL DEFAULT 0,
+  last_attempted_at timestamptz,
+  error             text,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  processed_at      timestamptz
+);
+
+CREATE INDEX marketing_email_sync_queue_pending_idx
+  ON marketing_email_sync_queue (created_at)
+  WHERE status IN ('pending', 'failed');
+
+ALTER TABLE marketing_email_sync_queue ENABLE ROW LEVEL SECURITY;
+
+-- marketing_email_unsubscribes: local mirror of provider unsubscribes for fast lookup
+CREATE TABLE marketing_email_unsubscribes (
+  id         bigserial   PRIMARY KEY,
+  email      text        NOT NULL UNIQUE,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE marketing_email_unsubscribes ENABLE ROW LEVEL SECURITY;
+
+-- Trigger: enqueue user.signed_up for every new auth user when marketing email is enabled
+CREATE OR REPLACE FUNCTION _marketing_email_on_user_signed_up()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM marketing_email_settings WHERE enabled = true
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.email IS NULL OR NEW.email = '' THEN
+    RETURN NEW;
+  END IF;
+
+  INSERT INTO marketing_email_sync_queue (event_type, email, payload, idempotency_key)
+  VALUES (
+    'user.signed_up',
+    NEW.email,
+    jsonb_build_object('user_id', NEW.id, 'created_at', NEW.created_at),
+    'user.signed_up:' || NEW.id::text
+  )
+  ON CONFLICT (idempotency_key) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER marketing_email_user_signed_up
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION _marketing_email_on_user_signed_up();

--- a/supabase/migrations/20260520200000_marketing_email_v1.sql
+++ b/supabase/migrations/20260520200000_marketing_email_v1.sql
@@ -1,24 +1,38 @@
--- marketing_email_settings: feature flag + config per product
+-- marketing_email_settings: feature flag + provider config per product
 CREATE TABLE public.marketing_email_settings (
   id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
   product_id  text        NOT NULL UNIQUE,
   enabled     boolean     NOT NULL DEFAULT false,
-  provider    text        NOT NULL DEFAULT 'kit',
+  provider    text        NOT NULL DEFAULT 'kit'
+    CHECK (provider IN ('kit')),
   config      jsonb       NOT NULL DEFAULT '{}',
   created_at  timestamptz NOT NULL DEFAULT now(),
   updated_at  timestamptz NOT NULL DEFAULT now()
 );
 
+-- Enforce at most one product with enabled = true; the auth.users trigger relies on this.
+CREATE UNIQUE INDEX marketing_email_settings_one_enabled_idx
+  ON public.marketing_email_settings ((enabled))
+  WHERE enabled = true;
+
+CREATE TRIGGER marketing_email_settings_updated_at
+  BEFORE UPDATE ON public.marketing_email_settings
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
 ALTER TABLE public.marketing_email_settings ENABLE ROW LEVEL SECURITY;
 
--- marketing_email_sync_queue: lifecycle events waiting to sync to the email provider
+-- marketing_email_sync_queue: lifecycle events pending sync to the email provider
 CREATE TABLE public.marketing_email_sync_queue (
   id                bigserial   PRIMARY KEY,
   product_id        text        NOT NULL,
-  event_type        text        NOT NULL,
+  event_type        text        NOT NULL
+    CHECK (event_type IN (
+      'user.signed_up', 'waitlist.joined', 'waitlist.approved',
+      'waitlist.converted', 'user.tier_changed', 'user.churned'
+    )),
   email             text        NOT NULL,
   payload           jsonb       NOT NULL DEFAULT '{}',
-  idempotency_key   text        UNIQUE,
+  idempotency_key   text        NOT NULL UNIQUE,
   status            text        NOT NULL DEFAULT 'pending'
     CHECK (status IN ('pending', 'processing', 'done', 'failed')),
   attempts          int         NOT NULL DEFAULT 0,
@@ -28,23 +42,28 @@ CREATE TABLE public.marketing_email_sync_queue (
   processed_at      timestamptz
 );
 
-CREATE INDEX public_marketing_email_sync_queue_pending_idx
-  ON public.marketing_email_sync_queue (created_at)
+-- Supports Phase 3 worker: WHERE status IN ('pending','failed') ORDER BY product_id, created_at
+CREATE INDEX marketing_email_sync_queue_pending_idx
+  ON public.marketing_email_sync_queue (product_id, created_at)
   WHERE status IN ('pending', 'failed');
 
 ALTER TABLE public.marketing_email_sync_queue ENABLE ROW LEVEL SECURITY;
 
--- marketing_email_unsubscribes: local mirror of provider unsubscribes for fast lookup
+-- marketing_email_unsubscribes: local mirror of provider unsubscribes for pre-send suppression
 CREATE TABLE public.marketing_email_unsubscribes (
   id         bigserial   PRIMARY KEY,
-  email      text        NOT NULL UNIQUE,
-  created_at timestamptz NOT NULL DEFAULT now()
+  product_id text        NOT NULL,
+  email      text        NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (product_id, email)
 );
 
 ALTER TABLE public.marketing_email_unsubscribes ENABLE ROW LEVEL SECURITY;
 
 -- Trigger: enqueue user.signed_up for every new auth user when marketing email is enabled.
--- SECURITY DEFINER with fixed search_path guards against search_path hijacking.
+-- Assumes exactly one product_id has enabled = true at a time, enforced by
+-- marketing_email_settings_one_enabled_idx. SECURITY DEFINER with fixed search_path
+-- guards against search_path hijacking.
 CREATE OR REPLACE FUNCTION public._marketing_email_on_user_signed_up()
 RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER
 SET search_path = public, pg_catalog AS $$
@@ -54,6 +73,7 @@ BEGIN
   SELECT product_id INTO v_product_id
     FROM public.marketing_email_settings
     WHERE enabled = true
+    ORDER BY product_id
     LIMIT 1;
 
   IF NOT FOUND THEN
@@ -69,7 +89,7 @@ BEGIN
   VALUES (
     v_product_id,
     'user.signed_up',
-    NEW.email,
+    lower(trim(NEW.email)),
     jsonb_build_object('user_id', NEW.id, 'created_at', NEW.created_at),
     'user.signed_up:' || NEW.id::text
   )
@@ -78,6 +98,8 @@ BEGIN
   RETURN NEW;
 END;
 $$;
+
+REVOKE ALL ON FUNCTION public._marketing_email_on_user_signed_up() FROM PUBLIC;
 
 CREATE TRIGGER marketing_email_user_signed_up
   AFTER INSERT ON auth.users

--- a/supabase/migrations/20260520200000_marketing_email_v1.sql
+++ b/supabase/migrations/20260520200000_marketing_email_v1.sql
@@ -1,5 +1,5 @@
 -- marketing_email_settings: feature flag + config per product
-CREATE TABLE marketing_email_settings (
+CREATE TABLE public.marketing_email_settings (
   id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
   product_id  text        NOT NULL UNIQUE,
   enabled     boolean     NOT NULL DEFAULT false,
@@ -9,11 +9,12 @@ CREATE TABLE marketing_email_settings (
   updated_at  timestamptz NOT NULL DEFAULT now()
 );
 
-ALTER TABLE marketing_email_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.marketing_email_settings ENABLE ROW LEVEL SECURITY;
 
 -- marketing_email_sync_queue: lifecycle events waiting to sync to the email provider
-CREATE TABLE marketing_email_sync_queue (
+CREATE TABLE public.marketing_email_sync_queue (
   id                bigserial   PRIMARY KEY,
+  product_id        text        NOT NULL,
   event_type        text        NOT NULL,
   email             text        NOT NULL,
   payload           jsonb       NOT NULL DEFAULT '{}',
@@ -27,28 +28,35 @@ CREATE TABLE marketing_email_sync_queue (
   processed_at      timestamptz
 );
 
-CREATE INDEX marketing_email_sync_queue_pending_idx
-  ON marketing_email_sync_queue (created_at)
+CREATE INDEX public_marketing_email_sync_queue_pending_idx
+  ON public.marketing_email_sync_queue (created_at)
   WHERE status IN ('pending', 'failed');
 
-ALTER TABLE marketing_email_sync_queue ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.marketing_email_sync_queue ENABLE ROW LEVEL SECURITY;
 
 -- marketing_email_unsubscribes: local mirror of provider unsubscribes for fast lookup
-CREATE TABLE marketing_email_unsubscribes (
+CREATE TABLE public.marketing_email_unsubscribes (
   id         bigserial   PRIMARY KEY,
   email      text        NOT NULL UNIQUE,
   created_at timestamptz NOT NULL DEFAULT now()
 );
 
-ALTER TABLE marketing_email_unsubscribes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.marketing_email_unsubscribes ENABLE ROW LEVEL SECURITY;
 
--- Trigger: enqueue user.signed_up for every new auth user when marketing email is enabled
-CREATE OR REPLACE FUNCTION _marketing_email_on_user_signed_up()
-RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
+-- Trigger: enqueue user.signed_up for every new auth user when marketing email is enabled.
+-- SECURITY DEFINER with fixed search_path guards against search_path hijacking.
+CREATE OR REPLACE FUNCTION public._marketing_email_on_user_signed_up()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_catalog AS $$
+DECLARE
+  v_product_id text;
 BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM marketing_email_settings WHERE enabled = true
-  ) THEN
+  SELECT product_id INTO v_product_id
+    FROM public.marketing_email_settings
+    WHERE enabled = true
+    LIMIT 1;
+
+  IF NOT FOUND THEN
     RETURN NEW;
   END IF;
 
@@ -56,8 +64,10 @@ BEGIN
     RETURN NEW;
   END IF;
 
-  INSERT INTO marketing_email_sync_queue (event_type, email, payload, idempotency_key)
+  INSERT INTO public.marketing_email_sync_queue
+    (product_id, event_type, email, payload, idempotency_key)
   VALUES (
+    v_product_id,
     'user.signed_up',
     NEW.email,
     jsonb_build_object('user_id', NEW.id, 'created_at', NEW.created_at),
@@ -71,4 +81,4 @@ $$;
 
 CREATE TRIGGER marketing_email_user_signed_up
   AFTER INSERT ON auth.users
-  FOR EACH ROW EXECUTE FUNCTION _marketing_email_on_user_signed_up();
+  FOR EACH ROW EXECUTE FUNCTION public._marketing_email_on_user_signed_up();

--- a/supabase/tests/marketing_email.test.sql
+++ b/supabase/tests/marketing_email.test.sql
@@ -1,0 +1,305 @@
+-- pgTAP tests for Phase 2 marketing email schema and trigger.
+-- Covers: table existence, RLS, CHECK constraints, trigger behavior, idempotency.
+-- Pattern: BEGIN / SELECT plan(N) / assertions / SELECT * FROM finish() / ROLLBACK
+
+BEGIN;
+
+SELECT plan(25);
+
+-- ── 1-3  Table existence ────────────────────────────────────────────────────
+
+SELECT has_table(
+    'public', 'marketing_email_settings',
+    'marketing_email_settings table exists'
+);
+
+SELECT has_table(
+    'public', 'marketing_email_sync_queue',
+    'marketing_email_sync_queue table exists'
+);
+
+SELECT has_table(
+    'public', 'marketing_email_unsubscribes',
+    'marketing_email_unsubscribes table exists'
+);
+
+-- ── 4-6  RLS enabled ────────────────────────────────────────────────────────
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'marketing_email_settings'
+          AND c.relrowsecurity = true
+    ),
+    'RLS enabled on marketing_email_settings'
+);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'marketing_email_sync_queue'
+          AND c.relrowsecurity = true
+    ),
+    'RLS enabled on marketing_email_sync_queue'
+);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'marketing_email_unsubscribes'
+          AND c.relrowsecurity = true
+    ),
+    'RLS enabled on marketing_email_unsubscribes'
+);
+
+-- ── 7-9  No user-facing RLS policies (all three tables are service-role only) ─
+
+SELECT ok(
+    NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'marketing_email_settings'
+    ),
+    'No RLS policies on marketing_email_settings — service-role access only'
+);
+
+SELECT ok(
+    NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'marketing_email_sync_queue'
+    ),
+    'No RLS policies on marketing_email_sync_queue — service-role access only'
+);
+
+SELECT ok(
+    NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'marketing_email_unsubscribes'
+    ),
+    'No RLS policies on marketing_email_unsubscribes — service-role access only'
+);
+
+-- ── 10-12  CHECK constraints ─────────────────────────────────────────────────
+
+SELECT throws_ok(
+    $throws$
+        INSERT INTO public.marketing_email_sync_queue
+            (product_id, event_type, email, idempotency_key)
+        VALUES ('chk', 'bad_event_type', 'a@b.com', 'chk-event-1')
+    $throws$,
+    '23514', NULL,
+    'event_type CHECK rejects values outside LifecycleEventType'
+);
+
+SELECT throws_ok(
+    $throws$
+        INSERT INTO public.marketing_email_sync_queue
+            (product_id, event_type, email, idempotency_key, status)
+        VALUES ('chk', 'user.signed_up', 'a@b.com', 'chk-status-1', 'bad_status')
+    $throws$,
+    '23514', NULL,
+    'status CHECK rejects invalid status values'
+);
+
+SELECT throws_ok(
+    $throws$
+        INSERT INTO public.marketing_email_settings (product_id, provider)
+        VALUES ('chk_provider', 'mailchimp')
+    $throws$,
+    '23514', NULL,
+    'provider CHECK rejects values other than ''kit'''
+);
+
+-- ── 13-14  NOT NULL constraints ──────────────────────────────────────────────
+
+SELECT throws_ok(
+    $throws$
+        INSERT INTO public.marketing_email_sync_queue
+            (product_id, event_type, email, idempotency_key)
+        VALUES ('chk', 'user.signed_up', 'a@b.com', NULL)
+    $throws$,
+    '23502', NULL,
+    'idempotency_key NOT NULL enforced on marketing_email_sync_queue'
+);
+
+SELECT throws_ok(
+    $throws$
+        INSERT INTO public.marketing_email_unsubscribes (product_id, email)
+        VALUES (NULL, 'a@b.com')
+    $throws$,
+    '23502', NULL,
+    'marketing_email_unsubscribes.product_id NOT NULL enforced'
+);
+
+-- ── 15-16  Trigger function and trigger existence ────────────────────────────
+
+SELECT has_function(
+    'public',
+    '_marketing_email_on_user_signed_up',
+    'trigger function _marketing_email_on_user_signed_up exists in public schema'
+);
+
+SELECT has_trigger(
+    'auth',
+    'users',
+    'marketing_email_user_signed_up',
+    'trigger marketing_email_user_signed_up exists on auth.users'
+);
+
+-- ── 17  PUBLIC execute revoked ───────────────────────────────────────────────
+-- REVOKE ALL FROM PUBLIC sets proacl to a non-null ACL on pg_proc.
+-- A null proacl means default privileges apply (PUBLIC can execute),
+-- so non-null confirms the revoke ran.
+
+SELECT ok(
+    (
+        SELECT p.proacl IS NOT NULL
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname = '_marketing_email_on_user_signed_up'
+    ),
+    'REVOKE ALL FROM PUBLIC sets non-null proacl on _marketing_email_on_user_signed_up'
+);
+
+-- ── 18  No enabled settings → auth insert → no queue row ────────────────────
+-- At this point no marketing_email_settings rows exist in this transaction,
+-- so the trigger's SELECT INTO finds nothing and returns early.
+
+INSERT INTO auth.users (
+    id, instance_id, email, encrypted_password, email_confirmed_at,
+    raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role
+) VALUES (
+    '00000000-0000-4444-0000-000000000001',
+    '00000000-0000-0000-0000-000000000000',
+    'nosettings@example.com',
+    crypt('x', gen_salt('bf')),
+    now(), '{}'::jsonb, '{}'::jsonb, now(), now(),
+    'authenticated', 'authenticated'
+);
+
+SELECT ok(
+    NOT EXISTS (
+        SELECT 1 FROM public.marketing_email_sync_queue
+        WHERE email = 'nosettings@example.com'
+    ),
+    'No enabled settings: auth.users INSERT does not produce a queue row'
+);
+
+-- ── Setup: enable marketing email for trigger behavior tests ─────────────────
+
+INSERT INTO public.marketing_email_settings (product_id, enabled, provider)
+VALUES ('trigger_test_product', true, 'kit');
+
+-- ── 19  Partial unique index: second enabled=true must fail ──────────────────
+
+SELECT throws_ok(
+    $throws$
+        INSERT INTO public.marketing_email_settings (product_id, enabled, provider)
+        VALUES ('trigger_test_product_2', true, 'kit')
+    $throws$,
+    '23505', NULL,
+    'Partial unique index prevents more than one marketing_email_settings row with enabled = true'
+);
+
+-- ── 20-24  Trigger: enabled=true → queue row with correct fields ─────────────
+-- Insert with mixed-case email to verify lower(trim()) normalization.
+
+INSERT INTO auth.users (
+    id, instance_id, email, encrypted_password, email_confirmed_at,
+    raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role
+) VALUES (
+    '00000000-0000-4444-0000-000000000002',
+    '00000000-0000-0000-0000-000000000000',
+    '  TRIGGERED@Example.com  ',
+    crypt('x', gen_salt('bf')),
+    now(), '{}'::jsonb, '{}'::jsonb, now(), now(),
+    'authenticated', 'authenticated'
+);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM public.marketing_email_sync_queue
+        WHERE idempotency_key = 'user.signed_up:00000000-0000-4444-0000-000000000002'
+    ),
+    'enabled=true: auth.users INSERT enqueues a user.signed_up row'
+);
+
+SELECT is(
+    (
+        SELECT product_id FROM public.marketing_email_sync_queue
+        WHERE idempotency_key = 'user.signed_up:00000000-0000-4444-0000-000000000002'
+    ),
+    'trigger_test_product',
+    'Queue row product_id matches the enabled marketing_email_settings row'
+);
+
+SELECT is(
+    (
+        SELECT email FROM public.marketing_email_sync_queue
+        WHERE idempotency_key = 'user.signed_up:00000000-0000-4444-0000-000000000002'
+    ),
+    'triggered@example.com',
+    'Queue row email is lower(trim(NEW.email)) — normalized regardless of input casing'
+);
+
+SELECT is(
+    (
+        SELECT event_type FROM public.marketing_email_sync_queue
+        WHERE idempotency_key = 'user.signed_up:00000000-0000-4444-0000-000000000002'
+    ),
+    'user.signed_up',
+    'Queue row event_type is user.signed_up'
+);
+
+-- ── 24  Idempotency: ON CONFLICT DO NOTHING on duplicate key ─────────────────
+
+INSERT INTO public.marketing_email_sync_queue
+    (product_id, event_type, email, idempotency_key)
+VALUES
+    ('trigger_test_product', 'user.signed_up',
+     'triggered@example.com',
+     'user.signed_up:00000000-0000-4444-0000-000000000002')
+ON CONFLICT (idempotency_key) DO NOTHING;
+
+SELECT ok(
+    (
+        SELECT count(*) = 1 FROM public.marketing_email_sync_queue
+        WHERE idempotency_key = 'user.signed_up:00000000-0000-4444-0000-000000000002'
+    ),
+    'ON CONFLICT DO NOTHING: duplicate idempotency_key leaves exactly one row'
+);
+
+-- ── 25  Null email → trigger returns early without enqueueing ────────────────
+
+INSERT INTO auth.users (
+    id, instance_id, email, encrypted_password, email_confirmed_at,
+    raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role
+) VALUES (
+    '00000000-0000-4444-0000-000000000003',
+    '00000000-0000-0000-0000-000000000000',
+    NULL,
+    crypt('x', gen_salt('bf')),
+    now(), '{}'::jsonb, '{}'::jsonb, now(), now(),
+    'authenticated', 'authenticated'
+);
+
+SELECT ok(
+    NOT EXISTS (
+        SELECT 1 FROM public.marketing_email_sync_queue
+        WHERE idempotency_key = 'user.signed_up:00000000-0000-4444-0000-000000000003'
+    ),
+    'Null email: trigger returns early without inserting a queue row'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;

--- a/tests/integration/marketing-email-queue.test.ts
+++ b/tests/integration/marketing-email-queue.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Integration tests for the marketing email queue (Phase 2).
+ *
+ * Tier 1 scope: exercises the DB layer that Edge Functions rely on —
+ * marketing_email_settings lookup, queue insertion, idempotency, and the
+ * waitlist_capture RPC. The full HTTP → Edge → queue path is Tier 2
+ * (tests/integration/waitlist-edge.test.ts, deferred to Phase 3).
+ *
+ * Prerequisites: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY pointing at a
+ * freshly migrated PR test DB (no pre-existing marketing_email_settings rows).
+ */
+
+import { SupabaseClient } from '@supabase/supabase-js';
+import { createServiceRoleClient } from '../utils/test-clients';
+import { TestData } from '../utils/test-helpers';
+
+const TEST_PRODUCT_ID = 'beakerstack';
+
+describe('Marketing Email Queue — Integration Tests', () => {
+  let admin: SupabaseClient;
+
+  beforeAll(() => {
+    admin = createServiceRoleClient();
+  });
+
+  afterAll(async () => {
+    await admin
+      .from('marketing_email_sync_queue')
+      .delete()
+      .eq('product_id', TEST_PRODUCT_ID);
+    await admin
+      .from('marketing_email_settings')
+      .delete()
+      .eq('product_id', TEST_PRODUCT_ID);
+    await admin
+      .from('waitlist_entries')
+      .delete()
+      .like('email', 'test-%@example.com');
+  });
+
+  // ── Queue table: field validation and idempotency ──────────────────────────
+
+  describe('Queue table — direct insert behavior', () => {
+    const email = TestData.email();
+    const idempotencyKey = `waitlist.joined:${email}`;
+
+    it('inserts a pending queue row with all expected fields', async () => {
+      const { error } = await admin.from('marketing_email_sync_queue').insert({
+        product_id: TEST_PRODUCT_ID,
+        event_type: 'waitlist.joined',
+        email,
+        payload: { metadata: { source: 'integration-test' } },
+        idempotency_key: idempotencyKey,
+      });
+      expect(error).toBeNull();
+
+      const { data: row, error: readErr } = await admin
+        .from('marketing_email_sync_queue')
+        .select('*')
+        .eq('idempotency_key', idempotencyKey)
+        .single();
+
+      expect(readErr).toBeNull();
+      expect(row).toBeDefined();
+      expect(row?.product_id).toBe(TEST_PRODUCT_ID);
+      expect(row?.event_type).toBe('waitlist.joined');
+      expect(row?.email).toBe(email);
+      expect(row?.status).toBe('pending');
+      expect(row?.attempts).toBe(0);
+      expect(row?.payload).toMatchObject({ metadata: { source: 'integration-test' } });
+      expect(row?.idempotency_key).toBe(idempotencyKey);
+    });
+
+    it('returns a 23505 unique_violation on duplicate idempotency_key', async () => {
+      const { error } = await admin.from('marketing_email_sync_queue').insert({
+        product_id: TEST_PRODUCT_ID,
+        event_type: 'waitlist.joined',
+        email,
+        payload: {},
+        idempotency_key: idempotencyKey,
+      });
+      expect(error).not.toBeNull();
+      expect(error?.code).toBe('23505');
+    });
+
+    it('ON CONFLICT DO NOTHING leaves exactly one row for the duplicate key', async () => {
+      // Callers swallow 23505 by using ON CONFLICT DO NOTHING at the DB level.
+      // Supabase JS doesn't expose upsert with DO NOTHING directly, so we verify
+      // the single-row invariant holds after a rejected duplicate.
+      const { data: rows, error } = await admin
+        .from('marketing_email_sync_queue')
+        .select('id')
+        .eq('idempotency_key', idempotencyKey);
+
+      expect(error).toBeNull();
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  // ── Settings-aware enqueue ──────────────────────────────────────────────────
+
+  describe('Settings-aware enqueue (enabled=true)', () => {
+    beforeAll(async () => {
+      // Disable any competing enabled row so the partial unique index won't
+      // reject our upsert. In a clean PR test DB this is a no-op.
+      await admin
+        .from('marketing_email_settings')
+        .update({ enabled: false })
+        .eq('enabled', true)
+        .neq('product_id', TEST_PRODUCT_ID);
+
+      const { error } = await admin.from('marketing_email_settings').upsert(
+        { product_id: TEST_PRODUCT_ID, enabled: true, provider: 'kit' },
+        { onConflict: 'product_id' }
+      );
+      expect(error).toBeNull();
+    });
+
+    it('settings lookup returns enabled for the test product', async () => {
+      const { data: settings, error } = await admin
+        .from('marketing_email_settings')
+        .select('enabled')
+        .eq('product_id', TEST_PRODUCT_ID)
+        .maybeSingle();
+
+      expect(error).toBeNull();
+      expect(settings?.enabled).toBe(true);
+    });
+
+    it('inserts waitlist.joined with correct product_id when enabled', async () => {
+      const email = TestData.email();
+      const idempotencyKey = `waitlist.joined:${email}:enabled-test`;
+
+      const { error } = await admin.from('marketing_email_sync_queue').insert({
+        product_id: TEST_PRODUCT_ID,
+        event_type: 'waitlist.joined',
+        email,
+        payload: { metadata: { plan: 'pro' } },
+        idempotency_key: idempotencyKey,
+      });
+      expect(error).toBeNull();
+
+      const { data: row, error: readErr } = await admin
+        .from('marketing_email_sync_queue')
+        .select('product_id, event_type, email, status, payload')
+        .eq('idempotency_key', idempotencyKey)
+        .single();
+
+      expect(readErr).toBeNull();
+      expect(row?.product_id).toBe(TEST_PRODUCT_ID);
+      expect(row?.event_type).toBe('waitlist.joined');
+      expect(row?.email).toBe(email);
+      expect(row?.status).toBe('pending');
+      expect(row?.payload).toMatchObject({ metadata: { plan: 'pro' } });
+    });
+
+    it('metadata is passed through intact in the queue payload', async () => {
+      const email = TestData.email();
+      const metadata = { plan: 'enterprise', ref: 'homepage-cta', extra: 42 };
+
+      const { error } = await admin.from('marketing_email_sync_queue').insert({
+        product_id: TEST_PRODUCT_ID,
+        event_type: 'waitlist.joined',
+        email,
+        payload: { metadata },
+        idempotency_key: `waitlist.joined:${email}:metadata-test`,
+      });
+      expect(error).toBeNull();
+
+      const { data: row } = await admin
+        .from('marketing_email_sync_queue')
+        .select('payload')
+        .eq('email', email)
+        .single();
+
+      expect(row?.payload).toMatchObject({ metadata });
+    });
+  });
+
+  describe('Settings-aware enqueue (enabled=false)', () => {
+    beforeAll(async () => {
+      const { error } = await admin
+        .from('marketing_email_settings')
+        .update({ enabled: false })
+        .eq('product_id', TEST_PRODUCT_ID);
+      expect(error).toBeNull();
+    });
+
+    afterAll(async () => {
+      // Restore enabled=true so later describe blocks that depend on it still work.
+      await admin
+        .from('marketing_email_settings')
+        .update({ enabled: true })
+        .eq('product_id', TEST_PRODUCT_ID);
+    });
+
+    it('settings lookup returns disabled', async () => {
+      const { data: settings, error } = await admin
+        .from('marketing_email_settings')
+        .select('enabled')
+        .eq('product_id', TEST_PRODUCT_ID)
+        .maybeSingle();
+
+      expect(error).toBeNull();
+      // enqueueMarketingEmail returns early when !settings?.enabled
+      expect(settings?.enabled).toBe(false);
+    });
+
+    it('settings lookup returns null for unknown product', async () => {
+      const { data: settings, error } = await admin
+        .from('marketing_email_settings')
+        .select('enabled')
+        .eq('product_id', 'nonexistent_product')
+        .maybeSingle();
+
+      expect(error).toBeNull();
+      // maybeSingle() returns null when no row matches;
+      // enqueueMarketingEmail returns early: !settings?.enabled is true
+      expect(settings).toBeNull();
+    });
+  });
+
+  // ── waitlist_capture RPC ────────────────────────────────────────────────────
+
+  describe('waitlist_capture RPC', () => {
+    it('captures a new waitlist entry successfully', async () => {
+      const email = TestData.email();
+      const { data, error } = await admin.rpc('waitlist_capture', {
+        p_email: email,
+        p_metadata: { source: 'integration-test' },
+        p_client_ip: null,
+      });
+
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+    });
+
+    it('is idempotent for duplicate email submissions', async () => {
+      const email = TestData.email();
+
+      const { error: err1 } = await admin.rpc('waitlist_capture', {
+        p_email: email,
+        p_metadata: {},
+        p_client_ip: null,
+      });
+      expect(err1).toBeNull();
+
+      // Second call with same email should not throw
+      const { error: err2 } = await admin.rpc('waitlist_capture', {
+        p_email: email,
+        p_metadata: {},
+        p_client_ip: null,
+      });
+      expect(err2).toBeNull();
+
+      // Confirm only one entry
+      const { data: entries } = await admin
+        .from('waitlist_entries')
+        .select('id')
+        .eq('email', email);
+      expect(entries).toHaveLength(1);
+    });
+
+    it('normalizes email to lowercase in waitlist_entries', async () => {
+      const rawEmail = `TEST-UPPER-${Date.now()}@EXAMPLE.COM`;
+      const normalizedEmail = rawEmail.toLowerCase();
+
+      await admin.rpc('waitlist_capture', {
+        p_email: rawEmail,
+        p_metadata: {},
+        p_client_ip: null,
+      });
+
+      const { data: entry, error } = await admin
+        .from('waitlist_entries')
+        .select('email')
+        .eq('email', normalizedEmail)
+        .maybeSingle();
+
+      expect(error).toBeNull();
+      expect(entry?.email).toBe(normalizedEmail);
+    });
+  });
+});


### PR DESCRIPTION
## What

Phase 2 of kit integration (#286): DB schema + lifecycle event emission wiring.

## DB migration (`20260520200000_marketing_email_v1.sql`)

Three new tables, all with RLS enabled (service-role only):

- **`marketing_email_settings`** — feature flag + provider config per product. `enabled = false` by default so nothing queues until explicitly turned on.
- **`marketing_email_sync_queue`** — events waiting to sync to the email provider. Has `idempotency_key UNIQUE` so duplicate emissions are safe. `status` constrained to `pending / processing / done / failed`.
- **`marketing_email_unsubscribes`** — local mirror of provider unsubscribes for fast pre-send lookup (used in Phase 3).

Also adds an `auth.users` AFTER INSERT trigger (`_marketing_email_on_user_signed_up`) that covers every signup path server-side. It checks the `enabled` flag before inserting and uses `ON CONFLICT DO NOTHING` for idempotency.

## Shared helper (`_shared/marketingEmailQueue.ts`)

`enqueueMarketingEmail(supabase, eventType, email, payload, idempotencyKey?)`:
- Reads `marketing_email_settings` first; returns early if nothing is enabled.
- Inserts to queue; swallows `23505` (unique violation) so callers don't need to handle idempotency explicitly.
- Used by the three Edge Functions below.

## Emission wiring

| Function | Event | Trigger point | Idempotency key |
|---|---|---|---|
| `waitlist-capture` | `waitlist.joined` | After successful `waitlist_capture` RPC | `waitlist.joined:<email>` |
| `waitlist-ops` | `waitlist.approved` | After `admin_approve_waitlist_entry` | `waitlist.approved:<entryId>` |
| `waitlist-ops` | `waitlist.converted` | After `waitlist_consume_invite` succeeds, skips `already_converted` | `waitlist.converted:<userId>` |
| `stripe-webhook` | `user.tier_changed` | After `customer.subscription.updated` written | `user.tier_changed:<stripeEventId>` |
| `stripe-webhook` | `user.churned` | After `customer.subscription.deleted` written | `user.churned:<stripeEventId>` |

`user.signed_up` is handled entirely in the DB trigger (covers all signup paths including OAuth, magic link, password).

## What's not here yet

- Phase 3: `kit-sync` Edge Function (reads queue, calls Kit API, marks done)
- Phase 4: `kit-webhook` (handles Kit → app unsubscribe events)
- Phase 5: admin UI for settings

## Test plan

- [ ] Apply migration locally; verify tables + RLS created; confirm trigger fires on `INSERT INTO auth.users` only when `enabled = true`
- [ ] With `enabled = false`: call `waitlist-capture`, `waitlist-ops approve`, `waitlist-ops consume`, Stripe webhook — queue should stay empty
- [ ] Flip `enabled = true`; repeat — one row per event should appear in `marketing_email_sync_queue`
- [ ] Submit same waitlist email twice — second enqueue silently deduped (`idempotency_key` conflict)
- [ ] Simulate retry of same Stripe event ID — second enqueue deduped
- [ ] `waitlist-ops consume` with `already_converted = true` — no queue row emitted
