### PR TITLE
chore: reformat admin/marketing-email and fix qs audit advisory

### DIFF
--- a/apps/web/src/admin/__tests__/AdminLayoutShell.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminLayoutShell.test.tsx
@@ -12,7 +12,10 @@ vi.mock('@beakerstack/shared/contexts/AuthContext', () => ({
 }));
 
 vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom'
+    );
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
@@ -66,7 +69,9 @@ describe('AdminLayoutShell', () => {
     const user = userEvent.setup();
     renderShell('/admin', 'admin', <p>Admin home</p>);
     const sidebar = screen.getByRole('complementary');
-    const signOutButton = within(sidebar).getByRole('button', { name: /sign out/i });
+    const signOutButton = within(sidebar).getByRole('button', {
+      name: /sign out/i,
+    });
     await user.click(signOutButton);
     await waitFor(() => {
       expect(mockSignOut).toHaveBeenCalledTimes(1);
@@ -78,21 +83,27 @@ describe('AdminLayoutShell', () => {
     it('Overview \u2192 Users for /users path', () => {
       renderShell('/users', 'users', <p>outlet</p>);
       const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
-      expect(within(bc).getByRole('link', { name: 'Overview' })).toHaveAttribute('href', '/admin');
+      expect(
+        within(bc).getByRole('link', { name: 'Overview' })
+      ).toHaveAttribute('href', '/admin');
       expect(within(bc).getByText('Users')).toBeInTheDocument();
     });
 
     it('Overview \u2192 Waitlist for /waitlist path', () => {
       renderShell('/waitlist', 'waitlist', <p>outlet</p>);
       const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
-      expect(within(bc).getByRole('link', { name: 'Overview' })).toHaveAttribute('href', '/admin');
+      expect(
+        within(bc).getByRole('link', { name: 'Overview' })
+      ).toHaveAttribute('href', '/admin');
       expect(within(bc).getByText('Waitlist')).toBeInTheDocument();
     });
 
     it('Overview \u2192 Waitlist Settings for /waitlist/settings path', () => {
       renderShell('/waitlist/settings', 'waitlist/settings', <p>outlet</p>);
       const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
-      expect(within(bc).getByRole('link', { name: 'Overview' })).toHaveAttribute('href', '/admin');
+      expect(
+        within(bc).getByRole('link', { name: 'Overview' })
+      ).toHaveAttribute('href', '/admin');
       expect(within(bc).getByText('Waitlist Settings')).toBeInTheDocument();
     });
 

--- a/apps/web/src/admin/__tests__/AdminMarketingEmailSettingsPage.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminMarketingEmailSettingsPage.test.tsx
@@ -122,7 +122,9 @@ describe('AdminMarketingEmailSettingsPage', () => {
     await user.click(screen.getByRole('button', { name: /save settings/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent(/namespace is required/i);
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /namespace is required/i
+      );
     });
     expect(mockUpdate).not.toHaveBeenCalled();
   });
@@ -138,7 +140,9 @@ describe('AdminMarketingEmailSettingsPage', () => {
     await user.click(screen.getByRole('button', { name: /save settings/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent(/kit form id is required/i);
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /kit form id is required/i
+      );
     });
     expect(mockUpdate).not.toHaveBeenCalled();
   });

--- a/apps/web/src/admin/__tests__/useAdminOverviewStats.test.tsx
+++ b/apps/web/src/admin/__tests__/useAdminOverviewStats.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { listUsers } from '@beakerstack/admin';
-import { getAdminWaitlistSettings, listWaitlistEntries } from '@beakerstack/waitlist';
+import {
+  getAdminWaitlistSettings,
+  listWaitlistEntries,
+} from '@beakerstack/waitlist';
 import { useAdminOverviewStats } from '../hooks/useAdminOverviewStats';
 
 vi.mock('@beakerstack/admin', async importOriginal => {

--- a/apps/web/src/admin/adminNav.ts
+++ b/apps/web/src/admin/adminNav.ts
@@ -1,5 +1,11 @@
 import type { AdminNavItem } from '@beakerstack/admin';
-import { ClipboardList, LayoutDashboard, Mail, Settings, Users } from 'lucide-react';
+import {
+  ClipboardList,
+  LayoutDashboard,
+  Mail,
+  Settings,
+  Users,
+} from 'lucide-react';
 import { createElement } from 'react';
 
 export const adminNavItems: AdminNavItem[] = [

--- a/apps/web/src/admin/components/AdminUserDetailDrawer.web.tsx
+++ b/apps/web/src/admin/components/AdminUserDetailDrawer.web.tsx
@@ -36,9 +36,9 @@ export function AdminUserDetailDrawer({
   const [detail, setDetail] = useState<AdminUserDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [actionPending, setActionPending] = useState<
-    'grant' | 'revoke' | null
-  >(null);
+  const [actionPending, setActionPending] = useState<'grant' | 'revoke' | null>(
+    null
+  );
   const [actionLoading, setActionLoading] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
 
@@ -199,7 +199,10 @@ export function AdminUserDetailDrawer({
               data-testid='confirm-dialog'
             >
               <div className='w-80 rounded-lg bg-white p-6 shadow-xl'>
-                <h4 id='confirm-dialog-title' className='text-sm font-semibold text-gray-900'>
+                <h4
+                  id='confirm-dialog-title'
+                  className='text-sm font-semibold text-gray-900'
+                >
                   {actionPending === 'grant'
                     ? 'Grant admin access'
                     : 'Revoke admin access'}

--- a/apps/web/src/admin/pages/AdminDashboardPage.tsx
+++ b/apps/web/src/admin/pages/AdminDashboardPage.tsx
@@ -37,7 +37,9 @@ export default function AdminOverviewPage() {
             </span>
             <div>
               <p className='font-semibold text-gray-900'>Users</p>
-              <p className='text-sm text-gray-500'>{stat(usersTotal)} total users</p>
+              <p className='text-sm text-gray-500'>
+                {stat(usersTotal)} total users
+              </p>
             </div>
           </div>
         </Link>

--- a/apps/web/src/admin/pages/AdminMarketingEmailSettingsPage.tsx
+++ b/apps/web/src/admin/pages/AdminMarketingEmailSettingsPage.tsx
@@ -11,8 +11,9 @@ import { supabase } from '../../lib/supabase';
 import { MARKETING_EMAIL_PRODUCT_ID } from '../../marketing-email/beakerstackMarketingEmailConfig';
 
 export default function AdminMarketingEmailSettingsPage() {
-  const [settings, setSettings] =
-    useState<MarketingEmailAdminSettings | null>(null);
+  const [settings, setSettings] = useState<MarketingEmailAdminSettings | null>(
+    null
+  );
   const [stats, setStats] = useState<MarketingEmailQueueStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -104,8 +105,8 @@ export default function AdminMarketingEmailSettingsPage() {
           Marketing email settings
         </h2>
         <p className='mt-1 text-sm text-gray-600'>
-          Configure the Kit integration for subscriber sync and manage the
-          sync queue.
+          Configure the Kit integration for subscriber sync and manage the sync
+          queue.
         </p>
       </div>
 
@@ -158,9 +159,8 @@ export default function AdminMarketingEmailSettingsPage() {
           </label>
           {!settings.enabled ? (
             <p className='text-xs text-amber-700'>
-              When disabled, new events are not enqueued.
-              Existing pending queue rows are not dropped — they will be
-              processed when re-enabled.
+              When disabled, new events are not enqueued. Existing pending queue
+              rows are not dropped — they will be processed when re-enabled.
             </p>
           ) : null}
         </fieldset>
@@ -171,9 +171,7 @@ export default function AdminMarketingEmailSettingsPage() {
           </legend>
 
           <label className='block'>
-            <span className='text-sm font-medium text-gray-700'>
-              Namespace
-            </span>
+            <span className='text-sm font-medium text-gray-700'>Namespace</span>
             <p className='text-xs text-gray-500'>
               Lowercase letters, digits, and hyphens — e.g.{' '}
               <code>my-product</code>. Used as a tag prefix in Kit.

--- a/apps/web/src/admin/pages/AdminUsersPage.tsx
+++ b/apps/web/src/admin/pages/AdminUsersPage.tsx
@@ -62,7 +62,10 @@ export default function AdminUsersPage() {
         header: 'Admin',
         cell: row =>
           row.is_admin ? (
-            <span data-testid='admin-badge' className='inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700 ring-1 ring-inset ring-indigo-600/20'>
+            <span
+              data-testid='admin-badge'
+              className='inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700 ring-1 ring-inset ring-indigo-600/20'
+            >
               Admin
             </span>
           ) : null,
@@ -190,4 +193,3 @@ export default function AdminUsersPage() {
     </div>
   );
 }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -24085,9 +24085,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "node-forge": "^1.3.4",
     "postcss": "^8.5.10",
+    "qs": "6.15.2",
     "semver": "^7.6.3",
     "send": "^0.19.0",
     "tar": "^7.5.11",

--- a/packages/admin/src/adminClient.ts
+++ b/packages/admin/src/adminClient.ts
@@ -24,11 +24,7 @@ function isNotFound(payload: unknown): boolean {
 }
 
 function errorCode(payload: unknown): string | undefined {
-  if (
-    payload !== null &&
-    typeof payload === 'object' &&
-    'error' in payload
-  ) {
+  if (payload !== null && typeof payload === 'object' && 'error' in payload) {
     return (payload as { error?: string }).error;
   }
   return undefined;

--- a/packages/admin/src/components/AdminLayout.web.test.tsx
+++ b/packages/admin/src/components/AdminLayout.web.test.tsx
@@ -78,7 +78,9 @@ describe('AdminLayout', () => {
       </MemoryRouter>
     );
     expect(screen.getByTestId('sidebar-footer')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Sign out' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Sign out' })
+    ).toBeInTheDocument();
   });
 
   it('renders no footer section when sidebarFooter is omitted', () => {

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -17,4 +17,3 @@ export type {
   AdminNavItem,
   RecordAuditEventInput,
 } from './types.js';
-

--- a/packages/marketing-email/src/__tests__/marketingEmailAdminClient.test.ts
+++ b/packages/marketing-email/src/__tests__/marketingEmailAdminClient.test.ts
@@ -17,7 +17,11 @@ describe('normalizeMarketingEmailAdminSettings', () => {
       product_id: 'acme',
       enabled: true,
       provider: 'kit',
-      config: { namespace: 'acme-ns', kitFormId: 'form-1', tierTagNames: ['pro'] },
+      config: {
+        namespace: 'acme-ns',
+        kitFormId: 'form-1',
+        tierTagNames: ['pro'],
+      },
       updated_at: '2026-01-01T00:00:00Z',
     });
     expect(result.product_id).toBe('acme');
@@ -92,7 +96,10 @@ describe('getAdminMarketingEmailSettings', () => {
   });
 
   it('returns null when settings payload is null', async () => {
-    const sb = makeSupabase({ data: { ok: true, settings: null }, error: null });
+    const sb = makeSupabase({
+      data: { ok: true, settings: null },
+      error: null,
+    });
     expect(await getAdminMarketingEmailSettings(sb)).toBeNull();
   });
 
@@ -138,7 +145,10 @@ describe('updateAdminMarketingEmailSettings', () => {
   });
 
   it('returns null when data contains an error key', async () => {
-    const sb = makeSupabase({ data: { error: 'invalid_namespace' }, error: null });
+    const sb = makeSupabase({
+      data: { error: 'invalid_namespace' },
+      error: null,
+    });
     expect(
       await updateAdminMarketingEmailSettings(sb, {
         product_id: 'beakerstack',
@@ -156,7 +166,11 @@ describe('updateAdminMarketingEmailSettings', () => {
           product_id: 'beakerstack',
           enabled: false,
           provider: 'kit',
-          config: { namespace: 'ns', kitFormId: 'form-2', tierTagNames: ['pro'] },
+          config: {
+            namespace: 'ns',
+            kitFormId: 'form-2',
+            tierTagNames: ['pro'],
+          },
           updated_at: '2026-01-02T00:00:00Z',
         },
       },


### PR DESCRIPTION
## Summary
- Run Prettier/ESLint formatting across admin web UI, `@beakerstack/admin`, and `@beakerstack/marketing-email` (formatting-only changes).
- Override transitive `qs` to `6.15.2` to resolve moderate audit advisory [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) from the Stripe dependency.

## Test plan
- [x] Pre-commit hooks pass (lint-staged + type-check)
- [x] `npm audit` reports 0 vulnerabilities
- [ ] CI checks pass on PR