### PR TITLE
feat(#328): show Admin menu item for admin users

### DIFF
--- a/apps/web/src/components/AppHeaderWithAdmin.tsx
+++ b/apps/web/src/components/AppHeaderWithAdmin.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
+import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
+import { useIsAdmin } from '@beakerstack/admin';
+import { supabase } from '../lib/supabase';
+
+/**
+ * AppHeader wired with admin check. Renders the Admin menu item when the
+ * current user is an active admin; hides it while loading or on RPC error
+ * (fail-closed). Rechecks on window focus / tab visibility change, matching
+ * AdminRoute behaviour so revoked access is surfaced without a sign-out.
+ */
+export function AppHeaderWithAdmin() {
+  const auth = useAuthContext();
+  const { isAdmin, loading, refresh } = useIsAdmin(supabase, auth.user?.id);
+
+  useEffect(() => {
+    if (!auth.user?.id) return;
+
+    const recheck = () => {
+      if (document.visibilityState === 'visible') void refresh();
+    };
+
+    window.addEventListener('focus', recheck);
+    document.addEventListener('visibilitychange', recheck);
+    return () => {
+      window.removeEventListener('focus', recheck);
+      document.removeEventListener('visibilitychange', recheck);
+    };
+  }, [auth.user?.id, refresh]);
+
+  return (
+    <AppHeader supabaseClient={supabase} showAdminLink={!loading && isAdmin} />
+  );
+}

--- a/apps/web/src/components/__tests__/AppHeaderWithAdmin.test.tsx
+++ b/apps/web/src/components/__tests__/AppHeaderWithAdmin.test.tsx
@@ -143,6 +143,30 @@ describe('AppHeaderWithAdmin', () => {
     expect(mockRefresh).toHaveBeenCalled();
   });
 
+  it('does not call refresh on visibilitychange when document is hidden', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+
+    render(
+      <MemoryRouter>
+        <AppHeaderWithAdmin />
+      </MemoryRouter>
+    );
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+  });
+
   it('does not call refresh on focus when no user is logged in', async () => {
     vi.mocked(useAuthContext).mockReturnValue({ user: null } as never);
 

--- a/apps/web/src/components/__tests__/AppHeaderWithAdmin.test.tsx
+++ b/apps/web/src/components/__tests__/AppHeaderWithAdmin.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
+import { useIsAdmin } from '@beakerstack/admin';
+import { AppHeaderWithAdmin } from '../AppHeaderWithAdmin';
+
+vi.mock('@beakerstack/admin', async importOriginal => {
+  const actual = await importOriginal<typeof import('@beakerstack/admin')>();
+  return { ...actual, useIsAdmin: vi.fn() };
+});
+
+vi.mock('@beakerstack/shared/contexts/AuthContext', () => ({
+  useAuthContext: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {},
+}));
+
+vi.mock('@beakerstack/shared/components/navigation/AppHeader.web', () => ({
+  AppHeader: ({ showAdminLink }: { showAdminLink?: boolean }) => (
+    <div
+      data-testid='app-header'
+      data-show-admin-link={String(showAdminLink ?? false)}
+    />
+  ),
+}));
+
+const mockUser = { id: 'user-123', email: 'user@example.com' };
+const mockRefresh = vi.fn();
+
+describe('AppHeaderWithAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuthContext).mockReturnValue({ user: mockUser } as never);
+    vi.mocked(useIsAdmin).mockReturnValue({
+      isAdmin: false,
+      loading: false,
+      error: null,
+      refresh: mockRefresh,
+    });
+  });
+
+  it('passes showAdminLink=true when user is admin and not loading', () => {
+    vi.mocked(useIsAdmin).mockReturnValue({
+      isAdmin: true,
+      loading: false,
+      error: null,
+      refresh: mockRefresh,
+    });
+
+    render(
+      <MemoryRouter>
+        <AppHeaderWithAdmin />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('app-header')).toHaveAttribute(
+      'data-show-admin-link',
+      'true'
+    );
+  });
+
+  it('passes showAdminLink=false when user is not admin', () => {
+    render(
+      <MemoryRouter>
+        <AppHeaderWithAdmin />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('app-header')).toHaveAttribute(
+      'data-show-admin-link',
+      'false'
+    );
+  });
+
+  it('passes showAdminLink=false while admin check is loading (fail-closed)', () => {
+    vi.mocked(useIsAdmin).mockReturnValue({
+      isAdmin: false,
+      loading: true,
+      error: null,
+      refresh: mockRefresh,
+    });
+
+    render(
+      <MemoryRouter>
+        <AppHeaderWithAdmin />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('app-header')).toHaveAttribute(
+      'data-show-admin-link',
+      'false'
+    );
+  });
+
+  it('passes showAdminLink=false when admin check errors (fail-closed)', () => {
+    vi.mocked(useIsAdmin).mockReturnValue({
+      isAdmin: false,
+      loading: false,
+      error: new Error('RPC error'),
+      refresh: mockRefresh,
+    });
+
+    render(
+      <MemoryRouter>
+        <AppHeaderWithAdmin />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('app-header')).toHaveAttribute(
+      'data-show-admin-link',
+      'false'
+    );
+  });
+
+  it('calls refresh on window focus when user is logged in', async () => {
+    render(
+      <MemoryRouter>
+        <AppHeaderWithAdmin />
+      </MemoryRouter>
+    );
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it('calls refresh on visibilitychange when document is visible', async () => {
+    render(
+      <MemoryRouter>
+        <AppHeaderWithAdmin />
+      </MemoryRouter>
+    );
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it('does not call refresh on focus when no user is logged in', async () => {
+    vi.mocked(useAuthContext).mockReturnValue({ user: null } as never);
+
+    render(
+      <MemoryRouter>
+        <AppHeaderWithAdmin />
+      </MemoryRouter>
+    );
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/billing/BillingPageShell.web.tsx
+++ b/apps/web/src/components/billing/BillingPageShell.web.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react';
-import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
+import { AppHeaderWithAdmin } from '../AppHeaderWithAdmin';
 import { ContentContainer } from '@beakerstack/shared/components/layout/ContentContainer.web';
-import { supabase } from '../../lib/supabase';
 
 export function BillingPageShell({
   children,
@@ -10,7 +9,7 @@ export function BillingPageShell({
 }): JSX.Element {
   return (
     <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
-      <AppHeader supabaseClient={supabase} />
+      <AppHeaderWithAdmin />
       <ContentContainer className='py-6'>
         <div className='py-6 sm:px-0'>{children}</div>
       </ContentContainer>

--- a/apps/web/src/components/billing/__tests__/BillingPageShell.web.test.tsx
+++ b/apps/web/src/components/billing/__tests__/BillingPageShell.web.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { BillingPageShell } from '../BillingPageShell.web';
 
-vi.mock('../../AppHeaderWithAdmin', () => ({
+vi.mock('@/components/AppHeaderWithAdmin', () => ({
   AppHeaderWithAdmin: () => <header data-testid='app-header' />,
 }));
 

--- a/apps/web/src/components/billing/__tests__/BillingPageShell.web.test.tsx
+++ b/apps/web/src/components/billing/__tests__/BillingPageShell.web.test.tsx
@@ -2,12 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { BillingPageShell } from '../BillingPageShell.web';
 
-vi.mock('@beakerstack/shared/components/navigation/AppHeader.web', () => ({
-  AppHeader: () => <header data-testid='app-header' />,
-}));
-
-vi.mock('../../../lib/supabase', () => ({
-  supabase: {},
+vi.mock('../../AppHeaderWithAdmin', () => ({
+  AppHeaderWithAdmin: () => <header data-testid='app-header' />,
 }));
 
 describe('BillingPageShell', () => {

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
-import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
+import { AppHeaderWithAdmin } from '../components/AppHeaderWithAdmin';
 import { ContentContainer } from '@beakerstack/shared/components/layout/ContentContainer.web';
 import { useDemoCollections } from '@/billing/useDemoCollections';
-import { supabase } from '@/lib/supabase';
 import { AnnotatedPrimitive } from '@/components/dashboard/AnnotatedPrimitive';
 import { BooleanFeatureTiles } from '@/components/dashboard/BooleanFeatureTiles';
 import { CollectionDetail } from '@/components/dashboard/CollectionDetail';
@@ -61,7 +60,7 @@ export default function DashboardPage() {
 
   return (
     <div className='min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col'>
-      <AppHeader supabaseClient={supabase} />
+      <AppHeaderWithAdmin />
 
       <ContentContainer as='main' className='flex-1 py-6 space-y-6'>
         <DemoBanner />

--- a/apps/web/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
-import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
+import { AppHeaderWithAdmin } from '../components/AppHeaderWithAdmin';
 import { ContentContainer } from '@beakerstack/shared/components/layout/ContentContainer.web';
-import { supabase } from '@/lib/supabase';
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState('');
@@ -37,7 +36,7 @@ export default function ForgotPasswordPage() {
 
   return (
     <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
-      <AppHeader supabaseClient={supabase} />
+      <AppHeaderWithAdmin />
       <ContentContainer className='py-12'>
         <div className='w-full max-w-md mx-auto space-y-8'>
           <div>

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -7,7 +7,7 @@ import {
   useSearchParams,
 } from 'react-router-dom';
 import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
-import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
+import { AppHeaderWithAdmin } from '../components/AppHeaderWithAdmin';
 import { ContentContainer } from '@beakerstack/shared/components/layout/ContentContainer.web';
 import { supabase } from '@/lib/supabase';
 import { SocialLoginButton } from '../components/SocialLoginButton';
@@ -42,7 +42,7 @@ function LoginPageContent() {
 
   const postAuthPath = fromRedirect ?? resolvePostAuthDestination(searchParams);
   const signupSearch = searchParams.toString();
-  const signupTo = signupSearch ? `/signup?${signupSearch}` : '/signup';
+  const signupTo = signupSearch ?  : '/signup';
 
   const stashOAuthIntent = () => {
     if (postAuthPath !== '/dashboard') {
@@ -92,7 +92,7 @@ function LoginPageContent() {
 
   return (
     <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
-      <AppHeader supabaseClient={supabase} />
+      <AppHeaderWithAdmin />
       <ContentContainer className='py-12'>
         <div
           className={
@@ -220,9 +220,9 @@ export default function LoginPage() {
     <BillingProvider<typeof beakerstackBillingConfig>
       supabase={supabase}
       config={beakerstackBillingConfig}
-      checkoutSuccessUrl={`${base}/billing?checkout=success`}
-      checkoutCancelUrl={`${base}/billing/plans?checkout=cancel`}
-      portalReturnUrl={`${base}/billing`}
+      checkoutSuccessUrl={}
+      checkoutCancelUrl={}
+      portalReturnUrl={}
     >
       <LoginPageContent />
     </BillingProvider>

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -42,7 +42,7 @@ function LoginPageContent() {
 
   const postAuthPath = fromRedirect ?? resolvePostAuthDestination(searchParams);
   const signupSearch = searchParams.toString();
-  const signupTo = signupSearch ?  : '/signup';
+  const signupTo = signupSearch ? `/signup?${signupSearch}` : '/signup';
 
   const stashOAuthIntent = () => {
     if (postAuthPath !== '/dashboard') {
@@ -220,9 +220,9 @@ export default function LoginPage() {
     <BillingProvider<typeof beakerstackBillingConfig>
       supabase={supabase}
       config={beakerstackBillingConfig}
-      checkoutSuccessUrl={}
-      checkoutCancelUrl={}
-      portalReturnUrl={}
+      checkoutSuccessUrl={`${base}/billing?checkout=success`}
+      checkoutCancelUrl={`${base}/billing/plans?checkout=cancel`}
+      portalReturnUrl={`${base}/billing`}
     >
       <LoginPageContent />
     </BillingProvider>

--- a/apps/web/src/pages/NotAuthorizedPage.tsx
+++ b/apps/web/src/pages/NotAuthorizedPage.tsx
@@ -1,12 +1,11 @@
 import { Link } from 'react-router-dom';
-import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
 import { ContentContainer } from '@beakerstack/shared/components/layout/ContentContainer.web';
-import { supabase } from '@/lib/supabase';
+import { AppHeaderWithAdmin } from '../components/AppHeaderWithAdmin';
 
 export default function NotAuthorizedPage() {
   return (
     <div className='min-h-screen bg-gray-50'>
-      <AppHeader supabaseClient={supabase} />
+      <AppHeaderWithAdmin />
       <ContentContainer className='py-16'>
         <div className='mx-auto max-w-md rounded-lg bg-white p-8 shadow-sm border border-gray-200 text-center'>
           <h1 className='text-xl font-semibold text-gray-900'>

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
 import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
 import { useProfileContext } from '@beakerstack/shared/contexts/ProfileContext';
-import { supabase } from '@/lib/supabase';
-import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
+import { AppHeaderWithAdmin } from '../components/AppHeaderWithAdmin';
 import { ContentContainer } from '@beakerstack/shared/components/layout/ContentContainer.web';
 // Import Profile Display Components - Vite will automatically resolve .web.tsx files
 import { ProfileHeader } from '@beakerstack/shared/components/profile/ProfileHeader.web';
@@ -18,7 +17,7 @@ export default function ProfilePage() {
 
   return (
     <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
-      <AppHeader supabaseClient={supabase} />
+      <AppHeaderWithAdmin />
 
       {/* Main Content */}
       <ContentContainer className='py-6'>

--- a/apps/web/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.tsx
@@ -62,7 +62,7 @@ export default function ResetPasswordPage() {
     setError(null);
 
     if (password.length < MIN_PASSWORD_LENGTH) {
-      setError();
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
       return;
     }
 
@@ -122,7 +122,7 @@ export default function ResetPasswordPage() {
                   onChange={e => setPassword(e.target.value)}
                   disabled={isLoading}
                   className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
-                  placeholder={}
+                  placeholder={`New password (min ${MIN_PASSWORD_LENGTH} characters)`}
                 />
               </div>
               <div>

--- a/apps/web/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
-import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
+import { AppHeaderWithAdmin } from '../components/AppHeaderWithAdmin';
 import { ContentContainer } from '@beakerstack/shared/components/layout/ContentContainer.web';
 import { MIN_PASSWORD_LENGTH } from '@beakerstack/shared/constants/auth';
 import { supabase } from '@/lib/supabase';
@@ -62,7 +62,7 @@ export default function ResetPasswordPage() {
     setError(null);
 
     if (password.length < MIN_PASSWORD_LENGTH) {
-      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+      setError();
       return;
     }
 
@@ -89,7 +89,7 @@ export default function ResetPasswordPage() {
 
   return (
     <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
-      <AppHeader supabaseClient={supabase} />
+      <AppHeaderWithAdmin />
       <ContentContainer className='py-12'>
         <div className='w-full max-w-md mx-auto space-y-8'>
           <div>
@@ -122,7 +122,7 @@ export default function ResetPasswordPage() {
                   onChange={e => setPassword(e.target.value)}
                   disabled={isLoading}
                   className='appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed'
-                  placeholder={`New password (min ${MIN_PASSWORD_LENGTH} characters)`}
+                  placeholder={}
                 />
               </div>
               <div>

--- a/apps/web/src/pages/SignupInvitePage.tsx
+++ b/apps/web/src/pages/SignupInvitePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
-import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
+import { AppHeaderWithAdmin } from '../components/AppHeaderWithAdmin';
 import { ContentContainer } from '@beakerstack/shared/components/layout/ContentContainer.web';
 import { MIN_PASSWORD_LENGTH } from '@beakerstack/shared/config/auth';
 import { emitLifecycleEvent } from '@beakerstack/waitlist';
@@ -102,7 +102,7 @@ export default function SignupInvitePage() {
       return;
     }
     if (password.length < MIN_PASSWORD_LENGTH) {
-      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+      setError();
       return;
     }
     setSubmitting(true);
@@ -276,7 +276,7 @@ export default function SignupInvitePage() {
 function InvitePageShell({ children }: { children: React.ReactNode }) {
   return (
     <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
-      <AppHeader supabaseClient={supabase} />
+      <AppHeaderWithAdmin />
       {children}
     </div>
   );

--- a/apps/web/src/pages/SignupInvitePage.tsx
+++ b/apps/web/src/pages/SignupInvitePage.tsx
@@ -102,7 +102,7 @@ export default function SignupInvitePage() {
       return;
     }
     if (password.length < MIN_PASSWORD_LENGTH) {
-      setError();
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
       return;
     }
     setSubmitting(true);

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -2,7 +2,7 @@ import { BillingProvider } from '@beakerstack/billing';
 import { useMemo, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
-import { AppHeader } from '@beakerstack/shared/components/navigation/AppHeader.web';
+import { AppHeaderWithAdmin } from '../components/AppHeaderWithAdmin';
 import { ContentContainer } from '@beakerstack/shared/components/layout/ContentContainer.web';
 import { MIN_PASSWORD_LENGTH } from '@beakerstack/shared/constants/auth';
 import { supabase } from '@/lib/supabase';
@@ -53,7 +53,7 @@ function SignupPageContent() {
   const paidIntent = hasPaidPlanIntent(searchParams);
   const postAuthPath = resolvePostAuthDestination(searchParams);
   const loginSearch = searchParams.toString();
-  const loginTo = loginSearch ? `/login?${loginSearch}` : '/login';
+  const loginTo = loginSearch ?  : '/login';
 
   const stashOAuthIntent = () => {
     if (postAuthPath !== '/dashboard') {
@@ -73,7 +73,7 @@ function SignupPageContent() {
     }
 
     if (password.length < MIN_PASSWORD_LENGTH) {
-      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+      setError();
       return;
     }
 
@@ -134,7 +134,7 @@ function SignupPageContent() {
   const submitLabel = isLoading
     ? 'Creating account...'
     : paidIntent && postAuthPath !== '/dashboard'
-      ? `Continue with ${displayName}`
+      ? 
       : 'Create account';
 
   const showPlanAside =
@@ -157,7 +157,7 @@ function SignupPageContent() {
   if (awaitingEmail) {
     return (
       <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
-        <AppHeader supabaseClient={supabase} />
+        <AppHeaderWithAdmin />
         <ContentContainer className='py-12'>
           <div className='mx-auto max-w-md rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-8 shadow-sm'>
             <h2 className='text-xl font-semibold text-gray-900 dark:text-white'>
@@ -186,7 +186,7 @@ function SignupPageContent() {
 
   return (
     <div className='min-h-screen bg-gray-50 dark:bg-gray-900'>
-      <AppHeader supabaseClient={supabase} />
+      <AppHeaderWithAdmin />
       <ContentContainer className='py-12'>
         <div
           className={
@@ -204,7 +204,7 @@ function SignupPageContent() {
               <div>
                 <h2 className='mt-0 text-center text-3xl font-extrabold text-gray-900 dark:text-white md:text-left'>
                   {paidIntent && postAuthPath !== '/dashboard'
-                    ? `Create your account to continue with ${displayName}`
+                    ? 
                     : 'Create your account'}
                 </h2>
                 {paidIntent && postAuthPath !== '/dashboard' ? (
@@ -337,9 +337,9 @@ export default function SignupPage() {
     <BillingProvider<typeof beakerstackBillingConfig>
       supabase={supabase}
       config={beakerstackBillingConfig}
-      checkoutSuccessUrl={`${base}/billing?checkout=success`}
-      checkoutCancelUrl={`${base}/billing/plans?checkout=cancel`}
-      portalReturnUrl={`${base}/billing`}
+      checkoutSuccessUrl={}
+      checkoutCancelUrl={}
+      portalReturnUrl={}
     >
       <SignupPageContent />
     </BillingProvider>

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -53,7 +53,7 @@ function SignupPageContent() {
   const paidIntent = hasPaidPlanIntent(searchParams);
   const postAuthPath = resolvePostAuthDestination(searchParams);
   const loginSearch = searchParams.toString();
-  const loginTo = loginSearch ?  : '/login';
+  const loginTo = loginSearch ? `/login?${loginSearch}` : '/login';
 
   const stashOAuthIntent = () => {
     if (postAuthPath !== '/dashboard') {
@@ -73,7 +73,7 @@ function SignupPageContent() {
     }
 
     if (password.length < MIN_PASSWORD_LENGTH) {
-      setError();
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
       return;
     }
 
@@ -134,7 +134,7 @@ function SignupPageContent() {
   const submitLabel = isLoading
     ? 'Creating account...'
     : paidIntent && postAuthPath !== '/dashboard'
-      ? 
+      ? `Continue with ${displayName}`
       : 'Create account';
 
   const showPlanAside =
@@ -204,7 +204,7 @@ function SignupPageContent() {
               <div>
                 <h2 className='mt-0 text-center text-3xl font-extrabold text-gray-900 dark:text-white md:text-left'>
                   {paidIntent && postAuthPath !== '/dashboard'
-                    ? 
+                    ? `Create your account to continue with ${displayName}`
                     : 'Create your account'}
                 </h2>
                 {paidIntent && postAuthPath !== '/dashboard' ? (
@@ -337,9 +337,9 @@ export default function SignupPage() {
     <BillingProvider<typeof beakerstackBillingConfig>
       supabase={supabase}
       config={beakerstackBillingConfig}
-      checkoutSuccessUrl={}
-      checkoutCancelUrl={}
-      portalReturnUrl={}
+      checkoutSuccessUrl={`${base}/billing?checkout=success`}
+      checkoutCancelUrl={`${base}/billing/plans?checkout=cancel`}
+      portalReturnUrl={`${base}/billing`}
     >
       <SignupPageContent />
     </BillingProvider>

--- a/apps/web/src/pages/__tests__/ForgotPasswordPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ForgotPasswordPage.test.tsx
@@ -24,8 +24,8 @@ vi.mock('@/lib/supabase', () => ({
   },
 }));
 
-vi.mock('@beakerstack/shared/components/navigation/AppHeader.web', () => ({
-  AppHeader: () => null,
+vi.mock('@/components/AppHeaderWithAdmin', () => ({
+  AppHeaderWithAdmin: () => null,
 }));
 
 vi.mock('@beakerstack/shared/components/layout/ContentContainer.web', () => ({

--- a/apps/web/src/pages/__tests__/NotAuthorizedPage.test.tsx
+++ b/apps/web/src/pages/__tests__/NotAuthorizedPage.test.tsx
@@ -3,11 +3,9 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import NotAuthorizedPage from '../NotAuthorizedPage';
 
-vi.mock('@beakerstack/shared/components/navigation/AppHeader.web', () => ({
-  AppHeader: () => <div data-testid='app-header'>header</div>,
+vi.mock('@/components/AppHeaderWithAdmin', () => ({
+  AppHeaderWithAdmin: () => <div data-testid='app-header'>header</div>,
 }));
-
-vi.mock('@/lib/supabase', () => ({ supabase: {} }));
 
 describe('NotAuthorizedPage', () => {
   it('renders not authorized message and dashboard link', () => {

--- a/apps/web/src/pages/__tests__/ProfilePage.coverage.test.tsx
+++ b/apps/web/src/pages/__tests__/ProfilePage.coverage.test.tsx
@@ -55,8 +55,8 @@ vi.mock('@/lib/supabase', () => ({
   supabase: { auth: { signOut: vi.fn() } },
 }));
 
-vi.mock('@beakerstack/shared/components/navigation/AppHeader.web', () => ({
-  AppHeader: () => <header data-testid='app-header'>Header</header>,
+vi.mock('@/components/AppHeaderWithAdmin', () => ({
+  AppHeaderWithAdmin: () => <header data-testid='app-header'>Header</header>,
 }));
 
 vi.mock('@beakerstack/shared/components/profile/ProfileHeader.web', () => ({

--- a/apps/web/src/pages/__tests__/ResetPasswordPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ResetPasswordPage.test.tsx
@@ -30,8 +30,8 @@ vi.mock('react-router-dom', async () => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-vi.mock('@beakerstack/shared/components/navigation/AppHeader.web', () => ({
-  AppHeader: () => null,
+vi.mock('@/components/AppHeaderWithAdmin', () => ({
+  AppHeaderWithAdmin: () => null,
 }));
 
 vi.mock('@beakerstack/shared/components/layout/ContentContainer.web', () => ({
@@ -142,7 +142,7 @@ describe('ResetPasswordPage', () => {
 
     expect(
       screen.getByText(
-        `Password must be at least ${MIN_PASSWORD_LENGTH} characters`
+        
       )
     ).toBeInTheDocument();
     expect(mockUpdateUser).not.toHaveBeenCalled();

--- a/apps/web/src/pages/__tests__/ResetPasswordPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ResetPasswordPage.test.tsx
@@ -142,7 +142,7 @@ describe('ResetPasswordPage', () => {
 
     expect(
       screen.getByText(
-        
+        `Password must be at least ${MIN_PASSWORD_LENGTH} characters`
       )
     ).toBeInTheDocument();
     expect(mockUpdateUser).not.toHaveBeenCalled();

--- a/apps/web/src/pages/__tests__/SignupInvitePage.test.tsx
+++ b/apps/web/src/pages/__tests__/SignupInvitePage.test.tsx
@@ -34,8 +34,8 @@ vi.mock('@beakerstack/shared/contexts/AuthContext', () => ({
   }),
 }));
 
-vi.mock('@beakerstack/shared/components/navigation/AppHeader.web', () => ({
-  AppHeader: () => <header data-testid='app-header' />,
+vi.mock('@/components/AppHeaderWithAdmin', () => ({
+  AppHeaderWithAdmin: () => <header data-testid='app-header' />,
 }));
 
 vi.mock('@beakerstack/waitlist', async importOriginal => {

--- a/packages/shared-tests/__tests__/components/navigation/UserMenu.test.tsx
+++ b/packages/shared-tests/__tests__/components/navigation/UserMenu.test.tsx
@@ -356,4 +356,59 @@ describe('UserMenu (Web)', () => {
     );
     expect(screen.queryByText('test@example.com')).not.toBeInTheDocument();
   });
+
+  it('should show Admin link when showAdminLink is true', async () => {
+    renderWithProviders(
+      <UserMenu user={mockUser} profile={mockProfile} showAdminLink={true} />
+    );
+    fireEvent.click(screen.getByLabelText('User menu'));
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: 'Admin' })).toBeInTheDocument()
+    );
+    expect(screen.getByRole('link', { name: 'Admin' })).toHaveAttribute(
+      'href',
+      '/admin'
+    );
+  });
+
+  it('should not show Admin link when showAdminLink is false', async () => {
+    renderWithProviders(
+      <UserMenu user={mockUser} profile={mockProfile} showAdminLink={false} />
+    );
+    fireEvent.click(screen.getByLabelText('User menu'));
+    await waitFor(() =>
+      expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByRole('link', { name: 'Admin' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should not show Admin link when showAdminLink is omitted', async () => {
+    renderWithProviders(<UserMenu user={mockUser} profile={mockProfile} />);
+    fireEvent.click(screen.getByLabelText('User menu'));
+    await waitFor(() =>
+      expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByRole('link', { name: 'Admin' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should close menu when Admin link is clicked', async () => {
+    renderWithProviders(
+      <UserMenu user={mockUser} profile={mockProfile} showAdminLink={true} />
+    );
+    fireEvent.click(screen.getByLabelText('User menu'));
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: 'Admin' })).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByRole('link', { name: 'Admin' }));
+    await waitFor(() => {
+      expect(screen.getByLabelText('User menu')).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      );
+    });
+  });
 });

--- a/packages/shared/src/components/navigation/AppHeader.web.tsx
+++ b/packages/shared/src/components/navigation/AppHeader.web.tsx
@@ -48,7 +48,11 @@ export function AppHeader({
 
   return (
     <header
-      className={}
+      className={`sticky top-0 z-50 bg-white dark:bg-gray-900 transition-shadow ${
+        scrolled
+          ? 'border-b border-gray-200 dark:border-gray-800 shadow-sm'
+          : ''
+      }`}
     >
       <ContentContainer>
         <div className='flex justify-between items-center h-16'>
@@ -56,7 +60,7 @@ export function AppHeader({
           <div className='flex items-center space-x-3'>
             <Link to='/' className='flex items-center'>
               <img
-                src={}
+                src={`${basePath}demo-flask-icon.svg`}
                 alt={BRANDING.displayName}
                 className='w-8 h-8'
               />

--- a/packages/shared/src/components/navigation/AppHeader.web.tsx
+++ b/packages/shared/src/components/navigation/AppHeader.web.tsx
@@ -9,13 +9,17 @@ import { ContentContainer } from '../layout/ContentContainer.web';
 
 export interface AppHeaderProps {
   supabaseClient: SupabaseClient;
+  showAdminLink?: boolean;
 }
 
 /**
  * AppHeader component for web
  * Displays app icon, title, and navigation based on auth state
  */
-export function AppHeader({ supabaseClient: _supabaseClient }: AppHeaderProps) {
+export function AppHeader({
+  supabaseClient: _supabaseClient,
+  showAdminLink = false,
+}: AppHeaderProps) {
   const auth = useAuthContext();
   const profile = useProfileContext();
   const [scrolled, setScrolled] = useState(false);
@@ -44,11 +48,7 @@ export function AppHeader({ supabaseClient: _supabaseClient }: AppHeaderProps) {
 
   return (
     <header
-      className={`sticky top-0 z-50 bg-white dark:bg-gray-900 transition-shadow ${
-        scrolled
-          ? 'border-b border-gray-200 dark:border-gray-800 shadow-sm'
-          : ''
-      }`}
+      className={}
     >
       <ContentContainer>
         <div className='flex justify-between items-center h-16'>
@@ -56,7 +56,7 @@ export function AppHeader({ supabaseClient: _supabaseClient }: AppHeaderProps) {
           <div className='flex items-center space-x-3'>
             <Link to='/' className='flex items-center'>
               <img
-                src={`${basePath}demo-flask-icon.svg`}
+                src={}
                 alt={BRANDING.displayName}
                 className='w-8 h-8'
               />
@@ -72,7 +72,11 @@ export function AppHeader({ supabaseClient: _supabaseClient }: AppHeaderProps) {
           {/* Right side: Auth buttons or user menu */}
           <div className='flex items-center space-x-4'>
             {auth.user ? (
-              <UserMenu user={auth.user} profile={profile.profile} />
+              <UserMenu
+                user={auth.user}
+                profile={profile.profile}
+                showAdminLink={showAdminLink}
+              />
             ) : (
               <>
                 <Link

--- a/packages/shared/src/components/navigation/UserMenu.web.tsx
+++ b/packages/shared/src/components/navigation/UserMenu.web.tsx
@@ -14,7 +14,7 @@ export interface UserMenuProps {
 
 /**
  * UserMenu component for web
- * Displays user avatar with dropdown menu containing Profile, Dashboard, and Sign Out options
+ * Displays user avatar with dropdown menu containing Profile, Billing, Dashboard, Admin (when showAdminLink=true), and Sign Out options
  */
 export function UserMenu({
   user,

--- a/packages/shared/src/components/navigation/UserMenu.web.tsx
+++ b/packages/shared/src/components/navigation/UserMenu.web.tsx
@@ -9,13 +9,18 @@ import { ProfileAvatar } from '../profile/ProfileAvatar.web';
 export interface UserMenuProps {
   user: User;
   profile: UserProfile | null;
+  showAdminLink?: boolean;
 }
 
 /**
  * UserMenu component for web
  * Displays user avatar with dropdown menu containing Profile, Dashboard, and Sign Out options
  */
-export function UserMenu({ user, profile }: UserMenuProps) {
+export function UserMenu({
+  user,
+  profile,
+  showAdminLink = false,
+}: UserMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const auth = useAuthContext();
@@ -99,6 +104,15 @@ export function UserMenu({ user, profile }: UserMenuProps) {
             >
               Dashboard
             </Link>
+            {showAdminLink && (
+              <Link
+                to='/admin'
+                onClick={() => setIsOpen(false)}
+                className='block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700'
+              >
+                Admin
+              </Link>
+            )}
             <div className='my-1 border-t border-gray-200 dark:border-gray-700' />
             <button
               onClick={handleSignOut}


### PR DESCRIPTION
## Summary

Closes #328.

Shows an Admin menu item in the user dropdown for users who have the admin role. Non-admins and unauthenticated users never see it.

## Implementation

- **`showAdminLink?: boolean` prop** added to `UserMenu` and `AppHeader` in `@beakerstack/shared`. When `true`, renders an Admin link between Dashboard and sign-out; clicking it closes the menu and navigates to `/admin`.

- **`AppHeaderWithAdmin` wrapper** (`apps/web/src/components/AppHeaderWithAdmin.tsx`) — keeps `@beakerstack/shared` free of any `@beakerstack/admin` dependency. The admin check lives here in the web app layer.
  - Calls `useIsAdmin(supabase, userId)` from `@beakerstack/admin`.
  - Passes `showAdminLink={!loading && isAdmin}` — **fail-closed**: the link is hidden while the RPC is in-flight and on any error.
  - Revalidates admin status on `window focus` and `visibilitychange` (same pattern as `AdminRoute`).

- **All 9 page-level headers** (`DashboardPage`, `ProfilePage`, `LoginPage`, `SignupPage`, `ForgotPasswordPage`, `ResetPasswordPage`, `NotAuthorizedPage`, `SignupInvitePage`, `BillingPageShell`) updated from `AppHeader` → `AppHeaderWithAdmin`.

## Tests

- `AppHeaderWithAdmin.test.tsx` — 7 tests: admin shown, non-admin hidden, fail-closed on loading, fail-closed on error, focus refresh, visibilitychange refresh, no refresh when logged out.
- `UserMenu.test.tsx` — 4 new tests: shows Admin link when `showAdminLink=true`, hides when false/omitted, closes menu on Admin click.
- All affected page test files updated to mock `AppHeaderWithAdmin` instead of `AppHeader.web`.

## Checklist

- [x] Lint clean
- [x] Type-check passes (all packages)
- [x] Unit tests pass
- [x] Fail-closed: link hidden while loading or on RPC error
- [x] No `@beakerstack/admin` dependency leaked into `@beakerstack/shared`
