### PR TITLE
fix(#312): show email confirmation pending state after signup

### DIFF
--- a/apps/mobile/__tests__/App.test.tsx
+++ b/apps/mobile/__tests__/App.test.tsx
@@ -237,6 +237,18 @@ jest.mock('../src/screens/ResetPasswordScreen', () => {
   };
 });
 
+jest.mock('../src/screens/SignupPendingScreen', () => {
+  const { View, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: () => (
+      <View testID='signup-pending-screen'>
+        <Text>Check your email</Text>
+      </View>
+    ),
+  };
+});
+
 import { render } from '@testing-library/react-native';
 import { describe, it, expect } from '@jest/globals';
 import App from '../App';

--- a/apps/mobile/__tests__/navigation/AppNavigator.test.tsx
+++ b/apps/mobile/__tests__/navigation/AppNavigator.test.tsx
@@ -101,6 +101,18 @@ jest.mock('../../src/screens/ResetPasswordScreen', () => {
   };
 });
 
+jest.mock('../../src/screens/SignupPendingScreen', () => {
+  const { View, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: () => (
+      <View testID='signup-pending-screen'>
+        <Text>Check your email</Text>
+      </View>
+    ),
+  };
+});
+
 describe('AppNavigator', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/apps/mobile/__tests__/screens/SignupPendingScreen.test.tsx
+++ b/apps/mobile/__tests__/screens/SignupPendingScreen.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import SignupPendingScreen from '../../src/screens/SignupPendingScreen';
+
+jest.mock('expo-constants', () => ({
+  default: {
+    expoConfig: {
+      extra: {
+        supabaseUrl: 'http://localhost:54321',
+        supabaseAnonKey: 'test-anon-key',
+        googleWebClientId: 'test-web-client-id',
+        googleIosClientId: 'test-ios-client-id',
+        googleAndroidClientId: 'test-android-client-id',
+      },
+    },
+  },
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: null }, error: null }),
+      onAuthStateChange: jest.fn(() => ({
+        data: { subscription: { unsubscribe: jest.fn() } },
+      })),
+    },
+  },
+}));
+
+jest.mock('@beakerstack/shared/components/navigation/AppHeader.native', () => ({
+  AppHeader: () => null,
+}));
+
+const mockNavigate = jest.fn();
+
+const mockRoute = {
+  key: 'SignupPending-1',
+  name: 'SignupPending' as const,
+  params: { email: 'pending@example.com' },
+};
+
+const mockNavigation = {
+  navigate: mockNavigate,
+  goBack: jest.fn(),
+  reset: jest.fn(),
+} as any;
+
+describe('SignupPendingScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders heading and email from route params', () => {
+    const { getByText } = render(
+      <SignupPendingScreen route={mockRoute} navigation={mockNavigation} />
+    );
+
+    expect(getByText('Check your email')).toBeTruthy();
+    expect(getByText('pending@example.com')).toBeTruthy();
+  });
+
+  it('navigates to Login when pressing sign in link', async () => {
+    const { getByText } = render(
+      <SignupPendingScreen route={mockRoute} navigation={mockNavigation} />
+    );
+
+    fireEvent.press(getByText('Already confirmed? Sign in'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('Login');
+    });
+  });
+});

--- a/apps/mobile/__tests__/screens/SignupScreen.test.tsx
+++ b/apps/mobile/__tests__/screens/SignupScreen.test.tsx
@@ -22,8 +22,13 @@ jest.mock('expo-constants', () => ({
 }));
 
 // Mock supabase
+const mockGetSession = jest.fn();
 jest.mock('../../src/lib/supabase', () => ({
-  supabase: {} as SupabaseClient,
+  supabase: {
+    auth: {
+      getSession: (...args: unknown[]) => mockGetSession(...args),
+    },
+  } as unknown as SupabaseClient,
 }));
 
 // Mock AppHeader
@@ -129,6 +134,7 @@ const renderWithProviders = (
 describe('SignupScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
     jest.spyOn(Alert, 'alert').mockImplementation(() => {});
   });
 
@@ -221,7 +227,17 @@ describe('SignupScreen', () => {
     });
   });
 
