### PR TITLE
feat(#341): refactor waitlist invite email to use email adapter pattern

### DIFF
--- a/docs/EMAIL_TEMPLATES.md
+++ b/docs/EMAIL_TEMPLATES.md
@@ -210,6 +210,17 @@ Recommended DMARC policy for production:
 v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@yourdomain.com; pct=100
 ```
 
+## Auth vs waitlist invite email
+
+Auth transactional email (this feature) and waitlist invite email are **entirely separate delivery paths** with separate configuration:
+
+| Path                                                               | Mechanism                                                                                         | Config                                                  |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| Auth email (signup confirmation, password reset, magic link, etc.) | Supabase SMTP via `[auth.email.smtp]` in `config.toml`                                            | `SMTP_*` env vars / `RESEND_SMTP_PASS`                  |
+| Waitlist invite email                                              | `waitlist-ops` Edge Function (`send_invite_email` action) via `@beakerstack/email` Resend adapter | `WAITLIST_RESEND_API_KEY`, `WAITLIST_INVITE_FROM`, etc. |
+
+Setting `WAITLIST_RESEND_API_KEY` has no effect on auth emails, and `SMTP_PASS` has no effect on waitlist invite delivery. See [docs/guides/waitlist-setup.md](guides/waitlist-setup.md) for waitlist invite configuration.
+
 ## Auth vs marketing email separation
 
 Transactional auth emails (this feature) and marketing/promotional emails should use **separate sending domains** or subdomains. For example:

--- a/docs/guides/waitlist-setup.md
+++ b/docs/guides/waitlist-setup.md
@@ -46,15 +46,17 @@
 
 ## Edge secrets (hosted)
 
-| Secret                     | Purpose                                         |
-| -------------------------- | ----------------------------------------------- |
-| `WAITLIST_ALLOWED_ORIGINS` | CORS for capture (e.g. `http://localhost:5173`) |
-| `WAITLIST_INVITE_SUBJECT`  | Optional invite email subject                   |
-| `WAITLIST_INVITE_HTML`     | Optional HTML template with `{{inviteUrl}}`     |
-| `WAITLIST_RESEND_API_KEY`  | Resend API key; without it, send returns 501    |
-| `WAITLIST_INVITE_FROM`     | Resend `from` address (e.g. `invites@your.com`) |
+| Secret                     | Purpose                                                                                                                 |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `WAITLIST_ALLOWED_ORIGINS` | CORS for capture (e.g. `http://localhost:5173`)                                                                         |
+| `WAITLIST_INVITE_SUBJECT`  | Optional invite email subject                                                                                           |
+| `WAITLIST_INVITE_HTML`     | Optional HTML template with `{{inviteUrl}}`                                                                             |
+| `WAITLIST_RESEND_API_KEY`  | Resend API key. Without it, send returns `501 email_not_configured` and logs metadata only (safe default for dev/test). |
+| `WAITLIST_INVITE_FROM`     | Resend `from` address (default: `onboarding@resend.dev`)                                                                |
 
 Uses the same Supabase service role / URL vars as billing Edge Functions.
+
+> **Note:** Waitlist invite email (`waitlist-ops`) and auth transactional email (Supabase SMTP) are **entirely separate delivery paths** with separate configuration. `WAITLIST_RESEND_API_KEY` only affects invite emails; auth emails use `SMTP_*` vars. See [docs/EMAIL_TEMPLATES.md](../EMAIL_TEMPLATES.md) for auth email setup.
 
 ## Mode changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2577,6 +2577,10 @@
       "resolved": "packages/logger",
       "link": true
     },
