### PR TITLE
fix(kit-sync): address #315 blockers — secret gating, plan_id pipeline, config guard

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -137,9 +137,11 @@ jobs:
             BILLING_SUPABASE_URL="${PRODUCTION_SUPABASE_URL}" \
             BILLING_SUPABASE_ANON_KEY="${PRODUCTION_SUPABASE_ANON_KEY}" \
             BILLING_SUPABASE_SERVICE_ROLE_KEY="${PRODUCTION_SUPABASE_SERVICE_ROLE_KEY}" \
-            BILLING_ALLOWED_ORIGINS="${PRODUCTION_BILLING_ALLOWED_ORIGINS}" \
-            KIT_API_KEY="${PRODUCTION_KIT_API_KEY}" \
-            KIT_CRON_SECRET="${PRODUCTION_KIT_CRON_SECRET}"
+            BILLING_ALLOWED_ORIGINS="${PRODUCTION_BILLING_ALLOWED_ORIGINS}"
+          # Only set Kit secrets when the GitHub secrets are configured; passing empty
+          # strings would clobber any manually-configured Supabase project secrets.
+          [[ -n "${PRODUCTION_KIT_API_KEY:-}" ]] && supabase secrets set KIT_API_KEY="${PRODUCTION_KIT_API_KEY}"
+          [[ -n "${PRODUCTION_KIT_CRON_SECRET:-}" ]] && supabase secrets set KIT_CRON_SECRET="${PRODUCTION_KIT_CRON_SECRET}"
           supabase functions deploy stripe-webhook billing-stripe waitlist-capture waitlist-ops kit-sync \
             --project-ref "${PRODUCTION_SUPABASE_PROJECT_REF}"
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -137,9 +137,11 @@ jobs:
             BILLING_SUPABASE_URL="${STAGING_SUPABASE_URL}" \
             BILLING_SUPABASE_ANON_KEY="${STAGING_SUPABASE_ANON_KEY}" \
             BILLING_SUPABASE_SERVICE_ROLE_KEY="${STAGING_SUPABASE_SERVICE_ROLE_KEY}" \
-            BILLING_ALLOWED_ORIGINS="${STAGING_BILLING_ALLOWED_ORIGINS}" \
-            KIT_API_KEY="${STAGING_KIT_API_KEY}" \
-            KIT_CRON_SECRET="${STAGING_KIT_CRON_SECRET}"
+            BILLING_ALLOWED_ORIGINS="${STAGING_BILLING_ALLOWED_ORIGINS}"
+          # Only set Kit secrets when the GitHub secrets are configured; passing empty
+          # strings would clobber any manually-configured Supabase project secrets.
+          [[ -n "${STAGING_KIT_API_KEY:-}" ]] && supabase secrets set KIT_API_KEY="${STAGING_KIT_API_KEY}"
+          [[ -n "${STAGING_KIT_CRON_SECRET:-}" ]] && supabase secrets set KIT_CRON_SECRET="${STAGING_KIT_CRON_SECRET}"
           supabase functions deploy stripe-webhook billing-stripe waitlist-capture waitlist-ops kit-sync \
             --project-ref "${STAGING_SUPABASE_PROJECT_REF}"
 

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -24,6 +24,14 @@ import {
 } from '@beakerstack/waitlist/web';
 import { beakerstackWaitlistConfig } from '../waitlist/beakerstackWaitlistConfig';
 
