### PR TITLE
feat(admin): rename Dashboard to Overview, add summary cards (#338)

### DIFF
--- a/apps/web/src/admin/AdminLayoutShell.tsx
+++ b/apps/web/src/admin/AdminLayoutShell.tsx
@@ -6,10 +6,17 @@ import { adminNavItems } from './adminNav';
 import { LayoutDashboard, LogOut } from 'lucide-react';
 
 function breadcrumbsForPath(pathname: string) {
-  if (pathname.endsWith('/users')) {
-    return [{ label: 'Admin Dashboard', to: '/admin' }, { label: 'Users' }];
+  const root = { label: 'Overview', to: '/admin' };
+  if (pathname.includes('/waitlist/settings')) {
+    return [root, { label: 'Waitlist Settings' }];
   }
-  return [{ label: 'Admin Dashboard' }];
+  if (pathname.includes('/waitlist')) {
+    return [root, { label: 'Waitlist' }];
+  }
+  if (pathname.includes('/users')) {
+    return [root, { label: 'Users' }];
+  }
+  return [{ label: 'Overview' }];
 }
 
 export function AdminLayoutShell() {

--- a/apps/web/src/admin/__tests__/AdminDashboardPage.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminDashboardPage.test.tsx
@@ -47,9 +47,9 @@ describe('AdminDashboardPage', () => {
         <AdminDashboardPage />
       </MemoryRouter>
     );
-    expect(screen.getByText('42 total')).toBeInTheDocument();
+    expect(screen.getByText('42 total users')).toBeInTheDocument();
     expect(screen.getByText('7 pending')).toBeInTheDocument();
-    expect(screen.getByText('Invite Only')).toBeInTheDocument();
+    expect(screen.getByText('Invite only')).toBeInTheDocument();
   });
 
   it('shows em-dash for stats while loading', () => {
@@ -65,7 +65,7 @@ describe('AdminDashboardPage', () => {
         <AdminDashboardPage />
       </MemoryRouter>
     );
-    expect(screen.getByText('\u2014 total')).toBeInTheDocument();
+    expect(screen.getByText('\u2014 total users')).toBeInTheDocument();
     expect(screen.getByText('\u2014 pending')).toBeInTheDocument();
     expect(screen.getAllByText('\u2014')).toHaveLength(1);
   });

--- a/apps/web/src/admin/__tests__/AdminDashboardPage.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminDashboardPage.test.tsx
@@ -1,21 +1,72 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import AdminDashboardPage from '../pages/AdminDashboardPage';
+import * as statsModule from '../hooks/useAdminOverviewStats';
+
+vi.mock('../hooks/useAdminOverviewStats');
+const mockUseStats = vi.mocked(statsModule.useAdminOverviewStats);
 
 describe('AdminDashboardPage', () => {
-  it('renders dashboard heading and users card link', () => {
+  beforeEach(() => {
+    mockUseStats.mockReturnValue({
+      usersTotal: 5,
+      waitlistPending: 2,
+      signupMode: 'open',
+      loading: false,
+      error: null,
+    });
+  });
+
+  it('renders overview heading and all three card links', () => {
     render(
       <MemoryRouter>
         <AdminDashboardPage />
       </MemoryRouter>
     );
     expect(
-      screen.getByRole('heading', { name: 'Dashboard' })
+      screen.getByRole('heading', { name: 'Overview' })
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /users/i })).toHaveAttribute(
-      'href',
-      '/admin/users'
+    const links = screen.getAllByRole('link');
+    const hrefs = links.map(l => l.getAttribute('href'));
+    expect(hrefs).toContain('/admin/users');
+    expect(hrefs).toContain('/admin/waitlist');
+    expect(hrefs).toContain('/admin/waitlist/settings');
+  });
+
+  it('displays live stats from the hook', () => {
+    mockUseStats.mockReturnValue({
+      usersTotal: 42,
+      waitlistPending: 7,
+      signupMode: 'invite_only',
+      loading: false,
+      error: null,
+    });
+    render(
+      <MemoryRouter>
+        <AdminDashboardPage />
+      </MemoryRouter>
     );
+    expect(screen.getByText('42 total')).toBeInTheDocument();
+    expect(screen.getByText('7 pending')).toBeInTheDocument();
+    expect(screen.getByText('Invite Only')).toBeInTheDocument();
+  });
+
+  it('shows em-dash for stats while loading', () => {
+    mockUseStats.mockReturnValue({
+      usersTotal: null,
+      waitlistPending: null,
+      signupMode: null,
+      loading: true,
+      error: null,
+    });
+    render(
+      <MemoryRouter>
+        <AdminDashboardPage />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('\u2014 total')).toBeInTheDocument();
+    expect(screen.getByText('\u2014 pending')).toBeInTheDocument();
+    expect(screen.getAllByText('\u2014')).toHaveLength(1);
   });
 });

--- a/apps/web/src/admin/__tests__/AdminLayoutShell.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminLayoutShell.test.tsx
@@ -73,4 +73,34 @@ describe('AdminLayoutShell', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/');
     });
   });
+
+  describe('breadcrumbs', () => {
+    it('Overview \u2192 Users for /users path', () => {
+      renderShell('/users', 'users', <p>outlet</p>);
+      const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
+      expect(within(bc).getByRole('link', { name: 'Overview' })).toHaveAttribute('href', '/admin');
+      expect(within(bc).getByText('Users')).toBeInTheDocument();
+    });
+
+    it('Overview \u2192 Waitlist for /waitlist path', () => {
+      renderShell('/waitlist', 'waitlist', <p>outlet</p>);
+      const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
+      expect(within(bc).getByRole('link', { name: 'Overview' })).toHaveAttribute('href', '/admin');
+      expect(within(bc).getByText('Waitlist')).toBeInTheDocument();
+    });
+
+    it('Overview \u2192 Waitlist Settings for /waitlist/settings path', () => {
+      renderShell('/waitlist/settings', 'waitlist/settings', <p>outlet</p>);
+      const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
+      expect(within(bc).getByRole('link', { name: 'Overview' })).toHaveAttribute('href', '/admin');
+      expect(within(bc).getByText('Waitlist Settings')).toBeInTheDocument();
+    });
+
+    it('single Overview crumb with no link on /admin root', () => {
+      renderShell('/admin', 'admin', <p>outlet</p>);
+      const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
+      expect(within(bc).getByText('Overview')).toBeInTheDocument();
+      expect(within(bc).queryByRole('link', { name: 'Overview' })).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/admin/__tests__/AdminLayoutShell.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminLayoutShell.test.tsx
@@ -42,9 +42,18 @@ describe('AdminLayoutShell', () => {
     expect(screen.getByText('Users outlet')).toBeInTheDocument();
   });
 
-  it('uses dashboard-only breadcrumbs on non-users admin routes', () => {
+  it('renders outlet for waitlist path', () => {
     renderShell('/waitlist', 'waitlist', <p>Waitlist outlet</p>);
     expect(screen.getByText('Waitlist outlet')).toBeInTheDocument();
+  });
+
+  it('renders outlet for waitlist settings path', () => {
+    renderShell(
+      '/waitlist/settings',
+      'waitlist/settings',
+      <p>Settings outlet</p>
+    );
+    expect(screen.getByText('Settings outlet')).toBeInTheDocument();
   });
 
   it('renders a Dashboard link pointing to /dashboard', () => {

--- a/apps/web/src/admin/__tests__/adminNav.test.ts
+++ b/apps/web/src/admin/__tests__/adminNav.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { adminNavItems } from '../adminNav';
 
 describe('adminNav', () => {
-  it('includes dashboard, users, and waitlist entries', () => {
+  it('includes overview, users, and waitlist entries', () => {
     expect(adminNavItems.map(n => n.label)).toEqual([
-      'Admin Dashboard',
+      'Overview',
       'Users',
       'Waitlist',
       'Waitlist settings',

--- a/apps/web/src/admin/__tests__/useAdminOverviewStats.test.tsx
+++ b/apps/web/src/admin/__tests__/useAdminOverviewStats.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { listUsers } from '@beakerstack/admin';
+import { getAdminWaitlistSettings, listWaitlistEntries } from '@beakerstack/waitlist';
+import { useAdminOverviewStats } from '../hooks/useAdminOverviewStats';
+
+vi.mock('@beakerstack/admin', async importOriginal => {
+  const actual = await importOriginal<typeof import('@beakerstack/admin')>();
+  return { ...actual, listUsers: vi.fn() };
+});
+
+vi.mock('@beakerstack/waitlist', async importOriginal => {
+  const actual = await importOriginal<typeof import('@beakerstack/waitlist')>();
+  return {
+    ...actual,
+    listWaitlistEntries: vi.fn(),
+    getAdminWaitlistSettings: vi.fn(),
+  };
+});
+
+const mockListUsers = vi.mocked(listUsers);
+const mockListWaitlistEntries = vi.mocked(listWaitlistEntries);
+const mockGetSettings = vi.mocked(getAdminWaitlistSettings);
+
+describe('useAdminOverviewStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListUsers.mockResolvedValue({
+      users: [],
+      total: 18,
+      limit: 1,
+      offset: 0,
+    } as never);
+    mockListWaitlistEntries.mockResolvedValue({
+      entries: [],
+      total: 3,
+      limit: 1,
+      offset: 0,
+    });
+    mockGetSettings.mockResolvedValue({ signup_mode: 'waitlist' });
+  });
+
+  it('fetches all three stats on mount', async () => {
+    const { result } = renderHook(() => useAdminOverviewStats());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.usersTotal).toBe(18);
+    expect(result.current.waitlistPending).toBe(3);
+    expect(result.current.signupMode).toBe('waitlist');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('surfaces errors and sets values to null', async () => {
+    mockListUsers.mockRejectedValueOnce(new Error('users failed'));
+    const { result } = renderHook(() => useAdminOverviewStats());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error?.message).toBe('users failed');
+    expect(result.current.usersTotal).toBeNull();
+  });
+
+  it('wraps non-Error throws into Error instances', async () => {
+    mockListWaitlistEntries.mockRejectedValueOnce('boom');
+    const { result } = renderHook(() => useAdminOverviewStats());
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.error?.message).toBe('boom');
+  });
+
+  it('handles null settings response', async () => {
+    mockGetSettings.mockResolvedValue(null);
+    const { result } = renderHook(() => useAdminOverviewStats());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.signupMode).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/apps/web/src/admin/__tests__/useAdminOverviewStats.test.tsx
+++ b/apps/web/src/admin/__tests__/useAdminOverviewStats.test.tsx
@@ -22,6 +22,16 @@ const mockListUsers = vi.mocked(listUsers);
 const mockListWaitlistEntries = vi.mocked(listWaitlistEntries);
 const mockGetSettings = vi.mocked(getAdminWaitlistSettings);
 
+const fullSettings = {
+  signup_mode: 'waitlist' as const,
+  default_plan_id: '',
+  invite_ttl_days: 7,
+  identity_match_mode: 'lenient' as const,
+  copy: {},
+  metadata_schema: [],
+  updated_at: '2024-01-01T00:00:00Z',
+};
+
 describe('useAdminOverviewStats', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -37,7 +47,7 @@ describe('useAdminOverviewStats', () => {
       limit: 1,
       offset: 0,
     });
-    mockGetSettings.mockResolvedValue({ signup_mode: 'waitlist' });
+    mockGetSettings.mockResolvedValue(fullSettings);
   });
 
   it('fetches all three stats on mount', async () => {
@@ -69,6 +79,16 @@ describe('useAdminOverviewStats', () => {
     const { result } = renderHook(() => useAdminOverviewStats());
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.signupMode).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('handles null list RPC responses gracefully', async () => {
+    mockListUsers.mockResolvedValue(null as never);
+    mockListWaitlistEntries.mockResolvedValue(null as never);
+    const { result } = renderHook(() => useAdminOverviewStats());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.usersTotal).toBeNull();
+    expect(result.current.waitlistPending).toBeNull();
     expect(result.current.error).toBeNull();
   });
 });

--- a/apps/web/src/admin/adminNav.ts
+++ b/apps/web/src/admin/adminNav.ts
@@ -4,7 +4,7 @@ import { createElement } from 'react';
 
 export const adminNavItems: AdminNavItem[] = [
   {
-    label: 'Admin Dashboard',
+    label: 'Overview',
     to: '/admin',
     icon: createElement(LayoutDashboard, { className: 'h-4 w-4 shrink-0' }),
   },

--- a/apps/web/src/admin/hooks/useAdminOverviewStats.ts
+++ b/apps/web/src/admin/hooks/useAdminOverviewStats.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { listUsers } from '@beakerstack/admin';
+import {
+  getAdminWaitlistSettings,
+  listWaitlistEntries,
+  type SignupMode,
+} from '@beakerstack/waitlist';
+import { supabase } from '../../lib/supabase';
+import { adminProductId } from '../adminUsageColumns';
+
+interface AdminOverviewStats {
+  usersTotal: number | null;
+  waitlistPending: number | null;
+  signupMode: SignupMode | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useAdminOverviewStats(): AdminOverviewStats {
+  const [usersTotal, setUsersTotal] = useState<number | null>(null);
+  const [waitlistPending, setWaitlistPending] = useState<number | null>(null);
+  const [signupMode, setSignupMode] = useState<SignupMode | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    Promise.all([
+      listUsers(supabase, { limit: 1, offset: 0, productId: adminProductId }),
+      listWaitlistEntries(supabase, { limit: 1, offset: 0, status: 'pending' }),
+      getAdminWaitlistSettings(supabase),
+    ])
+      .then(([usersResult, waitlistResult, settings]) => {
+        if (cancelled) return;
+        setUsersTotal(usersResult.total);
+        setWaitlistPending(waitlistResult.total);
+        setSignupMode(settings?.signup_mode ?? null);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { usersTotal, waitlistPending, signupMode, loading, error };
+}

--- a/apps/web/src/admin/hooks/useAdminOverviewStats.ts
+++ b/apps/web/src/admin/hooks/useAdminOverviewStats.ts
@@ -35,8 +35,8 @@ export function useAdminOverviewStats(): AdminOverviewStats {
     ])
       .then(([usersResult, waitlistResult, settings]) => {
         if (cancelled) return;
-        setUsersTotal(usersResult.total);
-        setWaitlistPending(waitlistResult.total);
+        setUsersTotal(usersResult?.total ?? null);
+        setWaitlistPending(waitlistResult?.total ?? null);
         setSignupMode(settings?.signup_mode ?? null);
       })
       .catch((e: unknown) => {

--- a/apps/web/src/admin/pages/AdminDashboardPage.tsx
+++ b/apps/web/src/admin/pages/AdminDashboardPage.tsx
@@ -6,7 +6,7 @@ import type { SignupMode } from '@beakerstack/waitlist';
 const SIGNUP_MODE_LABELS: Record<SignupMode, string> = {
   open: 'Open',
   waitlist: 'Waitlist',
-  invite_only: 'Invite Only',
+  invite_only: 'Invite only',
   closed: 'Closed',
 };
 

--- a/apps/web/src/admin/pages/AdminDashboardPage.tsx
+++ b/apps/web/src/admin/pages/AdminDashboardPage.tsx
@@ -37,7 +37,7 @@ export default function AdminOverviewPage() {
             </span>
             <div>
               <p className='font-semibold text-gray-900'>Users</p>
-              <p className='text-sm text-gray-500'>{stat(usersTotal)} total</p>
+              <p className='text-sm text-gray-500'>{stat(usersTotal)} total users</p>
             </div>
           </div>
         </Link>

--- a/apps/web/src/admin/pages/AdminDashboardPage.tsx
+++ b/apps/web/src/admin/pages/AdminDashboardPage.tsx
@@ -1,11 +1,26 @@
 import { Link } from 'react-router-dom';
-import { Users } from 'lucide-react';
+import { ClipboardList, Settings, Users } from 'lucide-react';
+import { useAdminOverviewStats } from '../hooks/useAdminOverviewStats';
+import type { SignupMode } from '@beakerstack/waitlist';
 
-export default function AdminDashboardPage() {
+const SIGNUP_MODE_LABELS: Record<SignupMode, string> = {
+  open: 'Open',
+  waitlist: 'Waitlist',
+  invite_only: 'Invite Only',
+  closed: 'Closed',
+};
+
+export default function AdminOverviewPage() {
+  const { usersTotal, waitlistPending, signupMode, loading } =
+    useAdminOverviewStats();
+
+  const stat = (value: number | null) =>
+    loading || value === null ? '\u2014' : String(value);
+
   return (
     <div className='space-y-6'>
       <div>
-        <h2 className='text-2xl font-bold text-gray-900'>Dashboard</h2>
+        <h2 className='text-2xl font-bold text-gray-900'>Overview</h2>
         <p className='mt-1 text-sm text-gray-600'>
           Operator overview for your BeakerStack app.
         </p>
@@ -22,8 +37,42 @@ export default function AdminDashboardPage() {
             </span>
             <div>
               <p className='font-semibold text-gray-900'>Users</p>
+              <p className='text-sm text-gray-500'>{stat(usersTotal)} total</p>
+            </div>
+          </div>
+        </Link>
+
+        <Link
+          to='/admin/waitlist'
+          className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm hover:border-indigo-300 hover:shadow-md transition-shadow'
+        >
+          <div className='flex items-center gap-3'>
+            <span className='inline-flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600'>
+              <ClipboardList className='h-5 w-5' />
+            </span>
+            <div>
+              <p className='font-semibold text-gray-900'>Waitlist</p>
               <p className='text-sm text-gray-500'>
-                View signups, plans, and metered usage
+                {stat(waitlistPending)} pending
+              </p>
+            </div>
+          </div>
+        </Link>
+
+        <Link
+          to='/admin/waitlist/settings'
+          className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm hover:border-indigo-300 hover:shadow-md transition-shadow'
+        >
+          <div className='flex items-center gap-3'>
+            <span className='inline-flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600'>
+              <Settings className='h-5 w-5' />
+            </span>
+            <div>
+              <p className='font-semibold text-gray-900'>Waitlist Settings</p>
+              <p className='text-sm text-gray-500'>
+                {loading || signupMode === null
+                  ? '\u2014'
+                  : SIGNUP_MODE_LABELS[signupMode]}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Renames the admin "Dashboard" nav label and page heading to **Overview** (`adminNav.ts`, `AdminDashboardPage.tsx`)
- Adds `useAdminOverviewStats` hook — fetches users total, waitlist pending count, and signup mode in parallel via `Promise.all`
- Extends the overview page with **Waitlist** and **Waitlist Settings** summary cards, each showing a live stat; all three cards show `—` while loading
- Fixes `breadcrumbsForPath` in `AdminLayoutShell.tsx` to cover `/admin/waitlist` and `/admin/waitlist/settings` routes (settings checked before waitlist)
- Updates `adminNav.test.ts`, `AdminDashboardPage.test.tsx`, `AdminLayoutShell.test.tsx`; adds `useAdminOverviewStats.test.tsx`

Closes #338

## Test plan

- [ ] `adminNav` test: labels array now starts with "Overview"
- [ ] `AdminDashboardPage` test: heading "Overview", three card links verified, live stats, loading em-dash state
- [ ] `AdminLayoutShell` test: outlet renders for waitlist and waitlist/settings paths
- [ ] `useAdminOverviewStats` test: fetches all three in parallel, surfaces errors, handles null settings