+    "node_modules/@beakerstack/marketing-email": {
+      "resolved": "packages/marketing-email",
+      "link": true
+    },
     "node_modules/@beakerstack/observability": {
       "resolved": "packages/observability",
       "link": true
@@ -29147,6 +29151,22 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/marketing-email": {
+      "name": "@beakerstack/marketing-email",
+      "version": "1.0.0",
+      "dependencies": {
+        "@beakerstack/lifecycle-events": "^1.0.0"
+      },
+      "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
+        "@vitest/coverage-v8": "^3.2.4",
+        "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.1.0",
+        "typescript": "^5.3.0",
+        "vitest": "^3.2.4"
+      }
+    },
     "packages/observability": {
       "name": "@beakerstack/observability",
       "version": "1.0.0",
@@ -29305,7 +29325,6 @@
       "name": "@beakerstack/waitlist",
       "version": "1.0.0",
       "dependencies": {
-        "@beakerstack/email": "^1.0.0",
         "@beakerstack/lifecycle-events": "^1.0.0",
         "@supabase/supabase-js": "^2.38.0",
         "zod": "^3.22.0"
@@ -29339,26 +29358,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@beakerstack/marketing-email": {
-      "resolved": "packages/marketing-email",
-      "link": true
-    },
-    "packages/marketing-email": {
-      "name": "@beakerstack/marketing-email",
-      "version": "1.0.0",
-      "dependencies": {
-        "@beakerstack/lifecycle-events": "^1.0.0"
-      },
-      "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^7.18.0",
-        "@typescript-eslint/parser": "^7.18.0",
-        "@vitest/coverage-v8": "^3.2.4",
-        "eslint": "^8.57.0",
-        "eslint-config-prettier": "^9.1.0",
-        "typescript": "^5.3.0",
-        "vitest": "^3.2.4"
       }
     }
   }

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,3 +1,4 @@
 export type { EmailAdapter, EmailMessage } from './types.js';
 export { createLogEmailAdapter } from './logAdapter.js';
+export { createResendEmailAdapter, EmailSendError } from './resendAdapter.js';
 export { renderEmailTemplate } from './renderTemplate.js';

--- a/packages/email/src/renderTemplate.ts
+++ b/packages/email/src/renderTemplate.ts
@@ -2,9 +2,8 @@ export function renderEmailTemplate(
   template: string,
   vars: Record<string, string>
 ): string {
-  let out = template;
-  for (const [key, value] of Object.entries(vars)) {
-    out = out.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
-  }
-  return out;
+  return Object.entries(vars).reduce(
+    (acc, [key, value]) => acc.replaceAll(`{{${key}}}`, value),
+    template
+  );
 }

--- a/packages/email/src/resendAdapter.test.ts
+++ b/packages/email/src/resendAdapter.test.ts
@@ -85,7 +85,7 @@ describe('createResendEmailAdapter', () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 403,
-      json: async () => errorBody,
+      text: async () => JSON.stringify(errorBody),
     });
     vi.stubGlobal('fetch', mockFetch);
 
@@ -111,9 +111,6 @@ describe('createResendEmailAdapter', () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 500,
-      json: async () => {
-        throw new Error('not json');
-      },
       text: async () => 'Internal Server Error',
     });
     vi.stubGlobal('fetch', mockFetch);