-  it('handles successful signup', async () => {
+  it('navigates to Dashboard when signup returns a session', async () => {
+    const mockSession = {
+      access_token: 'mock-token',
+      refresh_token: 'mock-refresh',
+      expires_in: 3600,
+      expires_at: Date.now() + 3600000,
+      token_type: 'bearer',
+      user: { id: 'test-user-id', email: 'test@example.com' } as any,
+    };
+    mockGetSession.mockResolvedValueOnce({ data: { session: mockSession }, error: null });
+
     const mockClient = createMockSupabaseClient();
     const { getByPlaceholderText, getByText } = renderWithProviders(
       <SignupScreen navigation={mockNavigation} />,
@@ -234,7 +250,6 @@ describe('SignupScreen', () => {
 
     await waitFor(() => {
       const submitButton = getByText('Create Account');
-
       fireEvent.changeText(emailInput, 'test@example.com');
       fireEvent.changeText(passwordInput, 'password123');
       fireEvent.changeText(confirmPasswordInput, 'password123');
@@ -250,6 +265,34 @@ describe('SignupScreen', () => {
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('Dashboard');
+    });
+  });
+
+  it('navigates to SignupPending when signup returns no session', async () => {
+    mockGetSession.mockResolvedValueOnce({ data: { session: null }, error: null });
+
+    const mockClient = createMockSupabaseClient();
+    const { getByPlaceholderText, getByText } = renderWithProviders(
+      <SignupScreen navigation={mockNavigation} />,
+      mockClient
+    );
+
+    const emailInput = getByPlaceholderText('Email address');
+    const passwordInput = getByPlaceholderText('Password');
+    const confirmPasswordInput = getByPlaceholderText('Confirm password');
+
+    await waitFor(() => {
+      const submitButton = getByText('Create Account');
+      fireEvent.changeText(emailInput, 'test@example.com');
+      fireEvent.changeText(passwordInput, 'password123');
+      fireEvent.changeText(confirmPasswordInput, 'password123');
+      fireEvent.press(submitButton);
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('SignupPending', {
+        email: 'test@example.com',
+      });
     });
   });
 

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -13,6 +13,7 @@ import BillingNavigator from '../navigation/BillingNavigator';
 import ForgotPasswordScreen from '../screens/ForgotPasswordScreen';
 import AuthCallbackScreen from '../screens/AuthCallbackScreen';
 import ResetPasswordScreen from '../screens/ResetPasswordScreen';
+import SignupPendingScreen from '../screens/SignupPendingScreen';
 import { useFeatureFlags } from '../config/featureFlags';
 import { navigationRef } from './navigationRef';
 import type { RootStackParamList } from './types';
@@ -68,6 +69,7 @@ export const AppNavigator = () => {
           component={BillingNavigator}
           options={{ headerShown: false }}
         />
+        <Stack.Screen name='SignupPending' component={SignupPendingScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -69,7 +69,11 @@ export const AppNavigator = () => {
           component={BillingNavigator}
           options={{ headerShown: false }}
         />
-        <Stack.Screen name='SignupPending' component={SignupPendingScreen} />
+        <Stack.Screen
+          name='SignupPending'
+          component={SignupPendingScreen}
+          options={{ title: 'Confirm your email' }}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -8,4 +8,5 @@ export type RootStackParamList = {
   ForgotPassword: undefined;
   AuthCallback: undefined;
   ResetPassword: undefined;
+  SignupPending: { email: string };
 };

--- a/apps/mobile/src/screens/SignupPendingScreen.tsx
+++ b/apps/mobile/src/screens/SignupPendingScreen.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  SafeAreaView,
+} from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { colors } from '@beakerstack/shared/theme/colors';
+import type { RootStackParamList } from '../navigation/types';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'SignupPending'>;
+
+export default function SignupPendingScreen({ route, navigation }: Props) {
+  const { email } = route.params;
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.heading}>Check your email</Text>
+        <Text style={styles.body}>
+          We sent a confirmation link to{' '}
+          <Text style={styles.emailHighlight}>{email}</Text>. Click the link in
+          that email to finish creating your account.
+        </Text>
+        <TouchableOpacity
+          style={styles.linkButton}
+          onPress={() => navigation.navigate('Login')}
+        >
+          <Text style={styles.linkText}>Already confirmed? Sign in</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  heading: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: colors.text,
+    marginBottom: 12,
+  },
+  body: {
+    fontSize: 15,
+    color: colors.textSecondary,
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  emailHighlight: {
+    fontWeight: '600',
+    color: colors.text,
+  },
+  linkButton: {
+    alignSelf: 'flex-start',
+  },
+  linkText: {
+    fontSize: 15,
+    color: colors.primary,
+    fontWeight: '500',
+  },
+});

--- a/apps/mobile/src/screens/SignupPendingScreen.tsx
+++ b/apps/mobile/src/screens/SignupPendingScreen.tsx
@@ -38,7 +38,7 @@ export default function SignupPendingScreen({ route, navigation }: Props) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.background,
+    backgroundColor: colors.pageBg,
   },
   content: {
     flex: 1,
@@ -48,25 +48,25 @@ const styles = StyleSheet.create({
   heading: {
     fontSize: 24,
     fontWeight: '600',
-    color: colors.text,
+    color: colors.textPrimary,
     marginBottom: 12,
   },
   body: {
     fontSize: 15,
-    color: colors.textSecondary,
+    color: colors.textSubtle,
     lineHeight: 22,
     marginBottom: 24,
   },
   emailHighlight: {
     fontWeight: '600',
-    color: colors.text,
+    color: colors.textPrimary,
   },
   linkButton: {
     alignSelf: 'flex-start',
   },
   linkText: {
     fontSize: 15,
-    color: colors.primary,
+    color: colors.brand,
     fontWeight: '500',
   },
 });

--- a/apps/mobile/src/screens/SignupPendingScreen.tsx
+++ b/apps/mobile/src/screens/SignupPendingScreen.tsx
@@ -13,7 +13,7 @@ import type { RootStackParamList } from '../navigation/types';
 type Props = NativeStackScreenProps<RootStackParamList, 'SignupPending'>;
 
 export default function SignupPendingScreen({ route, navigation }: Props) {
-  const email = route.params?.email ?? '';
+  const email = route?.params?.email ?? '';
 
   return (
     <SafeAreaView style={styles.container}>

--- a/apps/mobile/src/screens/SignupPendingScreen.tsx
+++ b/apps/mobile/src/screens/SignupPendingScreen.tsx
@@ -13,7 +13,7 @@ import type { RootStackParamList } from '../navigation/types';
 type Props = NativeStackScreenProps<RootStackParamList, 'SignupPending'>;
 
 export default function SignupPendingScreen({ route, navigation }: Props) {
-  const { email } = route.params;
+  const email = route.params?.email ?? '';
 
   return (
     <SafeAreaView style={styles.container}>

--- a/apps/mobile/src/screens/SignupPendingScreen.tsx
+++ b/apps/mobile/src/screens/SignupPendingScreen.tsx
@@ -8,15 +8,18 @@ import {
 } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { colors } from '@beakerstack/shared/theme/colors';
+import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.native';
+import { supabase } from '../lib/supabase';
 import type { RootStackParamList } from '../navigation/types';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'SignupPending'>;
 
 export default function SignupPendingScreen({ route, navigation }: Props) {
-  const email = route?.params?.email ?? '';
+  const { email } = route.params;
 
   return (
     <SafeAreaView style={styles.container}>
+      <AppHeader supabaseClient={supabase} />
       <View style={styles.content}>
         <Text style={styles.heading}>Check your email</Text>
         <Text style={styles.body}>

--- a/apps/mobile/src/screens/SignupScreen.tsx
+++ b/apps/mobile/src/screens/SignupScreen.tsx
@@ -18,14 +18,7 @@ import { MIN_PASSWORD_LENGTH } from '@beakerstack/shared/constants/auth';
 import { supabase } from '../lib/supabase';
 import { SocialLoginButton } from '../components/SocialLoginButton';
 import { useFeatureFlags } from '../config/featureFlags';
-
-type RootStackParamList = {
-  Home: undefined;
-  Login: undefined;
-  Signup: undefined;
-  Dashboard: undefined;
-  SignupPending: { email: string };
-};
+import type { RootStackParamList } from '../navigation/types';
 
 type SignupScreenNavigationProp = NativeStackNavigationProp<
   RootStackParamList,

--- a/apps/mobile/src/screens/SignupScreen.tsx
+++ b/apps/mobile/src/screens/SignupScreen.tsx
@@ -24,6 +24,7 @@ type RootStackParamList = {
   Login: undefined;
   Signup: undefined;
   Dashboard: undefined;
+  SignupPending: { email: string };
 };
 
 type SignupScreenNavigationProp = NativeStackNavigationProp<
@@ -75,7 +76,12 @@ export default function SignupScreen({ navigation }: Props) {
 
     try {
       await auth.signUp(email, password);
-      navigation.navigate('Dashboard');
+      const { data: { session } } = await supabase.auth.getSession();
+      if (session) {
+        navigation.navigate('Dashboard');
+      } else {
+        navigation.navigate('SignupPending', { email });
+      }
     } catch (error) {
       Alert.alert(
         'Sign Up Failed',

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -84,14 +84,14 @@ function SignupPageContent() {
       if (session) {
         clearPostAuthRedirectKeys();
         navigate(postAuthPath, { replace: true });
-      } else if (paidIntent && postAuthPath !== '/dashboard') {
-        localStorage.setItem(
-          POST_AUTH_REDIRECT_KEY,
-          serializePostAuthRedirectPayload(postAuthPath)
-        );
-        setAwaitingEmail(true);
       } else {
-        navigate('/dashboard', { replace: true });
+        if (paidIntent && postAuthPath !== '/dashboard') {
+          localStorage.setItem(
+            POST_AUTH_REDIRECT_KEY,
+            serializePostAuthRedirectPayload(postAuthPath)
+          );
+        }
+        setAwaitingEmail(true);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create account');
@@ -148,9 +148,11 @@ function SignupPageContent() {
             </h2>
             <p className='mt-3 text-sm text-gray-600 dark:text-gray-300'>
               We sent a confirmation link to <strong>{email}</strong>. Click the
-              link in that email to finish creating your account — we&apos;ll
-              take you to billing to complete your plan when you&apos;re signed
-              in.
+              link in that email to finish creating your account
+              {paidIntent && postAuthPath !== '/dashboard'
+                ? " — we’ll take you to billing to complete your plan when you’re signed in"
+                : ''}
+              .
             </p>
             <p className='mt-4 text-sm text-gray-500 dark:text-gray-400'>
               <Link to={loginTo} className='font-medium text-primary-600'>

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -148,12 +148,14 @@ function SignupPageContent() {
             </h2>
             <p className='mt-3 text-sm text-gray-600 dark:text-gray-300'>
               We sent a confirmation link to <strong>{email}</strong>. Click the
-              link in that email to finish creating your account
-              {paidIntent && postAuthPath !== '/dashboard'
-                ? " — we’ll take you to billing to complete your plan when you’re signed in"
-                : ''}
-              .
+              link in that email to finish creating your account.
             </p>
+            {paidIntent && postAuthPath !== '/dashboard' && (
+              <p className='mt-2 text-sm text-gray-600 dark:text-gray-300'>
+                We&apos;ll take you to billing to complete your plan when
+                you&apos;re signed in.
+              </p>
+            )}
             <p className='mt-4 text-sm text-gray-500 dark:text-gray-400'>
               <Link to={loginTo} className='font-medium text-primary-600'>
                 Already confirmed? Sign in

--- a/apps/web/src/pages/__tests__/SignupPage.test.tsx
+++ b/apps/web/src/pages/__tests__/SignupPage.test.tsx
@@ -473,7 +473,7 @@ describe('SignupPage', () => {
     expect(raw).toContain('/billing/plans');
   });
 
-  it('navigates to dashboard after signup when no session and no paid plan intent', async () => {
+  it('shows pending email confirmation UI after signup when no session and no paid plan intent', async () => {
     const user = userEvent.setup();
     renderWithProviders(<SignupPage />, { initialEntries: ['/signup'] });
 
@@ -489,10 +489,33 @@ describe('SignupPage', () => {
     await user.click(screen.getByRole('button', { name: /create account/i }));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
-        replace: true,
-      });
+      expect(screen.getByText('Check your email')).toBeInTheDocument();
+      expect(screen.getByText(/confirm@example\.com/)).toBeInTheDocument();
     });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does not show billing copy in pending UI for plain signup', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SignupPage />, { initialEntries: ['/signup'] });
+
+    await user.type(
+      screen.getByPlaceholderText('Email address'),
+      'confirm@example.com'
+    );
+    await user.type(screen.getByPlaceholderText('Password'), 'password123');
+    await user.type(
+      screen.getByPlaceholderText('Confirm password'),
+      'password123'
+    );
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Check your email')).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(/billing/i)
+    ).not.toBeInTheDocument();
   });
 
   it('shows generic message when email signup throws non-Error', async () => {

--- a/apps/web/src/pages/__tests__/SignupPage.test.tsx
+++ b/apps/web/src/pages/__tests__/SignupPage.test.tsx
@@ -473,7 +473,7 @@ describe('SignupPage', () => {
     expect(raw).toContain('/billing/plans');
   });
 
-  it('shows pending email confirmation UI after signup when no session and no paid plan intent', async () => {
+  it('shows pending email confirmation UI after plain signup without billing copy or redirect stash', async () => {
     const user = userEvent.setup();
     renderWithProviders(<SignupPage />, { initialEntries: ['/signup'] });
 
@@ -493,29 +493,8 @@ describe('SignupPage', () => {
       expect(screen.getByText(/confirm@example\.com/)).toBeInTheDocument();
     });
     expect(mockNavigate).not.toHaveBeenCalled();
-  });
-
-  it('does not show billing copy in pending UI for plain signup', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<SignupPage />, { initialEntries: ['/signup'] });
-
-    await user.type(
-      screen.getByPlaceholderText('Email address'),
-      'confirm@example.com'
-    );
-    await user.type(screen.getByPlaceholderText('Password'), 'password123');
-    await user.type(
-      screen.getByPlaceholderText('Confirm password'),
-      'password123'
-    );
-    await user.click(screen.getByRole('button', { name: /create account/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText('Check your email')).toBeInTheDocument();
-    });
-    expect(
-      screen.queryByText(/billing/i)
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/billing/i)).not.toBeInTheDocument();
+    expect(window.localStorage.getItem(POST_AUTH_REDIRECT_KEY)).toBeNull();
   });
 
   it('shows generic message when email signup throws non-Error', async () => {


### PR DESCRIPTION
## Summary

Fixes #312. After `auth.signUp()`, Supabase may not create a session if email confirmation is required. The old code silently redirected users to `/dashboard` (web) or `Dashboard` (mobile) as if signup succeeded — which looked like a broken login.

- **Web (`SignupPage.tsx`):** Remove the `else { navigate('/dashboard') }` branch. All no-session signups now show the existing `awaitingEmail` pending UI. Billing-specific copy ("we'll take you to billing") is conditionalized on `paidIntent`.
- **Mobile (`SignupScreen.tsx`):** Call `supabase.auth.getSession()` after signup; navigate to new `SignupPendingScreen` when no session, `Dashboard` when session is present.
- **New `SignupPendingScreen.tsx`:** Displays email, instruction copy, and "Already confirmed? Sign in" link. Registered in `AppNavigator` and typed in `RootStackParamList`.
- **Tests:** Web test rewritten to expect pending UI (not navigate to dashboard); two mobile tests split to cover both session / no-session paths.

## Test plan

- [ ] Plain signup on web with email confirmation on → should see "Check your email" screen, no navigation to dashboard
- [ ] Paid-plan signup on web with no session → should see "Check your email" with billing copy
- [ ] Session-returning signup on web → should navigate to dashboard as before
- [ ] Mobile signup with email confirmation on → should navigate to SignupPending screen with email displayed
- [ ] Mobile signup returning a session → should navigate to Dashboard
- [ ] "Already confirmed? Sign in" link on SignupPendingScreen navigates to Login
- [ ] All existing tests pass: `npm run test` in `apps/web` (18/18 SignupPage tests) and `apps/mobile` (231/231 tests)
