### PR TITLE
test(#347): assert createResendEmailAdapter and EmailSendError in barrel exports

### DIFF
--- a/packages/email/src/barrelExports.test.ts
+++ b/packages/email/src/barrelExports.test.ts
@@ -5,5 +5,7 @@ describe('package barrels', () => {
     const mod = await import('./index.js');
     expect(mod.createLogEmailAdapter).toBeTypeOf('function');
     expect(mod.renderEmailTemplate).toBeTypeOf('function');
+    expect(mod.createResendEmailAdapter).toBeTypeOf('function');
+    expect(mod.EmailSendError).toBeTypeOf('function');
   });
 });


### PR DESCRIPTION
## Summary

- Adds `expect(mod.createResendEmailAdapter).toBeTypeOf('function')` to `barrelExports.test.ts`
- Adds `expect(mod.EmailSendError).toBeTypeOf('function')` to `barrelExports.test.ts`

These were omitted when PR #344 added the Resend adapter exports. Brings the barrel test in line with other packages (`admin`, `marketing-email`, `waitlist`).

## Test plan
- [ ] `packages/email` unit tests pass
- [ ] CI green

Closes #347
