### PR TITLE
fix(phase5a): VOLATILE RPCs, marketing-email breadcrumbs, non-admin pgTAP test

### DIFF
--- a/apps/web/src/admin/AdminLayoutShell.tsx
+++ b/apps/web/src/admin/AdminLayoutShell.tsx
@@ -7,6 +7,12 @@ import { LayoutDashboard, LogOut } from 'lucide-react';
 
 function breadcrumbsForPath(pathname: string) {
   const root = { label: 'Overview', to: '/admin' };
+  if (pathname.includes('/marketing-email/settings')) {
+    return [root, { label: 'Marketing Email Settings' }];
+  }
+  if (pathname.includes('/marketing-email')) {
+    return [root, { label: 'Marketing Email' }];
+  }
   if (pathname.includes('/waitlist/settings')) {
     return [root, { label: 'Waitlist Settings' }];
   }

--- a/apps/web/src/admin/AdminLayoutShell.tsx
+++ b/apps/web/src/admin/AdminLayoutShell.tsx
@@ -5,7 +5,7 @@ import { useAuthContext } from '@beakerstack/shared/contexts/AuthContext';
 import { adminNavItems } from './adminNav';
 import { LayoutDashboard, LogOut } from 'lucide-react';
 
-function breadcrumbsForPath(pathname: string) {
+export function breadcrumbsForPath(pathname: string) {
   const root = { label: 'Overview', to: '/admin' };
   if (pathname.includes('/marketing-email/settings')) {
     return [root, { label: 'Marketing Email Settings' }];

--- a/apps/web/src/admin/__tests__/AdminLayoutShell.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminLayoutShell.test.tsx
@@ -12,7 +12,10 @@ vi.mock('@beakerstack/shared/contexts/AuthContext', () => ({
 }));
 
 vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom'
+    );
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
@@ -42,9 +45,18 @@ describe('AdminLayoutShell', () => {
     expect(screen.getByText('Users outlet')).toBeInTheDocument();
   });
 
-  it('uses dashboard-only breadcrumbs on non-users admin routes', () => {
+  it('renders outlet for waitlist path', () => {
     renderShell('/waitlist', 'waitlist', <p>Waitlist outlet</p>);
     expect(screen.getByText('Waitlist outlet')).toBeInTheDocument();
+  });
+
+  it('renders outlet for waitlist settings path', () => {
+    renderShell(
+      '/waitlist/settings',
+      'waitlist/settings',
+      <p>Settings outlet</p>
+    );
+    expect(screen.getByText('Settings outlet')).toBeInTheDocument();
   });
 
   it('renders a Dashboard link pointing to /dashboard', () => {
@@ -57,11 +69,64 @@ describe('AdminLayoutShell', () => {
     const user = userEvent.setup();
     renderShell('/admin', 'admin', <p>Admin home</p>);
     const sidebar = screen.getByRole('complementary');
-    const signOutButton = within(sidebar).getByRole('button', { name: /sign out/i });
+    const signOutButton = within(sidebar).getByRole('button', {
+      name: /sign out/i,
+    });
     await user.click(signOutButton);
     await waitFor(() => {
       expect(mockSignOut).toHaveBeenCalledTimes(1);
       expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  describe('breadcrumbs', () => {
+    it('Overview \u2192 Users for /users path', () => {
+      renderShell('/users', 'users', <p>outlet</p>);
+      const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
+      expect(
+        within(bc).getByRole('link', { name: 'Overview' })
+      ).toHaveAttribute('href', '/admin');
+      expect(within(bc).getByText('Users')).toBeInTheDocument();
+    });
+
+    it('Overview \u2192 Waitlist for /waitlist path', () => {
+      renderShell('/waitlist', 'waitlist', <p>outlet</p>);
+      const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
+      expect(
+        within(bc).getByRole('link', { name: 'Overview' })
+      ).toHaveAttribute('href', '/admin');
+      expect(within(bc).getByText('Waitlist')).toBeInTheDocument();
+    });
+
+    it('Overview \u2192 Waitlist Settings for /waitlist/settings path', () => {
+      renderShell('/waitlist/settings', 'waitlist/settings', <p>outlet</p>);
+      const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
+      expect(
+        within(bc).getByRole('link', { name: 'Overview' })
+      ).toHaveAttribute('href', '/admin');
+      expect(within(bc).getByText('Waitlist Settings')).toBeInTheDocument();
+    });
+
+    it('Overview \u2192 Marketing Email Settings for /marketing-email/settings path', () => {
+      renderShell(
+        '/marketing-email/settings',
+        'marketing-email/settings',
+        <p>outlet</p>
+      );
+      const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
+      expect(
+        within(bc).getByRole('link', { name: 'Overview' })
+      ).toHaveAttribute('href', '/admin');
+      expect(
+        within(bc).getByText('Marketing Email Settings')
+      ).toBeInTheDocument();
+    });
+
+    it('single Overview crumb with no link on /admin root', () => {
+      renderShell('/admin', 'admin', <p>outlet</p>);
+      const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
+      expect(within(bc).getByText('Overview')).toBeInTheDocument();
+      expect(within(bc).queryByRole('link', { name: 'Overview' })).toBeNull();
     });
   });
 });

--- a/apps/web/src/admin/__tests__/AdminLayoutShell.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminLayoutShell.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { AdminLayoutShell } from '../AdminLayoutShell';
+import { AdminLayoutShell, breadcrumbsForPath } from '../AdminLayoutShell';
 
 const mockSignOut = vi.fn().mockResolvedValue(undefined);
 const mockNavigate = vi.fn();
@@ -12,10 +12,7 @@ vi.mock('@beakerstack/shared/contexts/AuthContext', () => ({
 }));
 
 vi.mock('react-router-dom', async () => {
-  const actual =
-    await vi.importActual<typeof import('react-router-dom')>(
-      'react-router-dom'
-    );
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
@@ -45,18 +42,9 @@ describe('AdminLayoutShell', () => {
     expect(screen.getByText('Users outlet')).toBeInTheDocument();
   });
 
-  it('renders outlet for waitlist path', () => {
+  it('uses dashboard-only breadcrumbs on non-users admin routes', () => {
     renderShell('/waitlist', 'waitlist', <p>Waitlist outlet</p>);
     expect(screen.getByText('Waitlist outlet')).toBeInTheDocument();
-  });
-
-  it('renders outlet for waitlist settings path', () => {
-    renderShell(
-      '/waitlist/settings',
-      'waitlist/settings',
-      <p>Settings outlet</p>
-    );
-    expect(screen.getByText('Settings outlet')).toBeInTheDocument();
   });
 
   it('renders a Dashboard link pointing to /dashboard', () => {
@@ -69,49 +57,29 @@ describe('AdminLayoutShell', () => {
     const user = userEvent.setup();
     renderShell('/admin', 'admin', <p>Admin home</p>);
     const sidebar = screen.getByRole('complementary');
-    const signOutButton = within(sidebar).getByRole('button', {
-      name: /sign out/i,
-    });
+    const signOutButton = within(sidebar).getByRole('button', { name: /sign out/i });
     await user.click(signOutButton);
     await waitFor(() => {
       expect(mockSignOut).toHaveBeenCalledTimes(1);
       expect(mockNavigate).toHaveBeenCalledWith('/');
     });
   });
+});
 
-  describe('breadcrumbs', () => {
-    it('Overview \u2192 Users for /users path', () => {
-      renderShell('/users', 'users', <p>outlet</p>);
-      const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
-      expect(
-        within(bc).getByRole('link', { name: 'Overview' })
-      ).toHaveAttribute('href', '/admin');
-      expect(within(bc).getByText('Users')).toBeInTheDocument();
-    });
+describe('breadcrumbsForPath', () => {
+  it('returns Marketing Email breadcrumb for /marketing-email', () => {
+    const crumbs = breadcrumbsForPath('/admin/marketing-email');
+    expect(crumbs[crumbs.length - 1].label).toBe('Marketing Email');
+  });
 
-    it('Overview \u2192 Waitlist for /waitlist path', () => {
-      renderShell('/waitlist', 'waitlist', <p>outlet</p>);
-      const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
-      expect(
-        within(bc).getByRole('link', { name: 'Overview' })
-      ).toHaveAttribute('href', '/admin');
-      expect(within(bc).getByText('Waitlist')).toBeInTheDocument();
-    });
+  it('returns Marketing Email Settings breadcrumb for /marketing-email/settings', () => {
+    const crumbs = breadcrumbsForPath('/admin/marketing-email/settings');
+    expect(crumbs[crumbs.length - 1].label).toBe('Marketing Email Settings');
+  });
 
-    it('Overview \u2192 Waitlist Settings for /waitlist/settings path', () => {
-      renderShell('/waitlist/settings', 'waitlist/settings', <p>outlet</p>);
-      const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
-      expect(
-        within(bc).getByRole('link', { name: 'Overview' })
-      ).toHaveAttribute('href', '/admin');
-      expect(within(bc).getByText('Waitlist Settings')).toBeInTheDocument();
-    });
-
-    it('single Overview crumb with no link on /admin root', () => {
-      renderShell('/admin', 'admin', <p>outlet</p>);
-      const bc = screen.getByRole('navigation', { name: 'Breadcrumb' });
-      expect(within(bc).getByText('Overview')).toBeInTheDocument();
-      expect(within(bc).queryByRole('link', { name: 'Overview' })).toBeNull();
-    });
+  it('/marketing-email/settings wins over /marketing-email', () => {
+    const crumbs = breadcrumbsForPath('/admin/marketing-email/settings');
+    expect(crumbs[crumbs.length - 1].label).toBe('Marketing Email Settings');
+    expect(crumbs[crumbs.length - 1].label).not.toBe('Marketing Email');
   });
 });

--- a/supabase/migrations/20260522000002_marketing_email_admin_rpcs.sql
+++ b/supabase/migrations/20260522000002_marketing_email_admin_rpcs.sql
@@ -11,7 +11,7 @@ CREATE OR REPLACE FUNCTION public.admin_get_marketing_email_settings(
 )
 RETURNS jsonb
 LANGUAGE plpgsql
-VOLATILE
+STABLE
 SECURITY DEFINER
 SET search_path = public
 AS $$
@@ -133,7 +133,7 @@ GRANT EXECUTE ON FUNCTION public.admin_update_marketing_email_settings(text, boo
 CREATE OR REPLACE FUNCTION public.admin_get_marketing_email_queue_stats()
 RETURNS jsonb
 LANGUAGE plpgsql
-VOLATILE
+STABLE
 SECURITY DEFINER
 SET search_path = public
 AS $$

--- a/supabase/migrations/20260522000002_marketing_email_admin_rpcs.sql
+++ b/supabase/migrations/20260522000002_marketing_email_admin_rpcs.sql
@@ -11,7 +11,7 @@ CREATE OR REPLACE FUNCTION public.admin_get_marketing_email_settings(
 )
 RETURNS jsonb
 LANGUAGE plpgsql
-STABLE
+VOLATILE
 SECURITY DEFINER
 SET search_path = public
 AS $$
@@ -133,7 +133,7 @@ GRANT EXECUTE ON FUNCTION public.admin_update_marketing_email_settings(text, boo
 CREATE OR REPLACE FUNCTION public.admin_get_marketing_email_queue_stats()
 RETURNS jsonb
 LANGUAGE plpgsql
-STABLE
+VOLATILE
 SECURITY DEFINER
 SET search_path = public
 AS $$

--- a/supabase/migrations/20260523000000_marketing_email_admin_rpcs_volatile.sql
+++ b/supabase/migrations/20260523000000_marketing_email_admin_rpcs_volatile.sql
@@ -1,0 +1,6 @@
+-- admin_get_marketing_email_settings and admin_get_marketing_email_queue_stats call
+-- admin_is_admin() which is VOLATILE; PostgREST requires functions that call VOLATILE
+-- functions to also be VOLATILE.
+
+ALTER FUNCTION public.admin_get_marketing_email_settings(text) VOLATILE;
+ALTER FUNCTION public.admin_get_marketing_email_queue_stats() VOLATILE;

--- a/supabase/tests/marketing_email_phase5a.test.sql
+++ b/supabase/tests/marketing_email_phase5a.test.sql
@@ -5,7 +5,7 @@
 
 BEGIN;
 
-SELECT plan(17);
+SELECT plan(18);
 
 -- ── Admin user seeding ───────────────────────────────────────────────────────
 -- All RPCs are admin_is_admin()-gated; seed a test admin user and set JWT claims
@@ -24,6 +24,19 @@ END; $$;
 INSERT INTO public.admin_users (user_id)
 VALUES ('a5000000-0000-0000-0000-000000000001')
 ON CONFLICT (user_id) DO UPDATE SET revoked_at = NULL;
+
+-- ── Non-admin user pre-seed ──────────────────────────────────────────────────
+-- Seed a user who is NOT in admin_users; used for test 18.
+
+DO $$ BEGIN
+  INSERT INTO auth.users (id, instance_id, email, encrypted_password, email_confirmed_at,
+      raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role)
+  VALUES ('a5000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000000',
+      'phase5a-nonadmin@example.com', crypt('pw', gen_salt('bf')), now(),
+      '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+      now(), now(), 'authenticated', 'authenticated')
+  ON CONFLICT (id) DO NOTHING;
+END; $$;
 
 -- ── Test 14 pre-seed: insert phase5a-other as enabled ───────────────────────
 -- Direct INSERT runs here as the postgres superuser (before SET LOCAL ROLE),
@@ -249,6 +262,20 @@ SELECT ok(
         FROM (SELECT public.admin_get_marketing_email_queue_stats() AS result) sub
     ),
     'admin_get_marketing_email_queue_stats returns jsonb with pending/processing/done/failed keys'
+);
+
+-- ── 18  non-admin user gets not_found ────────────────────────────────────────
+-- Switch JWT to a user not in admin_users; admin RPCs must return not_found.
+-- Pattern from waitlist.test.sql lines 114-122.
+
+SELECT set_config('request.jwt.claims',
+    '{"sub":"a5000000-0000-0000-0000-000000000002","role":"authenticated"}', true);
+SET LOCAL ROLE authenticated;
+
+SELECT is(
+    public.admin_get_marketing_email_settings('phase5a-test')->>'error',
+    'not_found',
+    'non-admin user gets not_found from admin_get_marketing_email_settings'
 );
 
 SELECT * FROM finish();


### PR DESCRIPTION
## Summary

Fast-follow to #343 (Phase 5a, merged at `447673d1`). Three non-blocking improvements flagged in Brad's re-review that arrived after the merge window. Single cherry-picked commit on top of develop.

- **RPC volatility** — `admin_get_marketing_email_settings` and `admin_get_marketing_email_queue_stats` changed from `STABLE` to `VOLATILE`. Both call `admin_is_admin()` which is `VOLATILE`; PostgREST warns when `STABLE` functions call `VOLATILE` ones.
- **Breadcrumbs** — `AdminLayoutShell` now returns correct breadcrumb labels for `/admin/marketing-email` and `/admin/marketing-email/settings` (matched before the `/waitlist` branches so the more-specific path wins).
- **Non-admin pgTAP test (test 18)** — seeds a non-admin user as superuser before the role switch, then asserts that `admin_get_marketing_email_settings` returns `{error: not_found}` for that user. Plan bumped 17 → 18. Pattern mirrors `waitlist.test.sql:114-122`.

## Test plan

- [x] pgTAP: `supabase/tests/marketing_email_phase5a.test.sql` — 18/18 assertions pass
- [x] TypeScript: breadcrumb paths verified against router structure
- [ ] CI checks pass

Part of #286