--- a/packages/email/src/resendAdapter.test.ts
+++ b/packages/email/src/resendAdapter.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createResendEmailAdapter, EmailSendError } from './resendAdapter.js';
+
+const API_KEY = 'test-key';
+const FROM = 'from@example.com';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('createResendEmailAdapter', () => {
+  it('POSTs the correct request shape', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'abc' }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const adapter = createResendEmailAdapter({ apiKey: API_KEY, from: FROM });
+    await adapter.send({
+      to: 'user@example.com',
+      subject: 'Hello',
+      html: '<p>Hi</p>',
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.resend.com/emails');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['Authorization']).toBe(
+      `Bearer ${API_KEY}`
+    );
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({
+      from: FROM,
+      to: ['user@example.com'],
+      subject: 'Hello',
+      html: '<p>Hi</p>',
+    });
+  });
+
+  it('includes text field when provided', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const adapter = createResendEmailAdapter({ apiKey: API_KEY, from: FROM });
+    await adapter.send({
+      to: 'user@example.com',
+      subject: 'Hi',
+      html: '<p>Hi</p>',
+      text: 'Hi',
+    });
+
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string
+    );
+    expect(body.text).toBe('Hi');
+  });
+
+  it('omits text field when not provided', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const adapter = createResendEmailAdapter({ apiKey: API_KEY, from: FROM });
+    await adapter.send({
+      to: 'user@example.com',
+      subject: 'Hi',
+      html: '<p>Hi</p>',
+    });
+
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string
+    );
+    expect(body).not.toHaveProperty('text');
+  });
+
+  it('throws EmailSendError on non-2xx with status and parsed body', async () => {
+    const errorBody = { name: 'invalid_api_key', message: 'Invalid API key' };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => errorBody,
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const adapter = createResendEmailAdapter({ apiKey: API_KEY, from: FROM });
+    let thrown: unknown;
+    try {
+      await adapter.send({
+        to: 'user@example.com',
+        subject: 'Hi',
+        html: '<p>Hi</p>',
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(EmailSendError);
+    expect((thrown as EmailSendError).status).toBe(403);
+    expect((thrown as EmailSendError).body).toEqual(errorBody);
+    expect((thrown as EmailSendError).message).toContain('403');
+  });
+
+  it('falls back to text body when Resend returns non-JSON error', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error('not json');
+      },
+      text: async () => 'Internal Server Error',
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const adapter = createResendEmailAdapter({ apiKey: API_KEY, from: FROM });
+    let thrown: unknown;
+    try {
+      await adapter.send({
+        to: 'user@example.com',
+        subject: 'Hi',
+        html: '<p>Hi</p>',
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(EmailSendError);
+    expect((thrown as EmailSendError).status).toBe(500);
+    expect((thrown as EmailSendError).body).toBe('Internal Server Error');
+  });
+});

--- a/packages/email/src/resendAdapter.ts
+++ b/packages/email/src/resendAdapter.ts
@@ -1,0 +1,55 @@
+import type { EmailAdapter, EmailMessage } from './types.js';
+
+export class EmailSendError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+    public readonly body?: unknown
+  ) {
+    super(message);
+    this.name = 'EmailSendError';
+  }
+}
+
+export function createResendEmailAdapter({
+  apiKey,
+  from,
+}: {
+  apiKey: string;
+  from: string;
+}): EmailAdapter {
+  return {
+    async send(params: EmailMessage) {
+      const payload: Record<string, unknown> = {
+        from,
+        to: [params.to],
+        subject: params.subject,
+        html: params.html,
+      };
+      if (params.text !== undefined) payload['text'] = params.text;
+
+      const res = await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        let body: unknown;
+        try {
+          body = await res.json();
+        } catch {
+          body = await res.text();
+        }
+        throw new EmailSendError(
+          `Resend API error: ${res.status}`,
+          res.status,
+          body
+        );
+      }
+    },
+  };
+}

