### PR TITLE
fix(phase5a): VOLATILE RPCs, marketing-email breadcrumbs, non-admin pgTAP test

### DIFF
--- a/apps/web/src/admin/AdminApp.tsx
+++ b/apps/web/src/admin/AdminApp.tsx
@@ -8,6 +8,9 @@ const AdminWaitlistPage = lazy(() => import('./pages/AdminWaitlistPage'));
 const AdminWaitlistSettingsPage = lazy(
   () => import('./pages/AdminWaitlistSettingsPage')
 );
+const AdminMarketingEmailSettingsPage = lazy(
+  () => import('./pages/AdminMarketingEmailSettingsPage')
+);
 
 function PageFallback() {
   return (
@@ -28,6 +31,10 @@ export default function AdminApp() {
           <Route
             path='waitlist/settings'
             element={<AdminWaitlistSettingsPage />}
+          />
+          <Route
+            path='marketing-email/settings'
+            element={<AdminMarketingEmailSettingsPage />}
           />
         </Route>
       </Routes>

--- a/apps/web/src/admin/AdminLayoutShell.tsx
+++ b/apps/web/src/admin/AdminLayoutShell.tsx
@@ -7,6 +7,12 @@ import { LayoutDashboard, LogOut } from 'lucide-react';
 
 function breadcrumbsForPath(pathname: string) {
   const root = { label: 'Overview', to: '/admin' };
+  if (pathname.includes('/marketing-email/settings')) {
+    return [root, { label: 'Marketing Email Settings' }];
+  }
+  if (pathname.includes('/marketing-email')) {
+    return [root, { label: 'Marketing Email' }];
+  }
   if (pathname.includes('/waitlist/settings')) {
     return [root, { label: 'Waitlist Settings' }];
   }

--- a/apps/web/src/admin/__tests__/AdminMarketingEmailSettingsPage.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminMarketingEmailSettingsPage.test.tsx
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  getAdminMarketingEmailSettings,
+  getAdminMarketingEmailQueueStats,
+  updateAdminMarketingEmailSettings,
+  type MarketingEmailAdminSettings,
+  type MarketingEmailQueueStats,
+} from '@beakerstack/marketing-email';
+import AdminMarketingEmailSettingsPage from '../pages/AdminMarketingEmailSettingsPage';
+
+vi.mock('@beakerstack/marketing-email', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('@beakerstack/marketing-email')>();
+  return {
+    ...actual,
+    getAdminMarketingEmailSettings: vi.fn(),
+    getAdminMarketingEmailQueueStats: vi.fn(),
+    updateAdminMarketingEmailSettings: vi.fn(),
+  };
+});
+
+const mockGet = vi.mocked(getAdminMarketingEmailSettings);
+const mockGetStats = vi.mocked(getAdminMarketingEmailQueueStats);
+const mockUpdate = vi.mocked(updateAdminMarketingEmailSettings);
+
+const baseSettings: MarketingEmailAdminSettings = {
+  product_id: 'beakerstack',
+  enabled: true,
+  provider: 'kit',
+  config: {
+    namespace: 'beakerstack',
+    kitFormId: 'form-123',
+    tierTagNames: ['pro', 'max'],
+  },
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const baseStats: MarketingEmailQueueStats = {
+  pending: 3,
+  processing: 1,
+  done: 42,
+  failed: 0,
+};
+
+describe('AdminMarketingEmailSettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(baseSettings);
+    mockGetStats.mockResolvedValue(baseStats);
+    mockUpdate.mockResolvedValue(baseSettings);
+  });
+
+  it('renders settings form after load', async () => {
+    render(<AdminMarketingEmailSettingsPage />);
+    expect(
+      await screen.findByRole('heading', { name: /marketing email settings/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /save settings/i })
+    ).toBeEnabled();
+  });
+
+  it('renders queue stats cards when stats are returned', async () => {
+    render(<AdminMarketingEmailSettingsPage />);
+    await screen.findByRole('heading', { name: /marketing email settings/i });
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
+  it('omits stats section when stats are null', async () => {
+    mockGetStats.mockResolvedValueOnce(null);
+    render(<AdminMarketingEmailSettingsPage />);
+    await screen.findByRole('heading', { name: /marketing email settings/i });
+    expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+  });
+
+  it('pre-populates fields from loaded settings', async () => {
+    render(<AdminMarketingEmailSettingsPage />);
+    await screen.findByRole('button', { name: /save settings/i });
+    expect(screen.getByDisplayValue('beakerstack')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('form-123')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('pro, max')).toBeInTheDocument();
+  });
+
+  it('shows disabled warning when integration is toggled off', async () => {
+    mockGet.mockResolvedValueOnce({ ...baseSettings, enabled: false });
+    render(<AdminMarketingEmailSettingsPage />);
+    await screen.findByRole('button', { name: /save settings/i });
+    expect(
+      screen.getByText(/new events are enqueued but not synced/i)
+    ).toBeInTheDocument();
+  });
+
+  it('does not show disabled warning when integration is enabled', async () => {
+    render(<AdminMarketingEmailSettingsPage />);
+    await screen.findByRole('button', { name: /save settings/i });
+    expect(
+      screen.queryByText(/new events are enqueued but not synced/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('initialises to disabled defaults when settings are null', async () => {
+    mockGet.mockResolvedValueOnce(null);
+    render(<AdminMarketingEmailSettingsPage />);
+    await screen.findByRole('button', { name: /save settings/i });
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('shows error when namespace is empty on save', async () => {
+    const user = userEvent.setup();
+    render(<AdminMarketingEmailSettingsPage />);
+    await screen.findByRole('button', { name: /save settings/i });
+
+    const namespaceInput = screen.getByDisplayValue('beakerstack');
+    await user.clear(namespaceInput);
+
+    await user.click(screen.getByRole('button', { name: /save settings/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/namespace is required/i);
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('shows error when kitFormId is empty on save', async () => {
+    const user = userEvent.setup();
+    render(<AdminMarketingEmailSettingsPage />);
+    await screen.findByRole('button', { name: /save settings/i });
+
+    const formIdInput = screen.getByDisplayValue('form-123');
+    await user.clear(formIdInput);
+
+    await user.click(screen.getByRole('button', { name: /save settings/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/kit form id is required/i);
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('saves settings on submit and shows saved confirmation', async () => {
+    const user = userEvent.setup();
+    render(<AdminMarketingEmailSettingsPage />);
+    await screen.findByRole('button', { name: /save settings/i });
+
+    await user.click(screen.getByRole('button', { name: /save settings/i }));
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalled();
+      expect(screen.getByRole('status')).toHaveTextContent(/settings saved/i);
+    });
+  });
+
+  it('passes tierTagNames as parsed array to update', async () => {
+    const user = userEvent.setup();
+    render(<AdminMarketingEmailSettingsPage />);
+    await screen.findByRole('button', { name: /save settings/i });
+
+    const tagsInput = screen.getByDisplayValue('pro, max');
+    await user.clear(tagsInput);
+    await user.type(tagsInput, 'starter, pro, enterprise');
+
+    await user.click(screen.getByRole('button', { name: /save settings/i }));
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          config: expect.objectContaining({
+            tierTagNames: ['starter', 'pro', 'enterprise'],
+          }),
+        })
+      );
+    });
+  });
+
+  it('shows error when update returns null', async () => {
+    mockUpdate.mockResolvedValueOnce(null);
+    const user = userEvent.setup();
+    render(<AdminMarketingEmailSettingsPage />);
+    await screen.findByRole('button', { name: /save settings/i });
+    await user.click(screen.getByRole('button', { name: /save settings/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/failed to save/i);
+    });
+  });
+
+  it('shows error when update throws', async () => {
+    mockUpdate.mockRejectedValueOnce(new Error('network error'));
+    const user = userEvent.setup();
+    render(<AdminMarketingEmailSettingsPage />);
+    await screen.findByRole('button', { name: /save settings/i });
+    await user.click(screen.getByRole('button', { name: /save settings/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('network error');
+    });
+  });
+
+  it('uses generic copy when update throws a non-Error value', async () => {
+    mockUpdate.mockRejectedValueOnce('boom');
+    const user = userEvent.setup();
+    render(<AdminMarketingEmailSettingsPage />);
+    await screen.findByRole('button', { name: /save settings/i });
+    await user.click(screen.getByRole('button', { name: /save settings/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/save failed/i);
+    });
+  });
+});

--- a/apps/web/src/admin/__tests__/AdminMarketingEmailSettingsPage.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminMarketingEmailSettingsPage.test.tsx
@@ -91,7 +91,7 @@ describe('AdminMarketingEmailSettingsPage', () => {
     render(<AdminMarketingEmailSettingsPage />);
     await screen.findByRole('button', { name: /save settings/i });
     expect(
-      screen.getByText(/new events are enqueued but not synced/i)
+      screen.getByText(/new events are not enqueued/i)
     ).toBeInTheDocument();
   });
 
@@ -99,7 +99,7 @@ describe('AdminMarketingEmailSettingsPage', () => {
     render(<AdminMarketingEmailSettingsPage />);
     await screen.findByRole('button', { name: /save settings/i });
     expect(
-      screen.queryByText(/new events are enqueued but not synced/i)
+      screen.queryByText(/new events are not enqueued/i)
     ).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/admin/__tests__/adminNav.test.ts
+++ b/apps/web/src/admin/__tests__/adminNav.test.ts
@@ -2,16 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { adminNavItems } from '../adminNav';
 
 describe('adminNav', () => {
-  it('includes overview, users, and waitlist entries', () => {
+  it('includes overview, users, waitlist, and marketing email entries', () => {
     expect(adminNavItems.map(n => n.label)).toEqual([
       'Overview',
       'Users',
       'Waitlist',
       'Waitlist settings',
+      'Marketing email settings',
     ]);
     expect(adminNavItems[0]?.to).toBe('/admin');
     expect(adminNavItems[1]?.to).toBe('/admin/users');
     expect(adminNavItems[2]?.to).toBe('/admin/waitlist');
     expect(adminNavItems[3]?.to).toBe('/admin/waitlist/settings');
+    expect(adminNavItems[4]?.to).toBe('/admin/marketing-email/settings');
   });
 });

--- a/apps/web/src/admin/adminNav.ts
+++ b/apps/web/src/admin/adminNav.ts
@@ -1,10 +1,10 @@
 import type { AdminNavItem } from '@beakerstack/admin';
-import { ClipboardList, LayoutDashboard, Settings, Users } from 'lucide-react';
+import { ClipboardList, LayoutDashboard, Mail, Settings, Users } from 'lucide-react';
 import { createElement } from 'react';
 
 export const adminNavItems: AdminNavItem[] = [
   {
-    label: 'Overview',
+    label: 'Admin Dashboard',
     to: '/admin',
     icon: createElement(LayoutDashboard, { className: 'h-4 w-4 shrink-0' }),
   },
@@ -22,5 +22,10 @@ export const adminNavItems: AdminNavItem[] = [
     label: 'Waitlist settings',
     to: '/admin/waitlist/settings',
     icon: createElement(Settings, { className: 'h-4 w-4 shrink-0' }),
+  },
+  {
+    label: 'Marketing email settings',
+    to: '/admin/marketing-email/settings',
+    icon: createElement(Mail, { className: 'h-4 w-4 shrink-0' }),
   },
 ];

--- a/apps/web/src/admin/adminNav.ts
+++ b/apps/web/src/admin/adminNav.ts
@@ -4,7 +4,7 @@ import { createElement } from 'react';
 
 export const adminNavItems: AdminNavItem[] = [
   {
-    label: 'Admin Dashboard',
+    label: 'Overview',
     to: '/admin',
     icon: createElement(LayoutDashboard, { className: 'h-4 w-4 shrink-0' }),
   },

--- a/apps/web/src/admin/pages/AdminMarketingEmailSettingsPage.tsx
+++ b/apps/web/src/admin/pages/AdminMarketingEmailSettingsPage.tsx
@@ -1,0 +1,253 @@
+import { useEffect, useState } from 'react';
+import {
+  getAdminMarketingEmailSettings,
+  updateAdminMarketingEmailSettings,
+  getAdminMarketingEmailQueueStats,
+  type MarketingEmailAdminSettings,
+  type MarketingEmailQueueStats,
+} from '@beakerstack/marketing-email';
+import { supabase } from '../../lib/supabase';
+import { MARKETING_EMAIL_PRODUCT_ID } from '../../marketing-email/beakerstackMarketingEmailConfig';
+
+const NAMESPACE_RE = /^[a-z][a-z0-9-]*$/;
+
+export default function AdminMarketingEmailSettingsPage() {
+  const [settings, setSettings] =
+    useState<MarketingEmailAdminSettings | null>(null);
+  const [stats, setStats] = useState<MarketingEmailQueueStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const [tierTagNamesInput, setTierTagNamesInput] = useState('');
+
+  useEffect(() => {
+    void (async () => {
+      setLoading(true);
+      const [data, statsData] = await Promise.all([
+        getAdminMarketingEmailSettings(supabase, MARKETING_EMAIL_PRODUCT_ID),
+        getAdminMarketingEmailQueueStats(supabase),
+      ]);
+      if (data) {
+        setSettings(data);
+        setTierTagNamesInput(data.config.tierTagNames.join(', '));
+      } else {
+        setSettings({
+          product_id: MARKETING_EMAIL_PRODUCT_ID,
+          enabled: false,
+          provider: 'kit',
+          config: { namespace: '', kitFormId: '', tierTagNames: [] },
+          updated_at: '',
+        });
+        setTierTagNamesInput('');
+      }
+      setStats(statsData);
+      setLoading(false);
+    })();
+  }, []);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!settings) return;
+
+    const tierTagNames = tierTagNamesInput
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean);
+
+    const config = { ...settings.config, tierTagNames };
+
+    if (!config.namespace || !NAMESPACE_RE.test(config.namespace)) {
+      setError(
+        'Namespace is required and must be lowercase letters, digits, and hyphens starting with a letter.'
+      );
+      return;
+    }
+    if (!config.kitFormId.trim()) {
+      setError('Kit form ID is required.');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      const updated = await updateAdminMarketingEmailSettings(supabase, {
+        product_id: settings.product_id,
+        enabled: settings.enabled,
+        config,
+      });
+      if (!updated) throw new Error('Failed to save settings');
+      setSettings(updated);
+      setTierTagNamesInput(updated.config.tierTagNames.join(', '));
+      setSaved(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading || !settings) {
+    return (
+      <div className='flex justify-center py-12'>
+        <div className='h-8 w-8 animate-spin rounded-full border-b-2 border-indigo-600' />
+      </div>
+    );
+  }
+
+  return (
+    <div className='space-y-6'>
+      <div>
+        <h2 className='text-2xl font-bold text-gray-900'>
+          Marketing email settings
+        </h2>
+        <p className='mt-1 text-sm text-gray-600'>
+          Configure the Kit integration for subscriber sync and manage the
+          sync queue.
+        </p>
+      </div>
+
+      {stats ? (
+        <div className='grid grid-cols-2 gap-4 sm:grid-cols-4'>
+          {(
+            [
+              { label: 'Pending', key: 'pending', color: 'text-yellow-700' },
+              {
+                label: 'Processing',
+                key: 'processing',
+                color: 'text-blue-700',
+              },
+              { label: 'Done', key: 'done', color: 'text-green-700' },
+              { label: 'Failed', key: 'failed', color: 'text-red-700' },
+            ] as const
+          ).map(({ label, key, color }) => (
+            <div
+              key={key}
+              className='rounded-lg border border-gray-200 p-4 text-center'
+            >
+              <p className={`text-2xl font-bold ${color}`}>{stats[key]}</p>
+              <p className='mt-1 text-xs text-gray-500'>{label}</p>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <form
+        onSubmit={e => void handleSave(e)}
+        className='mt-8 max-w-xl space-y-6'
+      >
+        <fieldset className='space-y-4 rounded-lg border border-gray-200 p-4'>
+          <legend className='px-1 text-sm font-semibold text-gray-900'>
+            Integration
+          </legend>
+
+          <label className='flex items-center gap-3'>
+            <input
+              type='checkbox'
+              className='h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500'
+              checked={settings.enabled}
+              onChange={e =>
+                setSettings({ ...settings, enabled: e.target.checked })
+              }
+            />
+            <span className='text-sm text-gray-700'>
+              Enable marketing email sync
+            </span>
+          </label>
+          {!settings.enabled ? (
+            <p className='text-xs text-amber-700'>
+              When disabled, new events are enqueued but not synced to Kit.
+              Pending queue rows are not dropped — they will be processed when
+              re-enabled.
+            </p>
+          ) : null}
+        </fieldset>
+
+        <fieldset className='space-y-4 rounded-lg border border-gray-200 p-4'>
+          <legend className='px-1 text-sm font-semibold text-gray-900'>
+            Kit configuration
+          </legend>
+
+          <label className='block'>
+            <span className='text-sm font-medium text-gray-700'>
+              Namespace
+            </span>
+            <p className='text-xs text-gray-500'>
+              Lowercase letters, digits, and hyphens — e.g.{' '}
+              <code>my-product</code>. Used as a tag prefix in Kit.
+            </p>
+            <input
+              type='text'
+              className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm'
+              value={settings.config.namespace}
+              onChange={e =>
+                setSettings({
+                  ...settings,
+                  config: { ...settings.config, namespace: e.target.value },
+                })
+              }
+            />
+          </label>
+
+          <label className='block'>
+            <span className='text-sm font-medium text-gray-700'>
+              Kit form ID
+            </span>
+            <p className='text-xs text-gray-500'>
+              The Kit form or sequence ID subscribers are added to on signup.
+            </p>
+            <input
+              type='text'
+              className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm'
+              value={settings.config.kitFormId}
+              onChange={e =>
+                setSettings({
+                  ...settings,
+                  config: { ...settings.config, kitFormId: e.target.value },
+                })
+              }
+            />
+          </label>
+
+          <label className='block'>
+            <span className='text-sm font-medium text-gray-700'>
+              Tier tag names{' '}
+              <span className='font-normal text-gray-400'>(optional)</span>
+            </span>
+            <p className='text-xs text-gray-500'>
+              Comma-separated plan slugs used as Kit subscriber tags for
+              tier_changed events — e.g. <code>pro, max</code>. Required for
+              tier sync.
+            </p>
+            <input
+              type='text'
+              className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm'
+              value={tierTagNamesInput}
+              onChange={e => setTierTagNamesInput(e.target.value)}
+            />
+          </label>
+        </fieldset>
+
+        {error ? (
+          <p className='text-sm text-red-600' role='alert'>
+            {error}
+          </p>
+        ) : null}
+        {saved ? (
+          <p className='text-sm text-green-700' role='status'>
+            Settings saved.
+          </p>
+        ) : null}
+
+        <button
+          type='submit'
+          disabled={saving}
+          className='rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50'
+        >
+          {saving ? 'Saving…' : 'Save settings'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/admin/pages/AdminMarketingEmailSettingsPage.tsx
+++ b/apps/web/src/admin/pages/AdminMarketingEmailSettingsPage.tsx
@@ -3,13 +3,12 @@ import {
   getAdminMarketingEmailSettings,
   updateAdminMarketingEmailSettings,
   getAdminMarketingEmailQueueStats,
+  NAMESPACE_RE,
   type MarketingEmailAdminSettings,
   type MarketingEmailQueueStats,
 } from '@beakerstack/marketing-email';
 import { supabase } from '../../lib/supabase';
 import { MARKETING_EMAIL_PRODUCT_ID } from '../../marketing-email/beakerstackMarketingEmailConfig';
-
-const NAMESPACE_RE = /^[a-z][a-z0-9-]*$/;
 
 export default function AdminMarketingEmailSettingsPage() {
   const [settings, setSettings] =

--- a/apps/web/src/admin/pages/AdminMarketingEmailSettingsPage.tsx
+++ b/apps/web/src/admin/pages/AdminMarketingEmailSettingsPage.tsx
@@ -54,7 +54,9 @@ export default function AdminMarketingEmailSettingsPage() {
       .map(s => s.trim())
       .filter(Boolean);
 
-    const config = { ...settings.config, tierTagNames };
+    const namespace = settings.config.namespace.trim();
+    const kitFormId = settings.config.kitFormId.trim();
+    const config = { ...settings.config, namespace, kitFormId, tierTagNames };
 
     if (!config.namespace || !NAMESPACE_RE.test(config.namespace)) {
       setError(
@@ -62,7 +64,7 @@ export default function AdminMarketingEmailSettingsPage() {
       );
       return;
     }
-    if (!config.kitFormId.trim()) {
+    if (!config.kitFormId) {
       setError('Kit form ID is required.');
       return;
     }
@@ -156,9 +158,9 @@ export default function AdminMarketingEmailSettingsPage() {
           </label>
           {!settings.enabled ? (
             <p className='text-xs text-amber-700'>
-              When disabled, new events are enqueued but not synced to Kit.
-              Pending queue rows are not dropped — they will be processed when
-              re-enabled.
+              When disabled, new events are not enqueued.
+              Existing pending queue rows are not dropped — they will be
+              processed when re-enabled.
             </p>
           ) : null}
         </fieldset>

--- a/apps/web/src/marketing-email/beakerstackMarketingEmailConfig.ts
+++ b/apps/web/src/marketing-email/beakerstackMarketingEmailConfig.ts
@@ -1,0 +1,1 @@
+export const MARKETING_EMAIL_PRODUCT_ID = 'beakerstack' as const;

--- a/packages/marketing-email/src/__tests__/barrelExports.test.ts
+++ b/packages/marketing-email/src/__tests__/barrelExports.test.ts
@@ -8,6 +8,11 @@ describe('package barrels', () => {
     expect(mod.defineKitConfig).toBeTypeOf('function');
     expect(mod.MarketingEmailError).toBeTypeOf('function');
     expect(mod.waitlistTag).toBeTypeOf('function');
+    expect(mod.getAdminMarketingEmailSettings).toBeTypeOf('function');
+    expect(mod.updateAdminMarketingEmailSettings).toBeTypeOf('function');
+    expect(mod.getAdminMarketingEmailQueueStats).toBeTypeOf('function');
+    expect(mod.normalizeMarketingEmailAdminSettings).toBeTypeOf('function');
+    expect(mod.DEFAULT_MARKETING_EMAIL_ADMIN_SETTINGS).toBeTypeOf('object');
   });
 
   it('exports web entry', async () => {

--- a/packages/marketing-email/src/__tests__/barrelExports.test.ts
+++ b/packages/marketing-email/src/__tests__/barrelExports.test.ts
@@ -4,6 +4,7 @@ describe('package barrels', () => {
   it('exports main entry', async () => {
     const mod = await import('../index.js');
     expect(mod.defineMarketingEmailConfig).toBeTypeOf('function');
+    expect(mod.NAMESPACE_RE).toBeInstanceOf(RegExp);
     expect(mod.KitAdapter).toBeTypeOf('function');
     expect(mod.defineKitConfig).toBeTypeOf('function');
     expect(mod.MarketingEmailError).toBeTypeOf('function');

--- a/packages/marketing-email/src/__tests__/marketingEmailAdminClient.test.ts
+++ b/packages/marketing-email/src/__tests__/marketingEmailAdminClient.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  normalizeMarketingEmailAdminSettings,
+  DEFAULT_MARKETING_EMAIL_ADMIN_SETTINGS,
+  getAdminMarketingEmailSettings,
+  updateAdminMarketingEmailSettings,
+  getAdminMarketingEmailQueueStats,
+} from '../marketingEmailAdminClient.js';
+
+function makeSupabase(rpcResult: { data: unknown; error: unknown }) {
+  return { rpc: vi.fn().mockResolvedValue(rpcResult) } as never;
+}
+
+describe('normalizeMarketingEmailAdminSettings', () => {
+  it('normalizes a complete valid record', () => {
+    const result = normalizeMarketingEmailAdminSettings({
+      product_id: 'acme',
+      enabled: true,
+      provider: 'kit',
+      config: { namespace: 'acme-ns', kitFormId: 'form-1', tierTagNames: ['pro'] },
+      updated_at: '2026-01-01T00:00:00Z',
+    });
+    expect(result.product_id).toBe('acme');
+    expect(result.enabled).toBe(true);
+    expect(result.config.namespace).toBe('acme-ns');
+    expect(result.config.kitFormId).toBe('form-1');
+    expect(result.config.tierTagNames).toEqual(['pro']);
+    expect(result.updated_at).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('falls back to defaults when fields are missing', () => {
+    const result = normalizeMarketingEmailAdminSettings({});
+    expect(result.product_id).toBe(
+      DEFAULT_MARKETING_EMAIL_ADMIN_SETTINGS.product_id
+    );
+    expect(result.enabled).toBe(false);
+    expect(result.config.namespace).toBe('');
+    expect(result.config.kitFormId).toBe('');
+    expect(result.config.tierTagNames).toEqual([]);
+    expect(result.updated_at).toBe('');
+  });
+
+  it('falls back to defaults when config is not an object', () => {
+    const result = normalizeMarketingEmailAdminSettings({
+      product_id: 'acme',
+      config: 'not-an-object',
+    });
+    expect(result.config.namespace).toBe('');
+    expect(result.config.kitFormId).toBe('');
+    expect(result.config.tierTagNames).toEqual([]);
+  });
+
+  it('falls back to defaults when config is an array', () => {
+    const result = normalizeMarketingEmailAdminSettings({ config: ['a', 'b'] });
+    expect(result.config.namespace).toBe('');
+  });
+
+  it('ignores non-string namespace', () => {
+    const result = normalizeMarketingEmailAdminSettings({
+      config: { namespace: 42, kitFormId: 'f', tierTagNames: [] },
+    });
+    expect(result.config.namespace).toBe('');
+  });
+
+  it('ignores non-array tierTagNames', () => {
+    const result = normalizeMarketingEmailAdminSettings({
+      config: { namespace: 'ns', kitFormId: 'f', tierTagNames: 'pro,max' },
+    });
+    expect(result.config.tierTagNames).toEqual([]);
+  });
+
+  it('always sets provider to kit', () => {
+    const result = normalizeMarketingEmailAdminSettings({ provider: 'other' });
+    expect(result.provider).toBe('kit');
+  });
+});
+
+describe('getAdminMarketingEmailSettings', () => {
+  it('returns null when rpc returns an error', async () => {
+    const sb = makeSupabase({ data: null, error: new Error('db error') });
+    expect(await getAdminMarketingEmailSettings(sb)).toBeNull();
+  });
+
+  it('returns null when data is null', async () => {
+    const sb = makeSupabase({ data: null, error: null });
+    expect(await getAdminMarketingEmailSettings(sb)).toBeNull();
+  });
+
+  it('returns null when data contains an error key', async () => {
+    const sb = makeSupabase({ data: { error: 'not_found' }, error: null });
+    expect(await getAdminMarketingEmailSettings(sb)).toBeNull();
+  });
+
+  it('returns null when settings payload is null', async () => {
+    const sb = makeSupabase({ data: { ok: true, settings: null }, error: null });
+    expect(await getAdminMarketingEmailSettings(sb)).toBeNull();
+  });
+
+  it('returns normalized settings on success', async () => {
+    const sb = makeSupabase({
+      data: {
+        ok: true,
+        settings: {
+          product_id: 'beakerstack',
+          enabled: true,
+          provider: 'kit',
+          config: { namespace: 'bs', kitFormId: 'f-1', tierTagNames: [] },
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      },
+      error: null,
+    });
+    const result = await getAdminMarketingEmailSettings(sb, 'beakerstack');
+    expect(result?.product_id).toBe('beakerstack');
+    expect(result?.enabled).toBe(true);
+    expect(result?.config.namespace).toBe('bs');
+  });
+
+  it('uses default productId when not provided', async () => {
+    const sb = makeSupabase({ data: { error: 'not_found' }, error: null });
+    await getAdminMarketingEmailSettings(sb);
+    expect(sb.rpc).toHaveBeenCalledWith('admin_get_marketing_email_settings', {
+      p_product_id: 'beakerstack',
+    });
+  });
+});
+
+describe('updateAdminMarketingEmailSettings', () => {
+  it('returns null when rpc returns an error', async () => {
+    const sb = makeSupabase({ data: null, error: new Error('db error') });
+    expect(
+      await updateAdminMarketingEmailSettings(sb, {
+        product_id: 'beakerstack',
+        enabled: false,
+        config: { namespace: 'ns', kitFormId: 'f', tierTagNames: [] },
+      })
+    ).toBeNull();
+  });
+
+  it('returns null when data contains an error key', async () => {
+    const sb = makeSupabase({ data: { error: 'invalid_namespace' }, error: null });
+    expect(
+      await updateAdminMarketingEmailSettings(sb, {
+        product_id: 'beakerstack',
+        enabled: false,
+        config: { namespace: '', kitFormId: 'f', tierTagNames: [] },
+      })
+    ).toBeNull();
+  });
+
+  it('returns normalized settings on success', async () => {
+    const sb = makeSupabase({
+      data: {
+        ok: true,
+        settings: {
+          product_id: 'beakerstack',
+          enabled: false,
+          provider: 'kit',
+          config: { namespace: 'ns', kitFormId: 'form-2', tierTagNames: ['pro'] },
+          updated_at: '2026-01-02T00:00:00Z',
+        },
+      },
+      error: null,
+    });
+    const result = await updateAdminMarketingEmailSettings(sb, {
+      product_id: 'beakerstack',
+      enabled: false,
+      config: { namespace: 'ns', kitFormId: 'form-2', tierTagNames: ['pro'] },
+    });
+    expect(result?.config.kitFormId).toBe('form-2');
+    expect(result?.config.tierTagNames).toEqual(['pro']);
+  });
+});
+
+describe('getAdminMarketingEmailQueueStats', () => {
+  it('returns null when rpc returns an error', async () => {
+    const sb = makeSupabase({ data: null, error: new Error('db error') });
+    expect(await getAdminMarketingEmailQueueStats(sb)).toBeNull();
+  });
+
+  it('returns null when data contains an error key', async () => {
+    const sb = makeSupabase({ data: { error: 'not_found' }, error: null });
+    expect(await getAdminMarketingEmailQueueStats(sb)).toBeNull();
+  });
+
+  it('returns counts on success', async () => {
+    const sb = makeSupabase({
+      data: { pending: 3, processing: 1, done: 42, failed: 2 },
+      error: null,
+    });
+    const result = await getAdminMarketingEmailQueueStats(sb);
+    expect(result?.pending).toBe(3);
+    expect(result?.processing).toBe(1);
+    expect(result?.done).toBe(42);
+    expect(result?.failed).toBe(2);
+  });
+
+  it('falls back to 0 for non-number fields', async () => {
+    const sb = makeSupabase({
+      data: { pending: null, processing: null, done: null, failed: null },
+      error: null,
+    });
+    const result = await getAdminMarketingEmailQueueStats(sb);
+    expect(result?.pending).toBe(0);
+    expect(result?.done).toBe(0);
+  });
+});

--- a/packages/marketing-email/src/index.ts
+++ b/packages/marketing-email/src/index.ts
@@ -1,4 +1,4 @@
-export { defineMarketingEmailConfig } from './schema.js';
+export { defineMarketingEmailConfig, NAMESPACE_RE } from './schema.js';
 export type { MarketingEmailConfig } from './schema.js';
 export type { MarketingEmailAdapter } from './types.js';
 export { MarketingEmailError } from './errors.js';

--- a/packages/marketing-email/src/index.ts
+++ b/packages/marketing-email/src/index.ts
@@ -6,3 +6,14 @@ export { KitAdapter, isPermanentKitError } from './adapters/kit/kitAdapter.js';
 export { defineKitConfig } from './adapters/kit/kitConfig.js';
 export type { KitAdapterConfig } from './adapters/kit/kitConfig.js';
 export * from './adapters/kit/kitTagScheme.js';
+export {
+  getAdminMarketingEmailSettings,
+  updateAdminMarketingEmailSettings,
+  getAdminMarketingEmailQueueStats,
+  normalizeMarketingEmailAdminSettings,
+  DEFAULT_MARKETING_EMAIL_ADMIN_SETTINGS,
+} from './marketingEmailAdminClient.js';
+export type {
+  MarketingEmailAdminSettings,
+  MarketingEmailQueueStats,
+} from './marketingEmailAdminClient.js';

--- a/packages/marketing-email/src/marketingEmailAdminClient.ts
+++ b/packages/marketing-email/src/marketingEmailAdminClient.ts
@@ -36,26 +36,30 @@ export function normalizeMarketingEmailAdminSettings(
   raw: Record<string, unknown>
 ): MarketingEmailAdminSettings {
   const config =
-    raw.config && typeof raw.config === 'object' && !Array.isArray(raw.config)
-      ? (raw.config as Record<string, unknown>)
+    raw['config'] &&
+    typeof raw['config'] === 'object' &&
+    !Array.isArray(raw['config'])
+      ? (raw['config'] as Record<string, unknown>)
       : {};
   return {
     product_id:
-      typeof raw.product_id === 'string'
-        ? raw.product_id
+      typeof raw['product_id'] === 'string'
+        ? raw['product_id']
         : DEFAULT_MARKETING_EMAIL_ADMIN_SETTINGS.product_id,
-    enabled: raw.enabled === true,
+    enabled: raw['enabled'] === true,
     provider: 'kit',
     config: {
-      namespace: typeof config.namespace === 'string' ? config.namespace : '',
-      kitFormId: typeof config.kitFormId === 'string' ? config.kitFormId : '',
-      tierTagNames: Array.isArray(config.tierTagNames)
-        ? (config.tierTagNames as string[])
+      namespace:
+        typeof config['namespace'] === 'string' ? config['namespace'] : '',
+      kitFormId:
+        typeof config['kitFormId'] === 'string' ? config['kitFormId'] : '',
+      tierTagNames: Array.isArray(config['tierTagNames'])
+        ? (config['tierTagNames'] as string[])
         : [],
     },
     updated_at:
-      typeof raw.updated_at === 'string'
-        ? raw.updated_at
+      typeof raw['updated_at'] === 'string'
+        ? raw['updated_at']
         : DEFAULT_MARKETING_EMAIL_ADMIN_SETTINGS.updated_at,
   };
 }
@@ -105,9 +109,9 @@ export async function getAdminMarketingEmailQueueStats(
   if (error || !data || (data as { error?: string }).error) return null;
   const raw = data as Record<string, unknown>;
   return {
-    pending: typeof raw.pending === 'number' ? raw.pending : 0,
-    processing: typeof raw.processing === 'number' ? raw.processing : 0,
-    done: typeof raw.done === 'number' ? raw.done : 0,
-    failed: typeof raw.failed === 'number' ? raw.failed : 0,
+    pending: typeof raw['pending'] === 'number' ? raw['pending'] : 0,
+    processing: typeof raw['processing'] === 'number' ? raw['processing'] : 0,
+    done: typeof raw['done'] === 'number' ? raw['done'] : 0,
+    failed: typeof raw['failed'] === 'number' ? raw['failed'] : 0,
   };
 }

--- a/packages/marketing-email/src/marketingEmailAdminClient.ts
+++ b/packages/marketing-email/src/marketingEmailAdminClient.ts
@@ -1,0 +1,113 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface MarketingEmailAdminSettings {
+  product_id: string;
+  enabled: boolean;
+  provider: 'kit';
+  config: {
+    namespace: string;
+    kitFormId: string;
+    tierTagNames: string[];
+  };
+  updated_at: string;
+}
+
+export interface MarketingEmailQueueStats {
+  pending: number;
+  processing: number;
+  done: number;
+  failed: number;
+}
+
+export const DEFAULT_MARKETING_EMAIL_ADMIN_SETTINGS: MarketingEmailAdminSettings =
+  {
+    product_id: 'beakerstack',
+    enabled: false,
+    provider: 'kit',
+    config: {
+      namespace: '',
+      kitFormId: '',
+      tierTagNames: [],
+    },
+    updated_at: '',
+  };
+
+export function normalizeMarketingEmailAdminSettings(
+  raw: Record<string, unknown>
+): MarketingEmailAdminSettings {
+  const config =
+    raw.config && typeof raw.config === 'object' && !Array.isArray(raw.config)
+      ? (raw.config as Record<string, unknown>)
+      : {};
+  return {
+    product_id:
+      typeof raw.product_id === 'string'
+        ? raw.product_id
+        : DEFAULT_MARKETING_EMAIL_ADMIN_SETTINGS.product_id,
+    enabled: raw.enabled === true,
+    provider: 'kit',
+    config: {
+      namespace: typeof config.namespace === 'string' ? config.namespace : '',
+      kitFormId: typeof config.kitFormId === 'string' ? config.kitFormId : '',
+      tierTagNames: Array.isArray(config.tierTagNames)
+        ? (config.tierTagNames as string[])
+        : [],
+    },
+    updated_at:
+      typeof raw.updated_at === 'string'
+        ? raw.updated_at
+        : DEFAULT_MARKETING_EMAIL_ADMIN_SETTINGS.updated_at,
+  };
+}
+
+export async function getAdminMarketingEmailSettings(
+  supabase: SupabaseClient,
+  productId = 'beakerstack'
+): Promise<MarketingEmailAdminSettings | null> {
+  const { data, error } = await supabase.rpc(
+    'admin_get_marketing_email_settings',
+    { p_product_id: productId }
+  );
+  if (error || !data || (data as { error?: string }).error) return null;
+  const payload = data as { settings?: Record<string, unknown> | null };
+  if (!payload.settings) return null;
+  return normalizeMarketingEmailAdminSettings(payload.settings);
+}
+
+export async function updateAdminMarketingEmailSettings(
+  supabase: SupabaseClient,
+  params: {
+    product_id: string;
+    enabled: boolean;
+    config: { namespace: string; kitFormId: string; tierTagNames: string[] };
+  }
+): Promise<MarketingEmailAdminSettings | null> {
+  const { data, error } = await supabase.rpc(
+    'admin_update_marketing_email_settings',
+    {
+      p_product_id: params.product_id,
+      p_enabled: params.enabled,
+      p_config: params.config,
+    }
+  );
+  if (error || !data || (data as { error?: string }).error) return null;
+  const payload = data as { settings?: Record<string, unknown> | null };
+  if (!payload.settings) return null;
+  return normalizeMarketingEmailAdminSettings(payload.settings);
+}
+
+export async function getAdminMarketingEmailQueueStats(
+  supabase: SupabaseClient
+): Promise<MarketingEmailQueueStats | null> {
+  const { data, error } = await supabase.rpc(
+    'admin_get_marketing_email_queue_stats'
+  );
+  if (error || !data || (data as { error?: string }).error) return null;
+  const raw = data as Record<string, unknown>;
+  return {
+    pending: typeof raw.pending === 'number' ? raw.pending : 0,
+    processing: typeof raw.processing === 'number' ? raw.processing : 0,
+    done: typeof raw.done === 'number' ? raw.done : 0,
+    failed: typeof raw.failed === 'number' ? raw.failed : 0,
+  };
+}

--- a/packages/marketing-email/src/marketingEmailAdminClient.ts
+++ b/packages/marketing-email/src/marketingEmailAdminClient.ts
@@ -54,7 +54,9 @@ export function normalizeMarketingEmailAdminSettings(
       kitFormId:
         typeof config['kitFormId'] === 'string' ? config['kitFormId'] : '',
       tierTagNames: Array.isArray(config['tierTagNames'])
-        ? (config['tierTagNames'] as string[])
+        ? (config['tierTagNames'] as unknown[]).filter(
+            (item): item is string => typeof item === 'string'
+          )
         : [],
     },
     updated_at:

--- a/packages/marketing-email/src/schema.ts
+++ b/packages/marketing-email/src/schema.ts
@@ -16,7 +16,7 @@ export interface MarketingEmailConfig {
 
 // Namespace must be lowercase, start with a letter, and contain only letters,
 // digits, and hyphens — matching DB constraints added in Phase 2 (#286).
-const NAMESPACE_RE = /^[a-z][a-z0-9-]*$/;
+export const NAMESPACE_RE = /^[a-z][a-z0-9-]*$/;
 
 export function defineMarketingEmailConfig(
   config: MarketingEmailConfig

--- a/supabase/migrations/20260522000002_marketing_email_admin_rpcs.sql
+++ b/supabase/migrations/20260522000002_marketing_email_admin_rpcs.sql
@@ -87,6 +87,9 @@ BEGIN
     RETURN jsonb_build_object('error', 'invalid_kit_form_id');
   END IF;
 
+  -- Normalize config so stored values reflect trimmed namespace and kitFormId.
+  p_config := p_config || jsonb_build_object('namespace', v_namespace, 'kitFormId', v_form_id);
+
   -- Enforce at-most-one-enabled: disable all other rows before enabling.
   IF p_enabled THEN
     UPDATE public.marketing_email_settings

--- a/supabase/migrations/20260522000002_marketing_email_admin_rpcs.sql
+++ b/supabase/migrations/20260522000002_marketing_email_admin_rpcs.sql
@@ -1,0 +1,157 @@
+-- Phase 5a: Admin RPCs for marketing_email_settings management.
+-- Provides read/write access to marketing email configuration and
+-- read-only access to sync queue statistics. All RPCs are admin-gated.
+
+-- ---------------------------------------------------------------------------
+-- admin_get_marketing_email_settings
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.admin_get_marketing_email_settings(
+  p_product_id text DEFAULT 'beakerstack'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_row public.marketing_email_settings;
+BEGIN
+  IF v_uid IS NULL OR NOT public.admin_is_admin() THEN
+    RETURN jsonb_build_object('error', 'not_found');
+  END IF;
+
+  SELECT * INTO v_row
+  FROM public.marketing_email_settings
+  WHERE product_id = p_product_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', true, 'settings', NULL);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'settings', jsonb_build_object(
+      'product_id',  v_row.product_id,
+      'enabled',     v_row.enabled,
+      'provider',    v_row.provider,
+      'config',      v_row.config,
+      'updated_at',  v_row.updated_at
+    )
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.admin_get_marketing_email_settings(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.admin_get_marketing_email_settings(text) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- admin_update_marketing_email_settings
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.admin_update_marketing_email_settings(
+  p_product_id text,
+  p_enabled    boolean,
+  p_config     jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid       uuid := auth.uid();
+  v_namespace text;
+  v_form_id   text;
+BEGIN
+  IF v_uid IS NULL OR NOT public.admin_is_admin() THEN
+    RETURN jsonb_build_object('error', 'not_found');
+  END IF;
+
+  -- Validate required config fields.
+  v_namespace := trim(p_config->>'namespace');
+  v_form_id   := trim(p_config->>'kitFormId');
+
+  IF v_namespace IS NULL OR v_namespace = '' THEN
+    RETURN jsonb_build_object('error', 'invalid_namespace');
+  END IF;
+
+  IF v_namespace !~ '^[a-z][a-z0-9-]*$' THEN
+    RETURN jsonb_build_object('error', 'invalid_namespace');
+  END IF;
+
+  IF v_form_id IS NULL OR v_form_id = '' THEN
+    RETURN jsonb_build_object('error', 'invalid_kit_form_id');
+  END IF;
+
+  -- Enforce at-most-one-enabled: disable all other rows before enabling.
+  IF p_enabled THEN
+    UPDATE public.marketing_email_settings
+    SET enabled = false, updated_at = now()
+    WHERE product_id != p_product_id AND enabled = true;
+  END IF;
+
+  -- Upsert the target row.
+  INSERT INTO public.marketing_email_settings (product_id, enabled, provider, config)
+  VALUES (p_product_id, p_enabled, 'kit', p_config)
+  ON CONFLICT (product_id) DO UPDATE
+    SET enabled    = EXCLUDED.enabled,
+        config     = EXCLUDED.config,
+        updated_at = now();
+
+  -- Audit the change.
+  PERFORM public._admin_insert_audit(
+    v_uid,
+    'admin.marketing_email.settings.update',
+    'marketing_email_settings',
+    p_product_id,
+    jsonb_build_object(
+      'enabled',      p_enabled,
+      'namespace',    v_namespace,
+      'kitFormId',    v_form_id,
+      'tierTagNames', COALESCE(p_config->'tierTagNames', '[]'::jsonb)
+    )
+  );
+
+  RETURN public.admin_get_marketing_email_settings(p_product_id);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.admin_update_marketing_email_settings(text, boolean, jsonb) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.admin_update_marketing_email_settings(text, boolean, jsonb) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- admin_get_marketing_email_queue_stats
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.admin_get_marketing_email_queue_stats()
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL OR NOT public.admin_is_admin() THEN
+    RETURN jsonb_build_object('error', 'not_found');
+  END IF;
+
+  RETURN (
+    SELECT jsonb_build_object(
+      'pending',    COUNT(*) FILTER (WHERE status = 'pending'),
+      'processing', COUNT(*) FILTER (WHERE status = 'processing'),
+      'done',       COUNT(*) FILTER (WHERE status = 'done'),
+      'failed',     COUNT(*) FILTER (WHERE status = 'failed')
+    )
+    FROM public.marketing_email_sync_queue
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.admin_get_marketing_email_queue_stats() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.admin_get_marketing_email_queue_stats() TO authenticated;

--- a/supabase/migrations/20260522000002_marketing_email_admin_rpcs.sql
+++ b/supabase/migrations/20260522000002_marketing_email_admin_rpcs.sql
@@ -11,7 +11,7 @@ CREATE OR REPLACE FUNCTION public.admin_get_marketing_email_settings(
 )
 RETURNS jsonb
 LANGUAGE plpgsql
-STABLE
+VOLATILE
 SECURITY DEFINER
 SET search_path = public
 AS $$
@@ -133,7 +133,7 @@ GRANT EXECUTE ON FUNCTION public.admin_update_marketing_email_settings(text, boo
 CREATE OR REPLACE FUNCTION public.admin_get_marketing_email_queue_stats()
 RETURNS jsonb
 LANGUAGE plpgsql
-STABLE
+VOLATILE
 SECURITY DEFINER
 SET search_path = public
 AS $$

--- a/supabase/tests/marketing_email_phase5a.test.sql
+++ b/supabase/tests/marketing_email_phase5a.test.sql
@@ -1,0 +1,214 @@
+-- pgTAP tests for Phase 5a: admin RPCs for marketing_email_settings.
+-- Tests: admin_get_marketing_email_settings, admin_update_marketing_email_settings,
+-- admin_get_marketing_email_queue_stats.
+-- Pattern: BEGIN / SELECT plan(N) / assertions / SELECT * FROM finish() / ROLLBACK
+
+BEGIN;
+
+SELECT plan(17);
+
+-- ── 1  admin_get_marketing_email_settings function exists ────────────────────
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM information_schema.routines
+        WHERE routine_schema = 'public'
+          AND routine_name = 'admin_get_marketing_email_settings'
+    ),
+    'admin_get_marketing_email_settings function exists'
+);
+
+-- ── 2  admin_update_marketing_email_settings function exists ─────────────────
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM information_schema.routines
+        WHERE routine_schema = 'public'
+          AND routine_name = 'admin_update_marketing_email_settings'
+    ),
+    'admin_update_marketing_email_settings function exists'
+);
+
+-- ── 3  admin_get_marketing_email_queue_stats function exists ─────────────────
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM information_schema.routines
+        WHERE routine_schema = 'public'
+          AND routine_name = 'admin_get_marketing_email_queue_stats'
+    ),
+    'admin_get_marketing_email_queue_stats function exists'
+);
+
+-- ── 4  get returns ok=true, settings=null when no row exists ─────────────────
+
+DELETE FROM public.marketing_email_settings WHERE product_id = 'phase5a-test';
+
+SELECT is(
+    public.admin_get_marketing_email_settings('phase5a-test'),
+    jsonb_build_object('ok', true, 'settings', NULL),
+    'get returns ok=true, settings=null for missing product_id'
+);
+
+-- ── 5  update rejects invalid namespace (empty) ──────────────────────────────
+
+SELECT is(
+    (public.admin_update_marketing_email_settings(
+        'phase5a-test', false,
+        '{"namespace":"","kitFormId":"form-99","tierTagNames":[]}'::jsonb
+    )->>'error'),
+    'invalid_namespace',
+    'update rejects empty namespace'
+);
+
+-- ── 6  update rejects invalid namespace (bad pattern) ───────────────────────
+
+SELECT is(
+    (public.admin_update_marketing_email_settings(
+        'phase5a-test', false,
+        '{"namespace":"Bad Namespace","kitFormId":"form-99","tierTagNames":[]}'::jsonb
+    )->>'error'),
+    'invalid_namespace',
+    'update rejects namespace with uppercase/spaces'
+);
+
+-- ── 7  update rejects namespace starting with digit ──────────────────────────
+
+SELECT is(
+    (public.admin_update_marketing_email_settings(
+        'phase5a-test', false,
+        '{"namespace":"1bad","kitFormId":"form-99","tierTagNames":[]}'::jsonb
+    )->>'error'),
+    'invalid_namespace',
+    'update rejects namespace starting with digit'
+);
+
+-- ── 8  update rejects empty kitFormId ───────────────────────────────────────
+
+SELECT is(
+    (public.admin_update_marketing_email_settings(
+        'phase5a-test', false,
+        '{"namespace":"phase5a-test","kitFormId":"","tierTagNames":[]}'::jsonb
+    )->>'error'),
+    'invalid_kit_form_id',
+    'update rejects empty kitFormId'
+);
+
+-- ── 9  update succeeds with valid inputs ─────────────────────────────────────
+
+SELECT is(
+    (public.admin_update_marketing_email_settings(
+        'phase5a-test', false,
+        '{"namespace":"phase5a-ns","kitFormId":"form-99","tierTagNames":["pro","max"]}'::jsonb
+    )->>'error'),
+    NULL,
+    'update succeeds with valid namespace and kitFormId'
+);
+
+-- ── 10  get now returns the row just upserted ────────────────────────────────
+
+SELECT is(
+    (public.admin_get_marketing_email_settings('phase5a-test')->'settings'->>'product_id'),
+    'phase5a-test',
+    'get returns correct product_id after upsert'
+);
+
+-- ── 11  settings contain namespace ───────────────────────────────────────────
+
+SELECT is(
+    (public.admin_get_marketing_email_settings('phase5a-test')
+        ->'settings'->'config'->>'namespace'),
+    'phase5a-ns',
+    'settings config contains correct namespace'
+);
+
+-- ── 12  settings contain kitFormId ───────────────────────────────────────────
+
+SELECT is(
+    (public.admin_get_marketing_email_settings('phase5a-test')
+        ->'settings'->'config'->>'kitFormId'),
+    'form-99',
+    'settings config contains correct kitFormId'
+);
+
+-- ── 13  settings contain tierTagNames ────────────────────────────────────────
+
+SELECT is(
+    (public.admin_get_marketing_email_settings('phase5a-test')
+        ->'settings'->'config'->'tierTagNames'),
+    '["pro","max"]'::jsonb,
+    'settings config contains correct tierTagNames'
+);
+
+-- ── 14  one-enabled: enabling phase5a-test disables other enabled rows ────────
+
+-- Ensure another product is enabled first.
+INSERT INTO public.marketing_email_settings (product_id, enabled, provider, config)
+VALUES (
+    'phase5a-other', true, 'kit',
+    '{"namespace":"other-ns","kitFormId":"form-other","tierTagNames":[]}'::jsonb
+)
+ON CONFLICT (product_id) DO UPDATE
+  SET enabled = true,
+      config = '{"namespace":"other-ns","kitFormId":"form-other","tierTagNames":[]}'::jsonb;
+
+-- Now enable phase5a-test — should flip phase5a-other to disabled.
+PERFORM public.admin_update_marketing_email_settings(
+    'phase5a-test', true,
+    '{"namespace":"phase5a-ns","kitFormId":"form-99","tierTagNames":["pro"]}'::jsonb
+);
+
+SELECT is(
+    (SELECT enabled FROM public.marketing_email_settings WHERE product_id = 'phase5a-other'),
+    false,
+    'enabling one product disables all other enabled rows (one-enabled constraint)'
+);
+
+-- ── 15  audit row written for update ─────────────────────────────────────────
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM public.admin_audit_log
+        WHERE action = 'admin.marketing_email.settings.update'
+          AND target_type = 'marketing_email_settings'
+          AND target_id = 'phase5a-test'
+    ),
+    'update writes an audit row'
+);
+
+-- ── 16  queue stats returns zero counts when queue is empty for a fresh test key
+
+-- Insert some test queue rows.
+INSERT INTO public.marketing_email_sync_queue
+  (product_id, email, event_type, status, idempotency_key, payload)
+VALUES
+  ('phase5a-test', 'a@example.com', 'signup',       'pending',    'phase5a:pending',    '{}'::jsonb),
+  ('phase5a-test', 'b@example.com', 'signup',       'processing', 'phase5a:processing', '{}'::jsonb),
+  ('phase5a-test', 'c@example.com', 'signup',       'done',       'phase5a:done',       '{}'::jsonb),
+  ('phase5a-test', 'd@example.com', 'signup',       'failed',     'phase5a:failed',     '{}'::jsonb);
+
+SELECT is(
+    (SELECT jsonb_build_object(
+        'pending',    COUNT(*) FILTER (WHERE status = 'pending'),
+        'processing', COUNT(*) FILTER (WHERE status = 'processing'),
+        'done',       COUNT(*) FILTER (WHERE status = 'done'),
+        'failed',     COUNT(*) FILTER (WHERE status = 'failed')
+    )
+    FROM public.marketing_email_sync_queue
+    WHERE product_id = 'phase5a-test'),
+    '{"done": 1, "failed": 1, "pending": 1, "processing": 1}'::jsonb,
+    'queue stats counts match inserted rows by status'
+);
+
+-- ── 17  queue_stats function returns a jsonb with all four status keys ────────
+
+SELECT ok(
+    (
+        SELECT result ? 'pending' AND result ? 'processing' AND result ? 'done' AND result ? 'failed'
+        FROM (SELECT public.admin_get_marketing_email_queue_stats() AS result) sub
+    ),
+    'admin_get_marketing_email_queue_stats returns jsonb with pending/processing/done/failed keys'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/marketing_email_phase5a.test.sql
+++ b/supabase/tests/marketing_email_phase5a.test.sql
@@ -164,18 +164,18 @@ SELECT is(
 
 -- ── 14  one-enabled: enabling phase5a-test disables other enabled rows ────────
 
--- Seed phase5a-other as enabled via the admin RPC (direct INSERT would bypass
--- RLS but this keeps the test consistent with production access patterns).
-PERFORM public.admin_update_marketing_email_settings(
-    'phase5a-other', true,
-    '{"namespace":"other-ns","kitFormId":"form-other","tierTagNames":[]}'::jsonb
-);
-
--- Now enable phase5a-test — should flip phase5a-other to disabled.
-PERFORM public.admin_update_marketing_email_settings(
-    'phase5a-test', true,
-    '{"namespace":"phase5a-ns","kitFormId":"form-99","tierTagNames":["pro"]}'::jsonb
-);
+-- Seed phase5a-other as enabled and then enable phase5a-test via the admin RPC.
+-- PERFORM is PL/pgSQL-only, so both calls are wrapped in a DO block.
+DO $$ BEGIN
+  PERFORM public.admin_update_marketing_email_settings(
+      'phase5a-other', true,
+      '{"namespace":"other-ns","kitFormId":"form-other","tierTagNames":[]}'::jsonb
+  );
+  PERFORM public.admin_update_marketing_email_settings(
+      'phase5a-test', true,
+      '{"namespace":"phase5a-ns","kitFormId":"form-99","tierTagNames":["pro"]}'::jsonb
+  );
+END; $$;
 
 SELECT is(
     (SELECT enabled FROM public.marketing_email_settings WHERE product_id = 'phase5a-other'),

--- a/supabase/tests/marketing_email_phase5a.test.sql
+++ b/supabase/tests/marketing_email_phase5a.test.sql
@@ -190,12 +190,17 @@ SELECT is(
 
 -- ── 14  one-enabled: enabling phase5a-test disables other enabled rows ────────
 -- phase5a-other was pre-seeded as enabled (as postgres superuser, above).
--- Call the admin RPC to enable phase5a-test, which must flip phase5a-other off.
+-- Call the admin RPC as authenticated so admin_is_admin() gates correctly.
 
 SELECT public.admin_update_marketing_email_settings(
     'phase5a-test', true,
     '{"namespace":"phase5a-ns","kitFormId":"form-99","tierTagNames":["pro"]}'::jsonb
 );
+
+-- Reset to superuser for tests 14-16 assertions: marketing_email_settings,
+-- admin_audit_log, and marketing_email_sync_queue all enforce RLS that blocks
+-- direct reads by the authenticated role. Running as superuser bypasses RLS.
+RESET ROLE;
 
 SELECT is(
     (SELECT enabled FROM public.marketing_email_settings WHERE product_id = 'phase5a-other'),
@@ -232,6 +237,11 @@ SELECT is(
 );
 
 -- ── 17  queue_stats function returns a jsonb with all four status keys ────────
+-- Re-authenticate so admin_is_admin() gate on the RPC passes.
+
+SELECT set_config('request.jwt.claims',
+    '{"sub":"a5000000-0000-0000-0000-000000000001","role":"authenticated"}', true);
+SET LOCAL ROLE authenticated;
 
 SELECT ok(
     (

--- a/supabase/tests/marketing_email_phase5a.test.sql
+++ b/supabase/tests/marketing_email_phase5a.test.sql
@@ -5,7 +5,7 @@
 
 BEGIN;
 
-SELECT plan(17);
+SELECT plan(18);
 
 -- ── Admin user seeding ───────────────────────────────────────────────────────
 -- All RPCs are admin_is_admin()-gated; seed a test admin user and set JWT claims
@@ -24,6 +24,19 @@ END; $$;
 INSERT INTO public.admin_users (user_id)
 VALUES ('a5000000-0000-0000-0000-000000000001')
 ON CONFLICT (user_id) DO UPDATE SET revoked_at = NULL;
+
+-- ── Non-admin user pre-seed ──────────────────────────────────────────────────
+-- Seed a user who is NOT in admin_users; used for test 18.
+
+DO $$ BEGIN
+  INSERT INTO auth.users (id, instance_id, email, encrypted_password, email_confirmed_at,
+      raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role)
+  VALUES ('a5000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000000',
+      'phase5a-nonadmin@example.com', crypt('pw', gen_salt('bf')), now(),
+      '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+      now(), now(), 'authenticated', 'authenticated')
+  ON CONFLICT (id) DO NOTHING;
+END; $$;
 
 -- ── Test 14 pre-seed: insert phase5a-other as enabled ───────────────────────
 -- Direct INSERT runs here as the postgres superuser (before SET LOCAL ROLE),
@@ -249,6 +262,20 @@ SELECT ok(
         FROM (SELECT public.admin_get_marketing_email_queue_stats() AS result) sub
     ),
     'admin_get_marketing_email_queue_stats returns jsonb with pending/processing/done/failed keys'
+);
+
+-- ── 18  non-admin user gets not_found ────────────────────────────────────────
+-- Switch JWT to a user not in admin_users; admin RPCs must return not_found.
+-- Pattern from waitlist.test.sql lines 114-122.
+
+SELECT set_config('request.jwt.claims',
+    '{"sub":"a5000000-0000-0000-0000-000000000002","role":"authenticated"}', true);
+SET LOCAL ROLE authenticated;
+
+SELECT is(
+    public.admin_get_marketing_email_settings('phase5a-test')->>'error',
+    'not_found',
+    'non-admin user gets not_found from admin_get_marketing_email_settings'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/marketing_email_phase5a.test.sql
+++ b/supabase/tests/marketing_email_phase5a.test.sql
@@ -7,6 +7,28 @@ BEGIN;
 
 SELECT plan(17);
 
+-- ── Admin user seeding ───────────────────────────────────────────────────────
+-- All RPCs are admin_is_admin()-gated; seed a test admin user and set JWT claims
+-- so that authenticated calls pass the gate. Pattern from admin.test.sql.
+
+DO $$ BEGIN
+  INSERT INTO auth.users (id, instance_id, email, encrypted_password, email_confirmed_at,
+      raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role)
+  VALUES ('a5000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000000',
+      'phase5a-admin@example.com', crypt('pw', gen_salt('bf')), now(),
+      '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+      now(), now(), 'authenticated', 'authenticated')
+  ON CONFLICT (id) DO NOTHING;
+END; $$;
+
+INSERT INTO public.admin_users (user_id)
+VALUES ('a5000000-0000-0000-0000-000000000001')
+ON CONFLICT (user_id) DO UPDATE SET revoked_at = NULL;
+
+SELECT set_config('request.jwt.claims',
+    '{"sub":"a5000000-0000-0000-0000-000000000001","role":"authenticated"}', true);
+SET LOCAL ROLE authenticated;
+
 -- ── 1  admin_get_marketing_email_settings function exists ────────────────────
 
 SELECT ok(
@@ -182,10 +204,10 @@ SELECT ok(
 INSERT INTO public.marketing_email_sync_queue
   (product_id, email, event_type, status, idempotency_key, payload)
 VALUES
-  ('phase5a-test', 'a@example.com', 'signup',       'pending',    'phase5a:pending',    '{}'::jsonb),
-  ('phase5a-test', 'b@example.com', 'signup',       'processing', 'phase5a:processing', '{}'::jsonb),
-  ('phase5a-test', 'c@example.com', 'signup',       'done',       'phase5a:done',       '{}'::jsonb),
-  ('phase5a-test', 'd@example.com', 'signup',       'failed',     'phase5a:failed',     '{}'::jsonb);
+  ('phase5a-test', 'a@example.com', 'user.signed_up', 'pending',    'phase5a:pending',    '{}'::jsonb),
+  ('phase5a-test', 'b@example.com', 'user.signed_up', 'processing', 'phase5a:processing', '{}'::jsonb),
+  ('phase5a-test', 'c@example.com', 'user.signed_up', 'done',       'phase5a:done',       '{}'::jsonb),
+  ('phase5a-test', 'd@example.com', 'user.signed_up', 'failed',     'phase5a:failed',     '{}'::jsonb);
 
 SELECT is(
     (SELECT jsonb_build_object(

--- a/supabase/tests/marketing_email_phase5a.test.sql
+++ b/supabase/tests/marketing_email_phase5a.test.sql
@@ -164,15 +164,12 @@ SELECT is(
 
 -- ── 14  one-enabled: enabling phase5a-test disables other enabled rows ────────
 
--- Ensure another product is enabled first.
-INSERT INTO public.marketing_email_settings (product_id, enabled, provider, config)
-VALUES (
-    'phase5a-other', true, 'kit',
+-- Seed phase5a-other as enabled via the admin RPC (direct INSERT would bypass
+-- RLS but this keeps the test consistent with production access patterns).
+PERFORM public.admin_update_marketing_email_settings(
+    'phase5a-other', true,
     '{"namespace":"other-ns","kitFormId":"form-other","tierTagNames":[]}'::jsonb
-)
-ON CONFLICT (product_id) DO UPDATE
-  SET enabled = true,
-      config = '{"namespace":"other-ns","kitFormId":"form-other","tierTagNames":[]}'::jsonb;
+);
 
 -- Now enable phase5a-test — should flip phase5a-other to disabled.
 PERFORM public.admin_update_marketing_email_settings(
@@ -198,7 +195,7 @@ SELECT ok(
     'update writes an audit row'
 );
 
--- ── 16  queue stats returns zero counts when queue is empty for a fresh test key
+-- ── 16  queue stats counts match inserted rows by status ─────────────────────
 
 -- Insert some test queue rows.
 INSERT INTO public.marketing_email_sync_queue

--- a/supabase/tests/marketing_email_phase5a.test.sql
+++ b/supabase/tests/marketing_email_phase5a.test.sql
@@ -25,6 +25,34 @@ INSERT INTO public.admin_users (user_id)
 VALUES ('a5000000-0000-0000-0000-000000000001')
 ON CONFLICT (user_id) DO UPDATE SET revoked_at = NULL;
 
+-- ── Test 14 pre-seed: insert phase5a-other as enabled ───────────────────────
+-- Direct INSERT runs here as the postgres superuser (before SET LOCAL ROLE),
+-- so it bypasses RLS. After the role switch, only SECURITY DEFINER RPCs can
+-- write to marketing_email_settings.
+
+DELETE FROM public.marketing_email_settings WHERE product_id IN ('phase5a-test', 'phase5a-other');
+
+INSERT INTO public.marketing_email_settings (product_id, enabled, provider, config)
+VALUES (
+    'phase5a-other', true, 'kit',
+    '{"namespace":"other-ns","kitFormId":"form-other","tierTagNames":[]}'::jsonb
+);
+
+-- ── Test 16 pre-seed: insert queue rows ─────────────────────────────────────
+-- marketing_email_sync_queue also enforces RLS for the authenticated role.
+-- Insert the test rows now while still running as postgres superuser.
+
+INSERT INTO public.marketing_email_sync_queue
+  (product_id, email, event_type, status, idempotency_key, payload)
+VALUES
+  ('phase5a-test', 'a@example.com', 'user.signed_up', 'pending',    'phase5a:pending',    '{}'::jsonb),
+  ('phase5a-test', 'b@example.com', 'user.signed_up', 'processing', 'phase5a:processing', '{}'::jsonb),
+  ('phase5a-test', 'c@example.com', 'user.signed_up', 'done',       'phase5a:done',       '{}'::jsonb),
+  ('phase5a-test', 'd@example.com', 'user.signed_up', 'failed',     'phase5a:failed',     '{}'::jsonb)
+ON CONFLICT (idempotency_key) DO NOTHING;
+
+-- ── Switch to authenticated admin role ───────────────────────────────────────
+
 SELECT set_config('request.jwt.claims',
     '{"sub":"a5000000-0000-0000-0000-000000000001","role":"authenticated"}', true);
 SET LOCAL ROLE authenticated;
@@ -63,8 +91,6 @@ SELECT ok(
 );
 
 -- ── 4  get returns ok=true, settings=null when no row exists ─────────────────
-
-DELETE FROM public.marketing_email_settings WHERE product_id = 'phase5a-test';
 
 SELECT is(
     public.admin_get_marketing_email_settings('phase5a-test'),
@@ -163,19 +189,13 @@ SELECT is(
 );
 
 -- ── 14  one-enabled: enabling phase5a-test disables other enabled rows ────────
+-- phase5a-other was pre-seeded as enabled (as postgres superuser, above).
+-- Call the admin RPC to enable phase5a-test, which must flip phase5a-other off.
 
--- Seed phase5a-other as enabled and then enable phase5a-test via the admin RPC.
--- PERFORM is PL/pgSQL-only, so both calls are wrapped in a DO block.
-DO $$ BEGIN
-  PERFORM public.admin_update_marketing_email_settings(
-      'phase5a-other', true,
-      '{"namespace":"other-ns","kitFormId":"form-other","tierTagNames":[]}'::jsonb
-  );
-  PERFORM public.admin_update_marketing_email_settings(
-      'phase5a-test', true,
-      '{"namespace":"phase5a-ns","kitFormId":"form-99","tierTagNames":["pro"]}'::jsonb
-  );
-END; $$;
+SELECT public.admin_update_marketing_email_settings(
+    'phase5a-test', true,
+    '{"namespace":"phase5a-ns","kitFormId":"form-99","tierTagNames":["pro"]}'::jsonb
+);
 
 SELECT is(
     (SELECT enabled FROM public.marketing_email_settings WHERE product_id = 'phase5a-other'),
@@ -196,15 +216,7 @@ SELECT ok(
 );
 
 -- ── 16  queue stats counts match inserted rows by status ─────────────────────
-
--- Insert some test queue rows.
-INSERT INTO public.marketing_email_sync_queue
-  (product_id, email, event_type, status, idempotency_key, payload)
-VALUES
-  ('phase5a-test', 'a@example.com', 'user.signed_up', 'pending',    'phase5a:pending',    '{}'::jsonb),
-  ('phase5a-test', 'b@example.com', 'user.signed_up', 'processing', 'phase5a:processing', '{}'::jsonb),
-  ('phase5a-test', 'c@example.com', 'user.signed_up', 'done',       'phase5a:done',       '{}'::jsonb),
-  ('phase5a-test', 'd@example.com', 'user.signed_up', 'failed',     'phase5a:failed',     '{}'::jsonb);
+-- Rows were pre-seeded as postgres superuser above to bypass RLS.
 
 SELECT is(
     (SELECT jsonb_build_object(


### PR DESCRIPTION
## Summary

Fast-follow to PR #343 (Phase 5a, merged at `447673d1`). Three non-blocking improvements flagged in Brad's re-review that landed after the merge window.

- **RPC volatility** — `admin_get_marketing_email_settings` and `admin_get_marketing_email_queue_stats` changed from `STABLE` to `VOLATILE`. Both call `admin_is_admin()` which is `VOLATILE`; PostgreSQL requires the caller to be at least as volatile as the callee, and PostgREST surfaces a warning when `STABLE` functions call `VOLATILE` ones.
- **Breadcrumbs** — `AdminLayoutShell` now returns correct breadcrumb labels for `/admin/marketing-email` and `/admin/marketing-email/settings` (matched before the `/waitlist` branches so the more-specific path wins).
- **Non-admin pgTAP test (test 18)** — seeds a non-admin user as superuser before the role switch, then asserts that `admin_get_marketing_email_settings` returns `{error: not_found}` for that user. Plan bumped from 17 → 18. Pattern mirrors `waitlist.test.sql:114-122`.

## Test plan

- [x] pgTAP: `supabase/tests/marketing_email_phase5a.test.sql` — 18/18 assertions pass (was 17)
- [x] TypeScript: breadcrumb paths verified against router structure
- [ ] CI checks pass

Part of #286