### PR TITLE
feat(#286): kit-webhook Edge Function + user.deleted GDPR wiring (Phase 4)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -121,6 +121,7 @@ jobs:
           PRODUCTION_BILLING_ALLOWED_ORIGINS: ${{ secrets.PRODUCTION_BILLING_ALLOWED_ORIGINS }}
           PRODUCTION_KIT_API_KEY: ${{ secrets.PRODUCTION_KIT_API_KEY }}
           PRODUCTION_KIT_CRON_SECRET: ${{ secrets.PRODUCTION_KIT_CRON_SECRET }}
+          PRODUCTION_KIT_WEBHOOK_SECRET: ${{ secrets.PRODUCTION_KIT_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
           cd supabase
@@ -139,7 +140,8 @@ jobs:
           # strings would clobber any manually-configured Supabase project secrets.
           [[ -n "${PRODUCTION_KIT_API_KEY:-}" ]] && supabase secrets set KIT_API_KEY="${PRODUCTION_KIT_API_KEY}"
           [[ -n "${PRODUCTION_KIT_CRON_SECRET:-}" ]] && supabase secrets set KIT_CRON_SECRET="${PRODUCTION_KIT_CRON_SECRET}"
-          supabase functions deploy stripe-webhook billing-stripe waitlist-capture waitlist-ops kit-sync \
+          [[ -n "${PRODUCTION_KIT_WEBHOOK_SECRET:-}" ]] && supabase secrets set KIT_WEBHOOK_SECRET="${PRODUCTION_KIT_WEBHOOK_SECRET}"
+          supabase functions deploy stripe-webhook billing-stripe waitlist-capture waitlist-ops kit-sync kit-webhook \
             --project-ref "${PRODUCTION_SUPABASE_PROJECT_REF}"
 
       - name: Ensure kit-sync cron job (production)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -121,6 +121,7 @@ jobs:
           STAGING_BILLING_ALLOWED_ORIGINS: ${{ secrets.STAGING_BILLING_ALLOWED_ORIGINS }}
           STAGING_KIT_API_KEY: ${{ secrets.STAGING_KIT_API_KEY }}
           STAGING_KIT_CRON_SECRET: ${{ secrets.STAGING_KIT_CRON_SECRET }}
+          STAGING_KIT_WEBHOOK_SECRET: ${{ secrets.STAGING_KIT_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
           cd supabase
@@ -139,7 +140,8 @@ jobs:
           # strings would clobber any manually-configured Supabase project secrets.
           [[ -n "${STAGING_KIT_API_KEY:-}" ]] && supabase secrets set KIT_API_KEY="${STAGING_KIT_API_KEY}"
           [[ -n "${STAGING_KIT_CRON_SECRET:-}" ]] && supabase secrets set KIT_CRON_SECRET="${STAGING_KIT_CRON_SECRET}"
-          supabase functions deploy stripe-webhook billing-stripe waitlist-capture waitlist-ops kit-sync \
+          [[ -n "${STAGING_KIT_WEBHOOK_SECRET:-}" ]] && supabase secrets set KIT_WEBHOOK_SECRET="${STAGING_KIT_WEBHOOK_SECRET}"
+          supabase functions deploy stripe-webhook billing-stripe waitlist-capture waitlist-ops kit-sync kit-webhook \
             --project-ref "${STAGING_SUPABASE_PROJECT_REF}"
 
       - name: Ensure kit-sync cron job (staging)

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -390,6 +390,9 @@ verify_jwt = false
 [functions.kit-sync]
 verify_jwt = false
 
+[functions.kit-webhook]
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 55327

--- a/supabase/functions/_shared/marketingEmailQueue.ts
+++ b/supabase/functions/_shared/marketingEmailQueue.ts
@@ -6,7 +6,8 @@ export type LifecycleEventType =
   | 'waitlist.approved'
   | 'waitlist.converted'
   | 'user.tier_changed'
-  | 'user.churned';
+  | 'user.churned'
+  | 'user.deleted';
 
 // Fire-and-forget: failures are logged but never thrown so marketing email never
 // blocks user-facing flows. A transient failure permanently drops the event —

--- a/supabase/functions/kit-sync/index.ts
+++ b/supabase/functions/kit-sync/index.ts
@@ -152,7 +152,9 @@ async function handleWorker(
         .eq('email', row.email)
         .maybeSingle();
 
-      if (suppressed) {
+      // user.deleted is a GDPR erasure — it must run even if the user previously
+      // unsubscribed via Kit webhook. Suppression only governs marketing sends.
+      if (suppressed && row.event_type !== 'user.deleted') {
         await markDone(admin, row.id);
         skipped++;
         continue;
@@ -307,6 +309,12 @@ async function processEvent(
       if ((config.onChurn ?? 'tag_only') === 'unsubscribe') {
         await kit.unsubscribeUser(email);
       }
+      break;
+    }
+    case 'user.deleted': {
+      // GDPR erasure: hard-delete the subscriber from Kit. Bypasses suppression
+      // check above so this always runs regardless of unsubscribe status.
+      await kit.deleteUser(email);
       break;
     }
     default:

--- a/supabase/functions/kit-sync/index.ts
+++ b/supabase/functions/kit-sync/index.ts
@@ -123,10 +123,10 @@ async function handleWorker(
 
       const config = settings.config;
 
-      // Guard: namespace is required for all Kit tag operations. Dead-letter with a
-      // clear message so the operator knows exactly what to fix, rather than letting
-      // the row reach Kit API and fail with a confusing tag-not-found error.
-      if (!config.namespace) {
+      // Guard: namespace is required for tag operations, but not for GDPR erasure
+      // (deleteUser only needs API key + email). Carve out user.deleted so it is
+      // never dead-lettered by a missing namespace.
+      if (!config.namespace && row.event_type !== 'user.deleted') {
         const { error: upErr } = await admin
           .from('marketing_email_sync_queue')
           .update({

--- a/supabase/functions/kit-webhook/index.ts
+++ b/supabase/functions/kit-webhook/index.ts
@@ -41,7 +41,7 @@ async function verifyKitSignature(
   secret: string
 ): Promise<boolean> {
   if (!sigHeader?.startsWith('sha256=')) return false;
-  const expected = sigHeader.slice(7);
+  const expected = sigHeader.slice(7).toLowerCase();
   const key = await crypto.subtle.importKey(
     'raw',
     new TextEncoder().encode(secret),
@@ -68,12 +68,11 @@ async function checkRateLimit(
   bucketKey: string,
   limit: number
 ): Promise<boolean> {
-  const windowStart = new Date();
-  windowStart.setMinutes(0, 0, 0); // hour-truncated window
-
+  // Pass raw timestamp — the RPC applies date_trunc('hour', ...) server-side in UTC,
+  // avoiding any TZ skew from the Edge runtime's local clock.
   const { data, error } = await admin.rpc('kit_webhook_check_rate_limit', {
     p_bucket_key: bucketKey,
-    p_window_start: windowStart.toISOString(),
+    p_window_start: new Date().toISOString(),
     p_limit: limit,
   });
 
@@ -101,7 +100,9 @@ Deno.serve(async req => {
     return jsonResponse({ error: 'webhook_not_configured' }, 503);
   }
 
-  const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+  });
   const ip = clientIp(req);
 
   // Pre-HMAC rate limit — caps request flood before spending CPU on signature verification.

--- a/supabase/functions/kit-webhook/index.ts
+++ b/supabase/functions/kit-webhook/index.ts
@@ -1,0 +1,207 @@
+// Inbound Kit Creator webhook handler.
+// Validates HMAC-SHA256 signature, rate-limits by IP, records unsubscribes.
+//
+// Env vars required:
+//   KIT_WEBHOOK_SECRET  — Kit dashboard → Webhooks → Signing secret
+//   SUPABASE_URL
+//   SUPABASE_SERVICE_ROLE_KEY
+
+import { createClient } from 'npm:@supabase/supabase-js@2.45.0';
+
+const KIT_WEBHOOK_SECRET = Deno.env.get('KIT_WEBHOOK_SECRET') ?? '';
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? '';
+const SUPABASE_SERVICE_ROLE_KEY =
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+
+// Pre-HMAC cap: limits raw request flood before signature verification (200/hr per IP).
+const RAW_RATE_LIMIT = 200;
+// Post-HMAC cap: limits valid-signature traffic (60/hr per IP).
+const SIGNED_RATE_LIMIT = 60;
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function clientIp(req: Request): string {
+  const cf = req.headers.get('cf-connecting-ip');
+  if (cf) return cf.trim();
+  const real = req.headers.get('x-real-ip');
+  if (real) return real.trim();
+  const fwd = req.headers.get('x-forwarded-for');
+  if (fwd) return fwd.split(',').at(-1)?.trim() ?? 'unknown';
+  return 'unknown';
+}
+
+async function verifyKitSignature(
+  body: ArrayBuffer,
+  sigHeader: string | null,
+  secret: string
+): Promise<boolean> {
+  if (!sigHeader?.startsWith('sha256=')) return false;
+  const expected = sigHeader.slice(7);
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const mac = await crypto.subtle.sign('HMAC', key, body);
+  const actual = Array.from(new Uint8Array(mac))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+  // Constant-time string comparison to avoid timing oracles.
+  if (actual.length !== expected.length) return false;
+  let diff = 0;
+  for (let i = 0; i < actual.length; i++) {
+    diff |= actual.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/** Upsert a rate limit bucket; returns true if request is within the limit. */
+async function checkRateLimit(
+  admin: ReturnType<typeof createClient>,
+  bucketKey: string,
+  limit: number
+): Promise<boolean> {
+  const windowStart = new Date();
+  windowStart.setMinutes(0, 0, 0); // hour-truncated window
+
+  const { data, error } = await admin.rpc('kit_webhook_check_rate_limit', {
+    p_bucket_key: bucketKey,
+    p_window_start: windowStart.toISOString(),
+    p_limit: limit,
+  });
+
+  if (error) {
+    // On DB error, fail open (allow) to avoid blocking legitimate Kit deliveries.
+    console.error('kit-webhook rate limit check failed', error.message);
+    return true;
+  }
+  return data as boolean;
+}
+
+Deno.serve(async req => {
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'method_not_allowed' }, 405);
+  }
+
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    return jsonResponse({ error: 'server_misconfigured' }, 500);
+  }
+
+  // Reject immediately when webhook secret is not configured — prevents silent
+  // pass-through of unauthenticated requests during incomplete deploys. Kit
+  // will retry on 503 once the secret is set.
+  if (!KIT_WEBHOOK_SECRET) {
+    return jsonResponse({ error: 'webhook_not_configured' }, 503);
+  }
+
+  const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const ip = clientIp(req);
+
+  // Pre-HMAC rate limit — caps request flood before spending CPU on signature verification.
+  const withinRawLimit = await checkRateLimit(
+    admin,
+    `kit-webhook-raw:${ip}`,
+    RAW_RATE_LIMIT
+  );
+  if (!withinRawLimit) {
+    return jsonResponse({ error: 'rate_limited' }, 429);
+  }
+
+  // Read raw bytes before any parsing — HMAC is computed over the raw body.
+  const rawBody = await req.arrayBuffer();
+
+  const sigHeader = req.headers.get('x-kit-signature');
+  const valid = await verifyKitSignature(
+    rawBody,
+    sigHeader,
+    KIT_WEBHOOK_SECRET
+  );
+  if (!valid) {
+    return jsonResponse({ error: 'invalid_signature' }, 400);
+  }
+
+  // Post-HMAC rate limit — authenticated traffic only.
+  const withinSignedLimit = await checkRateLimit(
+    admin,
+    `kit-webhook:${ip}`,
+    SIGNED_RATE_LIMIT
+  );
+  if (!withinSignedLimit) {
+    return jsonResponse({ error: 'rate_limited' }, 429);
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(new TextDecoder().decode(rawBody)) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return jsonResponse({ error: 'invalid_json' }, 400);
+  }
+
+  // Kit v3 uses 'subscriber.unsubscribed'; Kit v4 uses 'subscriber.subscriber_unsubscribe'.
+  // Handle both — first live staging delivery will confirm the name in info logs.
+  const eventType = payload['type'] as string | undefined;
+  console.info('kit-webhook received event', eventType);
+
+  if (
+    eventType === 'subscriber.unsubscribed' ||
+    eventType === 'subscriber.subscriber_unsubscribe'
+  ) {
+    const subscriber = payload['subscriber'] as
+      | Record<string, unknown>
+      | undefined;
+    const rawEmail = subscriber?.['email_address'] as string | undefined;
+    const email = rawEmail?.trim().toLowerCase();
+
+    if (!email) {
+      console.warn('kit-webhook: unsubscribe payload missing email_address');
+      return jsonResponse({ ok: true }, 200);
+    }
+
+    // Look up the enabled product.
+    const { data: settings } = await admin
+      .from('marketing_email_settings')
+      .select('product_id')
+      .eq('enabled', true)
+      .order('product_id')
+      .limit(1)
+      .maybeSingle();
+
+    if (!settings) {
+      // Marketing email is disabled — nothing to record, acknowledge to Kit.
+      return jsonResponse({ ok: true }, 200);
+    }
+
+    const { error: insertErr } = await admin
+      .from('marketing_email_unsubscribes')
+      .insert({ product_id: settings.product_id, email });
+
+    // 23505 = unique_violation — idempotent, already recorded.
+    if (insertErr && insertErr.code !== '23505') {
+      console.error(
+        'kit-webhook: failed to record unsubscribe',
+        insertErr.message
+      );
+      // Return 500 so Kit retries — the row was not written.
+      return jsonResponse({ error: 'db_error' }, 500);
+    }
+
+    // TODO(phase5): write audit row once admin_audit_log supports nullable actor_user_id
+    // or a system-actor RPC is available. For now, marketing_email_unsubscribes.created_at
+    // is the durable timestamp record.
+
+    return jsonResponse({ ok: true }, 200);
+  }
+
+  // All other event types: acknowledge without processing. Logged above for observability.
+  return jsonResponse({ ok: true }, 200);
+});

--- a/supabase/migrations/20260522000001_marketing_email_user_deleted.sql
+++ b/supabase/migrations/20260522000001_marketing_email_user_deleted.sql
@@ -1,0 +1,97 @@
+-- Phase 4: add user.deleted lifecycle event for GDPR erasure propagation.
+-- Extends the event_type CHECK on marketing_email_sync_queue and wires an
+-- AFTER DELETE trigger on auth.users to enqueue the event.
+
+-- ---------------------------------------------------------------------------
+-- Extend event_type CHECK to include user.deleted
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.marketing_email_sync_queue
+  DROP CONSTRAINT IF EXISTS marketing_email_sync_queue_event_type_check;
+
+ALTER TABLE public.marketing_email_sync_queue
+  ADD CONSTRAINT marketing_email_sync_queue_event_type_check
+  CHECK (event_type IN (
+    'user.signed_up', 'waitlist.joined', 'waitlist.approved',
+    'waitlist.converted', 'user.tier_changed', 'user.churned',
+    'user.deleted'
+  ));
+
+-- ---------------------------------------------------------------------------
+-- AFTER DELETE trigger: enqueue user.deleted when marketing email is enabled
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public._marketing_email_on_user_deleted()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_catalog AS $$
+DECLARE
+  v_product_id text;
+  v_email      text;
+BEGIN
+  v_email := lower(trim(OLD.email));
+
+  -- No-op when email is NULL (OAuth-only users have no Kit record).
+  IF v_email IS NULL OR v_email = '' THEN
+    RETURN OLD;
+  END IF;
+
+  SELECT product_id INTO v_product_id
+    FROM public.marketing_email_settings
+    WHERE enabled = true
+    ORDER BY product_id
+    LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN OLD;
+  END IF;
+
+  -- Idempotent: a second DELETE trigger (shouldn't happen, but safe) is a no-op.
+  INSERT INTO public.marketing_email_sync_queue
+    (product_id, event_type, email, idempotency_key, payload, status)
+  VALUES
+    (v_product_id, 'user.deleted', v_email,
+     'user.deleted:' || OLD.id::text,
+     jsonb_build_object('user_id', OLD.id),
+     'pending')
+  ON CONFLICT (idempotency_key) DO NOTHING;
+
+  RETURN OLD;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER marketing_email_on_user_deleted
+  AFTER DELETE ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public._marketing_email_on_user_deleted();
+
+-- ---------------------------------------------------------------------------
+-- Rate limit helper for kit-webhook Edge Function
+-- Uses the shared waitlist_rate_limits table with a 'kit-webhook*:' prefix.
+-- Returns true when the request is within the limit; false when exceeded.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.kit_webhook_check_rate_limit(
+  p_bucket_key text,
+  p_window_start timestamptz,
+  p_limit integer
+)
+RETURNS boolean
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  INSERT INTO public.waitlist_rate_limits (bucket_key, window_start, count)
+  VALUES (p_bucket_key, date_trunc('hour', p_window_start), 1)
+  ON CONFLICT (bucket_key, window_start)
+  DO UPDATE SET count = public.waitlist_rate_limits.count + 1
+  RETURNING count INTO v_count;
+
+  RETURN v_count <= p_limit;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.kit_webhook_check_rate_limit(text, timestamptz, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.kit_webhook_check_rate_limit(text, timestamptz, integer) TO service_role;

--- a/supabase/migrations/20260522000001_marketing_email_user_deleted.sql
+++ b/supabase/migrations/20260522000001_marketing_email_user_deleted.sql
@@ -59,6 +59,8 @@ BEGIN
 END;
 $$;
 
+REVOKE ALL ON FUNCTION public._marketing_email_on_user_deleted() FROM PUBLIC;
+
 CREATE OR REPLACE TRIGGER marketing_email_on_user_deleted
   AFTER DELETE ON auth.users
   FOR EACH ROW EXECUTE FUNCTION public._marketing_email_on_user_deleted();

--- a/supabase/tests/marketing_email_phase4.test.sql
+++ b/supabase/tests/marketing_email_phase4.test.sql
@@ -52,11 +52,11 @@ SELECT ok(
 
 -- Enable marketing email for one product so trigger fires.
 INSERT INTO public.marketing_email_settings
-  (product_id, enabled, provider, namespace, form_id)
+  (product_id, enabled, provider, config)
 VALUES
-  ('beakerstack', true, 'kit', 'bstack-test', 'form-1')
+  ('beakerstack', true, 'kit', '{"namespace":"bstack-test","form_id":"form-1"}')
 ON CONFLICT (product_id) DO UPDATE
-  SET enabled = true, provider = 'kit', namespace = 'bstack-test', form_id = 'form-1';
+  SET enabled = true, provider = 'kit', config = '{"namespace":"bstack-test","form_id":"form-1"}'::jsonb;
 
 -- Test user to delete.
 DO $$

--- a/supabase/tests/marketing_email_phase4.test.sql
+++ b/supabase/tests/marketing_email_phase4.test.sql
@@ -1,0 +1,274 @@
+-- pgTAP tests for Phase 4: user.deleted CHECK constraint, AFTER DELETE trigger,
+-- and kit_webhook_check_rate_limit RPC.
+-- Pattern: BEGIN / SELECT plan(N) / assertions / SELECT * FROM finish() / ROLLBACK
+
+BEGIN;
+
+SELECT plan(14);
+
+-- ── 1  user.deleted accepted by event_type CHECK ────────────────────────────
+
+SELECT ok(
+    (
+        SELECT count(*)::int = 0
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE n.nspname = 'public'
+          AND t.relname = 'marketing_email_sync_queue'
+          AND c.contype = 'c'
+          AND c.conname = 'marketing_email_sync_queue_event_type_check'
+          AND pg_get_constraintdef(c.oid) NOT LIKE '%user.deleted%'
+    ),
+    'event_type CHECK includes user.deleted'
+);
+
+-- ── 2  AFTER DELETE trigger exists on auth.users ────────────────────────────
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_trigger t
+        JOIN pg_class c ON c.oid = t.tgrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'auth'
+          AND c.relname = 'users'
+          AND t.tgname = 'marketing_email_on_user_deleted'
+    ),
+    'AFTER DELETE trigger exists on auth.users'
+);
+
+-- ── 3  kit_webhook_check_rate_limit function exists ─────────────────────────
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM information_schema.routines
+        WHERE routine_schema = 'public'
+          AND routine_name = 'kit_webhook_check_rate_limit'
+    ),
+    'kit_webhook_check_rate_limit function exists'
+);
+
+-- ── Test fixtures ────────────────────────────────────────────────────────────
+
+-- Enable marketing email for one product so trigger fires.
+INSERT INTO public.marketing_email_settings
+  (product_id, enabled, provider, namespace, form_id)
+VALUES
+  ('beakerstack', true, 'kit', 'bstack-test', 'form-1')
+ON CONFLICT (product_id) DO UPDATE
+  SET enabled = true, provider = 'kit', namespace = 'bstack-test', form_id = 'form-1';
+
+-- Test user to delete.
+DO $$
+BEGIN
+  INSERT INTO auth.users (
+    id, instance_id, email, encrypted_password, email_confirmed_at,
+    raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role
+  ) VALUES (
+    'b2000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000000',
+    'deleted-user@example.com',
+    crypt('pw', gen_salt('bf')),
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    now(), now(), 'authenticated', 'authenticated'
+  ) ON CONFLICT (id) DO NOTHING;
+END;
+$$;
+
+-- ── 4  DELETE trigger enqueues user.deleted ──────────────────────────────────
+
+DELETE FROM auth.users WHERE id = 'b2000000-0000-0000-0000-000000000001';
+
+SELECT is(
+    (SELECT event_type FROM public.marketing_email_sync_queue
+     WHERE idempotency_key = 'user.deleted:b2000000-0000-0000-0000-000000000001'),
+    'user.deleted',
+    'DELETE trigger enqueues user.deleted row'
+);
+
+-- ── 5  enqueued email is normalized (lowercase/trimmed) ─────────────────────
+
+SELECT is(
+    (SELECT email FROM public.marketing_email_sync_queue
+     WHERE idempotency_key = 'user.deleted:b2000000-0000-0000-0000-000000000001'),
+    'deleted-user@example.com',
+    'enqueued email is lowercase/trimmed'
+);
+
+-- ── 6  enqueued status is pending ───────────────────────────────────────────
+
+SELECT is(
+    (SELECT status FROM public.marketing_email_sync_queue
+     WHERE idempotency_key = 'user.deleted:b2000000-0000-0000-0000-000000000001'),
+    'pending',
+    'enqueued user.deleted row has status=pending'
+);
+
+-- ── 7  Idempotent: second delete does not produce a second queue row ─────────
+-- (auth.users row is already deleted; simulate by inserting then deleting again)
+
+DO $$
+BEGIN
+  INSERT INTO auth.users (
+    id, instance_id, email, encrypted_password, email_confirmed_at,
+    raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role
+  ) VALUES (
+    'b2000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000000',
+    'deleted-user@example.com',
+    crypt('pw', gen_salt('bf')),
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    now(), now(), 'authenticated', 'authenticated'
+  ) ON CONFLICT (id) DO NOTHING;
+END;
+$$;
+
+DELETE FROM auth.users WHERE id = 'b2000000-0000-0000-0000-000000000001';
+
+SELECT is(
+    (SELECT count(*)::int FROM public.marketing_email_sync_queue
+     WHERE idempotency_key = 'user.deleted:b2000000-0000-0000-0000-000000000001'),
+    1,
+    'duplicate DELETE does not produce second queue row (idempotent)'
+);
+
+-- ── 8  NULL email user: trigger is a no-op ──────────────────────────────────
+
+DO $$
+BEGIN
+  INSERT INTO auth.users (
+    id, instance_id, email, encrypted_password,
+    raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role
+  ) VALUES (
+    'b2000000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000000',
+    NULL,
+    crypt('pw', gen_salt('bf')),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    now(), now(), 'authenticated', 'authenticated'
+  ) ON CONFLICT (id) DO NOTHING;
+END;
+$$;
+
+DELETE FROM auth.users WHERE id = 'b2000000-0000-0000-0000-000000000002';
+
+SELECT is(
+    (SELECT count(*)::int FROM public.marketing_email_sync_queue
+     WHERE idempotency_key = 'user.deleted:b2000000-0000-0000-0000-000000000002'),
+    0,
+    'NULL email user: trigger does not enqueue'
+);
+
+-- ── 9  Trigger is a no-op when marketing email is disabled ──────────────────
+
+UPDATE public.marketing_email_settings
+  SET enabled = false WHERE product_id = 'beakerstack';
+
+DO $$
+BEGIN
+  INSERT INTO auth.users (
+    id, instance_id, email, encrypted_password, email_confirmed_at,
+    raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role
+  ) VALUES (
+    'b2000000-0000-0000-0000-000000000003',
+    '00000000-0000-0000-0000-000000000000',
+    'disabled-product-user@example.com',
+    crypt('pw', gen_salt('bf')),
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    now(), now(), 'authenticated', 'authenticated'
+  ) ON CONFLICT (id) DO NOTHING;
+END;
+$$;
+
+DELETE FROM auth.users WHERE id = 'b2000000-0000-0000-0000-000000000003';
+
+SELECT is(
+    (SELECT count(*)::int FROM public.marketing_email_sync_queue
+     WHERE idempotency_key = 'user.deleted:b2000000-0000-0000-0000-000000000003'),
+    0,
+    'trigger is a no-op when marketing email is disabled'
+);
+
+-- Re-enable for remaining tests.
+UPDATE public.marketing_email_settings
+  SET enabled = true WHERE product_id = 'beakerstack';
+
+-- ── 10-12  kit_webhook_check_rate_limit behavior ────────────────────────────
+
+-- First call: within limit → true.
+SELECT is(
+    public.kit_webhook_check_rate_limit('kit-webhook-test:1.2.3.4', now(), 5),
+    true,
+    'rate limit: first request is within limit'
+);
+
+-- Burn 4 more (total 5 = at limit).
+SELECT public.kit_webhook_check_rate_limit('kit-webhook-test:1.2.3.4', now(), 5);
+SELECT public.kit_webhook_check_rate_limit('kit-webhook-test:1.2.3.4', now(), 5);
+SELECT public.kit_webhook_check_rate_limit('kit-webhook-test:1.2.3.4', now(), 5);
+SELECT public.kit_webhook_check_rate_limit('kit-webhook-test:1.2.3.4', now(), 5);
+
+-- 6th call: exceeds limit → false.
+SELECT is(
+    public.kit_webhook_check_rate_limit('kit-webhook-test:1.2.3.4', now(), 5),
+    false,
+    'rate limit: 6th request exceeds limit of 5'
+);
+
+-- Different IP is independent.
+SELECT is(
+    public.kit_webhook_check_rate_limit('kit-webhook-test:9.9.9.9', now(), 5),
+    true,
+    'rate limit: different IP has its own independent bucket'
+);
+
+-- ── 13  user.deleted in queue payload contains user_id ──────────────────────
+
+-- Re-insert and delete a fresh user to check payload.
+DO $$
+BEGIN
+  INSERT INTO auth.users (
+    id, instance_id, email, encrypted_password, email_confirmed_at,
+    raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role
+  ) VALUES (
+    'b2000000-0000-0000-0000-000000000004',
+    '00000000-0000-0000-0000-000000000000',
+    'payload-check@example.com',
+    crypt('pw', gen_salt('bf')),
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    now(), now(), 'authenticated', 'authenticated'
+  ) ON CONFLICT (id) DO NOTHING;
+END;
+$$;
+
+DELETE FROM auth.users WHERE id = 'b2000000-0000-0000-0000-000000000004';
+
+SELECT is(
+    (SELECT (payload->>'user_id')::uuid FROM public.marketing_email_sync_queue
+     WHERE idempotency_key = 'user.deleted:b2000000-0000-0000-0000-000000000004'),
+    'b2000000-0000-0000-0000-000000000004'::uuid,
+    'user.deleted queue payload includes user_id'
+);
+
+-- ── 14  kit_webhook_check_rate_limit uses hour-truncated window ──────────────
+
+-- Calls in the same hour window should accumulate into one bucket row.
+SELECT is(
+    (SELECT count(*)::int FROM public.waitlist_rate_limits
+     WHERE bucket_key = 'kit-webhook-test:1.2.3.4'
+       AND window_start = date_trunc('hour', now())),
+    1,
+    'rate limit uses hour-truncated window (one bucket row per IP per hour)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

- **`kit-webhook` Edge Function** — inbound Kit Creator webhook handler with HMAC-SHA256 signature validation (constant-time comparison), dual rate limiting (pre-HMAC 200/hr + post-HMAC 60/hr per IP), handles `subscriber.unsubscribed` (Kit v3) and `subscriber.subscriber_unsubscribe` (Kit v4); routes unsubscribes to `marketing_email_unsubscribes`; returns 503 when `KIT_WEBHOOK_SECRET` is not configured
- **`user.deleted` GDPR wiring** — AFTER DELETE trigger on `auth.users` enqueues `user.deleted` into `marketing_email_sync_queue`; `kit-sync` adds a GDPR suppression bypass so erasure calls proceed even if the email appears in the unsubscribes list
- **Migration `20260522000001`** — extends `event_type` CHECK constraint, adds trigger + `_marketing_email_on_user_deleted()` function, adds `kit_webhook_check_rate_limit` RPC (reuses `waitlist_rate_limits` table with hour-truncated window)
- **pgTAP tests** — 14 assertions covering CHECK constraint, trigger existence, trigger behavior (idempotent, NULL email, disabled product), rate limit RPC (within/exceeds/independent-IP/window), and queue payload shape
- **Deploy wiring** — `KIT_WEBHOOK_SECRET` secret set in staging + production workflows; `kit-webhook` added to `supabase functions deploy` list

## Notes

- Audit row deferred to Phase 5: `admin_audit_log.actor_user_id` is NOT NULL — system-actor support requires a schema change (see TODO comment in webhook handler)
- `user.deleted` dispatch in `kit-sync` calls `kit.deleteUser(email)` — GDPR erasure best-effort per Brad's guidance

## Test plan

- [ ] `supabase db test` passes (14 pgTAP assertions in `marketing_email_phase4.test.sql`)
- [ ] CI green on staging deploy
- [ ] Set `STAGING_KIT_WEBHOOK_SECRET` GitHub secret → verify Kit dashboard can send a test event and it routes correctly
- [ ] Verify `supabase functions deploy` includes `kit-webhook`

Closes #286 Phase 4