--- a/packages/email/src/resendAdapter.ts
+++ b/packages/email/src/resendAdapter.ts
@@ -38,11 +38,12 @@ export function createResendEmailAdapter({
       });
 
       if (!res.ok) {
+        const text = await res.text();
         let body: unknown;
         try {
-          body = await res.json();
+          body = JSON.parse(text);
         } catch {
-          body = await res.text();
+          body = text;
         }
         throw new EmailSendError(
           `Resend API error: ${res.status}`,

--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -8,7 +8,8 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "lib": ["ES2021", "DOM", "DOM.Iterable"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/waitlist/README.md
+++ b/packages/waitlist/README.md
@@ -54,9 +54,23 @@ Set `WAITLIST_ALLOWED_ORIGINS` (or `BILLING_ALLOWED_ORIGINS`) on Edge Functions 
 
 ## Email
 
-No Resend/Kit required for v1. Default: **log adapter** (invite URL in Edge logs) + **Copy invite link** in admin.
+Invite email delivery is handled by the `waitlist-ops` Edge Function using the `@beakerstack/email` adapter pattern.
 
-Optional: wire a transactional provider via `waitlist-ops` `send_invite_email` body or extend the Edge function.
+### Adapter selection
+
+| `WAITLIST_RESEND_API_KEY` set? | Behavior                                                                                                                                         |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| No (default)                   | **Log adapter** — logs `to=` and `subject=` metadata to Edge logs; returns `501 email_not_configured`. Admin UI shows "Copy invite link".        |
+| Yes                            | **Resend adapter** — sends email via `https://api.resend.com/emails`; returns `200 { ok: true }` on success or `502 email_send_failed` on error. |
+
+### Edge Function env vars
+
+| Variable                  | Purpose                                                |
+| ------------------------- | ------------------------------------------------------ |
+| `WAITLIST_RESEND_API_KEY` | Resend API key. Required for real email delivery.      |
+| `WAITLIST_INVITE_FROM`    | Sender address (default: `onboarding@resend.dev`).     |
+| `WAITLIST_INVITE_SUBJECT` | Email subject (default: `You are invited to sign up`). |
+| `WAITLIST_INVITE_HTML`    | HTML template with `{{inviteUrl}}` placeholder.        |
 
 Marketing nurture (ConvertKit) is a separate package — see `docs/specs/kit-integration-feature-brief.md`. Listen with `onLifecycleEvent('waitlist.joined' | 'waitlist.approved')`.
 

--- a/packages/waitlist/package.json
+++ b/packages/waitlist/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@beakerstack/lifecycle-events": "^1.0.0",
-    "@beakerstack/email": "^1.0.0",
     "@supabase/supabase-js": "^2.38.0",
     "zod": "^3.22.0"
   },

--- a/supabase/functions/_shared/email.ts
+++ b/supabase/functions/_shared/email.ts
@@ -81,9 +81,8 @@ export function renderEmailTemplate(
   template: string,
   vars: Record<string, string>
 ): string {
-  let out = template;
-  for (const [key, value] of Object.entries(vars)) {
-    out = out.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
-  }
-  return out;
+  return Object.entries(vars).reduce(
+    (acc, [key, value]) => acc.replaceAll(`{{${key}}}`, value),
+    template
+  );
 }

--- a/supabase/functions/_shared/email.ts
+++ b/supabase/functions/_shared/email.ts
@@ -1,0 +1,89 @@
+// Self-contained Deno port of packages/email. Shared across Edge Functions via relative import.
+// Keep in sync with packages/email/src/ — no automated sync guard exists between this file and its npm source.
+
+export interface EmailMessage {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+}
+
+export interface EmailAdapter {
+  send(params: EmailMessage): Promise<void>;
+}
+
+export class EmailSendError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+    public readonly body?: unknown
+  ) {
+    super(message);
+    this.name = 'EmailSendError';
+  }
+}
+
+export function createLogEmailAdapter(
+  log: (line: string) => void = (line: string) => console.log(line)
+): EmailAdapter {
+  return {
+    async send(params: EmailMessage) {
+      // Metadata only — omit body so Edge logs avoid PII.
+      log(`[beakerstack/email] to=${params.to} subject=${params.subject}`);
+    },
+  };
+}
+
+export function createResendEmailAdapter({
+  apiKey,
+  from,
+}: {
+  apiKey: string;
+  from: string;
+}): EmailAdapter {
+  return {
+    async send(params: EmailMessage) {
+      const payload: Record<string, unknown> = {
+        from,
+        to: [params.to],
+        subject: params.subject,
+        html: params.html,
+      };
+      if (params.text !== undefined) payload['text'] = params.text;
+
+      const res = await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        let body: unknown;
+        try {
+          body = await res.json();
+        } catch {
+          body = await res.text();
+        }
+        throw new EmailSendError(
+          `Resend API error: ${res.status}`,
+          res.status,
+          body
+        );
+      }
+    },
+  };
+}
+
+export function renderEmailTemplate(
+  template: string,
+  vars: Record<string, string>
+): string {
+  let out = template;
+  for (const [key, value] of Object.entries(vars)) {
+    out = out.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+  }
+  return out;
+}