+function signupPlanMetadata(sp: URLSearchParams): { plan_id: string } | undefined {
+  const planId = sp.get('plan');
+  if (!planId) return undefined;
+  const cfg = beakerstackBillingConfig.plans.find(p => p.id === planId);
+  if (!cfg || cfg.priceCents === 0) return undefined;
+  return { plan_id: planId };
+}
+
 function SignupPageContent() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -76,7 +84,8 @@ function SignupPageContent() {
     setError(null);
 
     try {
-      await auth.signUp(email, password);
+      const planMeta = signupPlanMetadata(searchParams);
+      await auth.signUp(email, password, planMeta ? { data: planMeta } : undefined);
       const {
         data: { session },
       } = await supabase.auth.getSession();
@@ -134,7 +143,9 @@ function SignupPageContent() {
     if (!planId) return undefined;
     const cfg = beakerstackBillingConfig.plans.find(p => p.id === planId);
     if (!cfg || cfg.priceCents === 0) return undefined;
-    return { [PLAN_INTEREST_METADATA_KEY]: cfg.displayName };
+    // Include both stable plan_id (for kit-sync interest tagging and waitlist-ops approve)
+    // and the display name (for human-readable metadata in the waitlist dashboard).
+    return { [PLAN_INTEREST_METADATA_KEY]: cfg.displayName, plan_id: planId };
   }, [isWaitlist, paidIntent, searchParams]);
 
   if (awaitingEmail) {

--- a/packages/shared/src/hooks/useAuth.ts
+++ b/packages/shared/src/hooks/useAuth.ts
@@ -71,7 +71,11 @@ export function useAuth(supabaseClient: SupabaseClient): AuthHookReturn {
     setLoading(false);
   };
 
-  const signUp = async (email: string, password: string): Promise<void> => {
+  const signUp = async (
+    email: string,
+    password: string,
+    options?: { data?: Record<string, unknown> }
+  ): Promise<void> => {
     setLoading(true);
     setError(null);
 
@@ -83,7 +87,10 @@ export function useAuth(supabaseClient: SupabaseClient): AuthHookReturn {
     const { error } = await supabaseClient.auth.signUp({
       email,
       password,
-      ...(emailRedirectTo ? { options: { emailRedirectTo } } : {}),
+      options: {
+        ...(emailRedirectTo ? { emailRedirectTo } : {}),
+        ...(options?.data ? { data: options.data } : {}),
+      },
     });
 
     setLoading(false);

--- a/packages/shared/src/types/auth.ts
+++ b/packages/shared/src/types/auth.ts
@@ -9,7 +9,7 @@ export interface AuthState {
 
 export interface AuthActions {
   signIn: (email: string, password: string) => Promise<void>;
-  signUp: (email: string, password: string) => Promise<void>;
+  signUp: (email: string, password: string, options?: { data?: Record<string, unknown> }) => Promise<void>;
   signOut: () => Promise<void>;
   signInWithGoogle: () => Promise<void>;
   requestPasswordReset: (email: string) => Promise<void>;

--- a/supabase/functions/kit-sync/index.ts
+++ b/supabase/functions/kit-sync/index.ts
@@ -117,6 +117,22 @@ async function handleWorker(
 
       const config = settings.config;
 
+      // Guard: namespace is required for all Kit tag operations. Dead-letter with a
+      // clear message so the operator knows exactly what to fix, rather than letting
+      // the row reach Kit API and fail with a confusing tag-not-found error.
+      if (!config.namespace) {
+        const { error: upErr } = await admin
+          .from('marketing_email_sync_queue')
+          .update({
+            status: 'failed',
+            error: `marketing_email_settings.config missing required field "namespace" for product "${row.product_id}" — insert or update the row in marketing_email_settings with a non-empty namespace`,
+          })
+          .eq('id', row.id);
+        if (upErr) console.error('Failed to dead-letter config-invalid row', row.id, upErr.message);
+        failed++;
+        continue;
+      }
+
       // Suppression check
       const { data: suppressed } = await admin
         .from('marketing_email_unsubscribes')
@@ -192,7 +208,7 @@ async function processEvent(
     case 'user.signed_up': {
       if (formId) await kit.subscribeToForm(email, formId);
       await kit.applyTag(email, signupTag(ns, opts));
-      const rawPlanId = payload.plan_id as string | undefined;
+      const rawPlanId = typeof payload.plan_id === 'string' && payload.plan_id ? payload.plan_id : undefined;
       if (rawPlanId) {
         const slug = planIdToSlug(rawPlanId, tierTagNames);
         await kit.applyTag(email, interestTag(ns, slug, opts));
@@ -202,11 +218,21 @@ async function processEvent(
     case 'waitlist.joined': {
       if (formId) await kit.subscribeToForm(email, formId);
       await kit.applyTag(email, waitlistTag(ns, opts));
+      const rawPlanId = typeof payload.plan_id === 'string' && payload.plan_id ? payload.plan_id : undefined;
+      if (rawPlanId) {
+        const slug = planIdToSlug(rawPlanId, tierTagNames);
+        await kit.applyTag(email, interestTag(ns, slug, opts));
+      }
       break;
     }
     case 'waitlist.approved': {
       if (formId) await kit.subscribeToForm(email, formId);
       await kit.applyTag(email, waitlistApprovedTag(ns, opts));
+      const rawPlanId = typeof payload.plan_id === 'string' && payload.plan_id ? payload.plan_id : undefined;
+      if (rawPlanId) {
+        const slug = planIdToSlug(rawPlanId, tierTagNames);
+        await kit.applyTag(email, interestTag(ns, slug, opts));
+      }
       break;
     }
     case 'waitlist.converted': {
@@ -216,7 +242,11 @@ async function processEvent(
     }
     case 'user.tier_changed': {
       // stripe-webhook enqueues with { user_id, plan_id, status }.
-      const rawPlanId = payload.plan_id as string | undefined;
+      if (tierTagNames.length === 0) throw new KitClientError(
+        `user.tier_changed requires tierTagNames in marketing_email_settings.config for product "${row.product_id}" — add tier slugs (e.g. ["pro","max"]) to config`,
+        'kit_api_400'
+      );
+      const rawPlanId = typeof payload.plan_id === 'string' && payload.plan_id ? payload.plan_id : undefined;
       if (!rawPlanId) throw new KitClientError(
         'user.tier_changed payload missing plan_id',
         'kit_api_400'

--- a/supabase/functions/waitlist-capture/index.ts
+++ b/supabase/functions/waitlist-capture/index.ts
@@ -82,12 +82,21 @@ Deno.serve(async req => {
   }
   const productId = envProductId || 'beakerstack';
 
+  const metadata = body.metadata ?? {};
+  // Hoist plan_id to the top level of the queue payload so the kit-sync worker
+  // can apply the interest tag without digging into the metadata envelope.
+  // Validate it's a non-empty string so a malformed client can't poison the queue.
+  const rawPlanId = metadata.plan_id;
+  const planId = typeof rawPlanId === 'string' && rawPlanId.trim() ? rawPlanId.trim() : null;
   await enqueueMarketingEmail(
     admin,
     productId,
     'waitlist.joined',
     email,
-    { metadata: body.metadata ?? {} },
+    {
+      metadata,
+      ...(planId ? { plan_id: planId } : {}),
+    },
     `waitlist.joined:${email}`
   );
 


### PR DESCRIPTION
## Summary

Addresses the three blockers in #315 raised after PR #311 (Kit Phase 3) merged.

### Fix 1 — Deploy does not clobber Kit secrets when GitHub secrets are unset

`supabase secrets set` previously always passed `KIT_API_KEY` and `KIT_CRON_SECRET`, even when the corresponding GitHub secrets were absent (empty string). On every deploy this would silently overwrite any manually-configured Supabase project secrets.

**Fix:** split the `secrets set` call — non-Kit secrets always set; Kit secrets only set when the GitHub secret is non-empty (same guard pattern as the cron ensure step).

### Fix 2 — plan_id flows end-to-end from signup/waitlist → queue → Kit interest tag

Four gaps closed:

| Layer | Before | After |
|---|---|---|
| `useAuth.signUp` | no metadata support | optional `{ data }` param forwarded to Supabase `auth.signUp` |
| `SignupPage` email signup | `auth.signUp(email, pw)` | passes `{ data: { plan_id } }` when `?plan=` is present |
| `SignupPage` waitlist metadata | `{ plan_interest: displayName }` only | adds `plan_id` (stable ID) so `waitlist-ops approve` can read `metadata.plan_id` |
| `waitlist-capture` queue payload | `{ metadata: {...} }` | hoists `plan_id` to top-level so worker doesn't need to dig into metadata |
| kit-sync `waitlist.joined` | form subscribe + waitlist tag only | adds interest tag when `payload.plan_id` present |
| kit-sync `waitlist.approved` | form subscribe + approved tag only | adds interest tag when `payload.plan_id` present |

> **OAuth gap:** `signInWithGoogle` cannot pass user metadata at OAuth initiation time (Supabase OAuth limitation). The postAuthPath already carries `?plan=...` so the billing redirect still works; Kit interest tagging via OAuth is deferred to a follow-up (noted in #315).

### Fix 3 — Config guard: missing namespace dead-letters with a clear error

When `marketing_email_settings.config.namespace` is unset, the worker previously reached the Kit API and got a confusing `kit_tag_not_found` error (permanent → dead-lettered). Now the worker checks namespace first and dead-letters with:
`marketing_email_settings.config missing required field namespace for product X`

### Known limitations (not in scope for this PR, tracked in #315)

- Bulk-sync does not backfill `user.tier_changed` from `billing_subscriptions` — deferred to Phase 5 admin UI
- OAuth signup does not propagate `plan_id` to user metadata — deferred

## Test plan

- [ ] Deploy staging: verify `supabase secrets set` run with no Kit GitHub secrets set does not overwrite existing Supabase secrets (check Supabase dashboard before/after)
- [ ] Sign up with `?plan=beakerstack_pro` via email — confirm `auth.users.raw_user_meta_data` contains `plan_id`
- [ ] Join waitlist with `?plan=beakerstack_pro` — confirm `waitlist_entries.metadata` has `plan_id` and `marketing_email_sync_queue` row has `payload.plan_id`
- [ ] Approve a waitlist entry with `plan_id` in metadata — confirm kit-sync applies `{ns}:interest:{slug}` tag in Kit dashboard
- [ ] Seed a `marketing_email_settings` row with `config = {}` (missing namespace) and trigger a queue row — confirm it dead-letters with the descriptive error