--- a/supabase/functions/_shared/email.ts
+++ b/supabase/functions/_shared/email.ts
@@ -61,11 +61,12 @@ export function createResendEmailAdapter({
       });
 
       if (!res.ok) {
+        const text = await res.text();
         let body: unknown;
         try {
-          body = await res.json();
+          body = JSON.parse(text);
         } catch {
-          body = await res.text();
+          body = text;
         }
         throw new EmailSendError(
           `Resend API error: ${res.status}`,

--- a/supabase/functions/waitlist-ops/index.ts
+++ b/supabase/functions/waitlist-ops/index.ts
@@ -4,6 +4,12 @@ import {
   jsonResponse,
 } from '../_shared/waitlist-origins.ts';
 import { enqueueMarketingEmail } from '../_shared/marketingEmailQueue.ts';
+import {
+  createLogEmailAdapter,
+  createResendEmailAdapter,
+  renderEmailTemplate,
+  EmailSendError,
+} from '../_shared/email.ts';
 
 type Body = {
   action:
@@ -24,17 +30,6 @@ type Body = {
   html?: string;
   productId?: string;
 };
-
-function renderTemplate(
-  template: string,
-  vars: Record<string, string>
-): string {
-  let out = template;
-  for (const [key, value] of Object.entries(vars)) {
-    out = out.replaceAll(`{{${key}}}`, value);
-  }
-  return out;
-}
 
 async function requireAdmin(
   req: Request,
@@ -311,35 +306,27 @@ Deno.serve(async req => {
       body.html ??
       Deno.env.get('WAITLIST_INVITE_HTML') ??
       '<p>Complete your signup: <a href="{{inviteUrl}}">{{inviteUrl}}</a></p>';
-    const html = renderTemplate(htmlTemplate, { inviteUrl });
+    const html = renderEmailTemplate(htmlTemplate, { inviteUrl });
 
-    const resendKey = Deno.env.get('WAITLIST_RESEND_API_KEY');
-    if (!resendKey) {
-      console.log(
-        `[beakerstack/email] waitlist invite (log only) to=${to} subject=${subject}\n${html}`
-      );
+    const apiKey = Deno.env.get('WAITLIST_RESEND_API_KEY');
+    const from =
+      Deno.env.get('WAITLIST_INVITE_FROM') ?? 'onboarding@resend.dev';
+    const logAdapter = createLogEmailAdapter();
+
+    if (!apiKey) {
+      await logAdapter.send({ to, subject, html });
       return jsonResponse({ error: 'email_not_configured' }, 501, req);
     }
 
-    const from =
-      Deno.env.get('WAITLIST_INVITE_FROM') ?? 'onboarding@resend.dev';
-    const resendRes = await fetch('https://api.resend.com/emails', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${resendKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        from,
-        to: [to],
-        subject,
-        html,
-      }),
-    });
-    if (!resendRes.ok) {
-      const detail = await resendRes.text();
-      console.error('resend send failed', resendRes.status, detail);
-      return jsonResponse({ error: 'email_send_failed' }, 502, req);
+    try {
+      const adapter = createResendEmailAdapter({ apiKey, from });
+      await adapter.send({ to, subject, html });
+    } catch (err) {
+      if (err instanceof EmailSendError) {
+        console.error('resend send failed', err.status, err.body);
+        return jsonResponse({ error: 'email_send_failed' }, 502, req);
+      }
+      throw err;
     }
 
     return jsonResponse({ ok: true }, 200, req);


### PR DESCRIPTION
## Summary

Closes #341.

- **`packages/email`**: adds `EmailSendError` class and `createResendEmailAdapter` (with 5 unit tests using `vi.stubGlobal('fetch')`); exports both from `index.ts`
- **`supabase/functions/_shared/email.ts`**: self-contained Deno port (no npm imports) matching the `_shared/kitClient.ts` pattern — exports all types, both adapters, and `renderEmailTemplate`
- **`supabase/functions/waitlist-ops`**: imports from `_shared/email.ts`, removes local duplicate `renderTemplate()`, uses adapters in `send_invite_email`; all existing HTTP responses and env vars preserved
- **`packages/waitlist`**: removes unused `@beakerstack/email` dep
- **Docs**: adapter env var tables in `packages/waitlist/README.md`, `docs/guides/waitlist-setup.md`; auth vs waitlist delivery path note in `docs/EMAIL_TEMPLATES.md`

### Adapter selection (no behavior change for operators)

| `WAITLIST_RESEND_API_KEY` | Behavior |
|---|---|
| Absent (default) | Log adapter — logs `to=`/`subject=` metadata, returns `501 email_not_configured` |
| Set | Resend adapter — sends via Resend API, returns `200` or `502 email_send_failed` |

## Test plan

- [x] `packages/email` unit tests: 9 passed (5 new `resendAdapter` tests)
- [x] Full unit test suite: 97 test files, 693 tests passed
- [x] Type-check: all packages clean
- [x] Lint: clean
- [x] Pre-commit hook: shared build + type-check + lint all pass
