### PR TITLE
feat(#286): Phase 5b — marketing email overview card

### DIFF
--- a/apps/web/src/admin/__tests__/AdminDashboardPage.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminDashboardPage.test.tsx
@@ -7,18 +7,28 @@ import * as statsModule from '../hooks/useAdminOverviewStats';
 vi.mock('../hooks/useAdminOverviewStats');
 const mockUseStats = vi.mocked(statsModule.useAdminOverviewStats);
 
+const meSettings = {
+  product_id: 'test-product',
+  enabled: true,
+  provider: 'kit' as const,
+  config: { namespace: 'ns', kitFormId: 'form-1', tierTagNames: [] },
+};
+
+const defaultStats = {
+  usersTotal: 5,
+  waitlistPending: 2,
+  signupMode: 'open' as const,
+  marketingEmail: null,
+  loading: false,
+  error: null,
+};
+
 describe('AdminDashboardPage', () => {
   beforeEach(() => {
-    mockUseStats.mockReturnValue({
-      usersTotal: 5,
-      waitlistPending: 2,
-      signupMode: 'open',
-      loading: false,
-      error: null,
-    });
+    mockUseStats.mockReturnValue(defaultStats);
   });
 
-  it('renders overview heading and all three card links', () => {
+  it('renders overview heading and all four card links', () => {
     render(
       <MemoryRouter>
         <AdminDashboardPage />
@@ -32,15 +42,15 @@ describe('AdminDashboardPage', () => {
     expect(hrefs).toContain('/admin/users');
     expect(hrefs).toContain('/admin/waitlist');
     expect(hrefs).toContain('/admin/waitlist/settings');
+    expect(hrefs).toContain('/admin/marketing-email/settings');
   });
 
   it('displays live stats from the hook', () => {
     mockUseStats.mockReturnValue({
+      ...defaultStats,
       usersTotal: 42,
       waitlistPending: 7,
       signupMode: 'invite_only',
-      loading: false,
-      error: null,
     });
     render(
       <MemoryRouter>
@@ -54,19 +64,144 @@ describe('AdminDashboardPage', () => {
 
   it('shows em-dash for stats while loading', () => {
     mockUseStats.mockReturnValue({
+      ...defaultStats,
       usersTotal: null,
       waitlistPending: null,
       signupMode: null,
       loading: true,
-      error: null,
     });
     render(
       <MemoryRouter>
         <AdminDashboardPage />
       </MemoryRouter>
     );
-    expect(screen.getByText('\u2014 total users')).toBeInTheDocument();
-    expect(screen.getByText('\u2014 pending')).toBeInTheDocument();
-    expect(screen.getAllByText('\u2014')).toHaveLength(1);
+    expect(screen.getByText('— total users')).toBeInTheDocument();
+    expect(screen.getByText('— pending')).toBeInTheDocument();
+    expect(screen.getAllByText('—')).toHaveLength(1);
+  });
+
+  it('shows "…" placeholder for marketing email while loading', () => {
+    mockUseStats.mockReturnValue({
+      ...defaultStats,
+      marketingEmail: null,
+      loading: true,
+    });
+    render(
+      <MemoryRouter>
+        <AdminDashboardPage />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('…')).toBeInTheDocument();
+  });
+
+  it('shows "Not configured" when settings is null', () => {
+    mockUseStats.mockReturnValue({
+      ...defaultStats,
+      marketingEmail: { settings: null, stats: null },
+    });
+    render(
+      <MemoryRouter>
+        <AdminDashboardPage />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Not configured')).toBeInTheDocument();
+  });
+
+  it('shows "Enabled" with no backlog', () => {
+    mockUseStats.mockReturnValue({
+      ...defaultStats,
+      marketingEmail: {
+        settings: meSettings,
+        stats: { pending: 0, processing: 0, done: 10, failed: 0 },
+      },
+    });
+    render(
+      <MemoryRouter>
+        <AdminDashboardPage />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+  });
+
+  it('shows "Disabled" with no backlog', () => {
+    mockUseStats.mockReturnValue({
+      ...defaultStats,
+      marketingEmail: {
+        settings: { ...meSettings, enabled: false },
+        stats: { pending: 0, processing: 0, done: 0, failed: 0 },
+      },
+    });
+    render(
+      <MemoryRouter>
+        <AdminDashboardPage />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+  });
+
+  it('appends pending and failed counts when non-zero', () => {
+    mockUseStats.mockReturnValue({
+      ...defaultStats,
+      marketingEmail: {
+        settings: meSettings,
+        stats: { pending: 3, processing: 0, done: 10, failed: 2 },
+      },
+    });
+    render(
+      <MemoryRouter>
+        <AdminDashboardPage />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Enabled · 3 pending · 2 failed')).toBeInTheDocument();
+  });
+
+  it('shows "Disabled · 12 pending · 2 failed" when disabled with backlog', () => {
+    mockUseStats.mockReturnValue({
+      ...defaultStats,
+      marketingEmail: {
+        settings: { ...meSettings, enabled: false },
+        stats: { pending: 12, processing: 0, done: 0, failed: 2 },
+      },
+    });
+    render(
+      <MemoryRouter>
+        <AdminDashboardPage />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Disabled · 12 pending · 2 failed')).toBeInTheDocument();
+  });
+
+  it('applies red styling when there are failures', () => {
+    mockUseStats.mockReturnValue({
+      ...defaultStats,
+      marketingEmail: {
+        settings: meSettings,
+        stats: { pending: 0, processing: 0, done: 10, failed: 2 },
+      },
+    });
+    render(
+      <MemoryRouter>
+        <AdminDashboardPage />
+      </MemoryRouter>
+    );
+    const subtitle = screen.getByText('Enabled · 2 failed');
+    expect(subtitle).toHaveClass('text-red-600');
+  });
+
+  it('uses gray styling when there are no failures', () => {
+    mockUseStats.mockReturnValue({
+      ...defaultStats,
+      marketingEmail: {
+        settings: meSettings,
+        stats: { pending: 3, processing: 0, done: 10, failed: 0 },
+      },
+    });
+    render(
+      <MemoryRouter>
+        <AdminDashboardPage />
+      </MemoryRouter>
+    );
+    const subtitle = screen.getByText('Enabled · 3 pending');
+    expect(subtitle).toHaveClass('text-gray-500');
   });
 });

--- a/apps/web/src/admin/__tests__/AdminDashboardPage.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminDashboardPage.test.tsx
@@ -12,6 +12,7 @@ const meSettings = {
   enabled: true,
   provider: 'kit' as const,
   config: { namespace: 'ns', kitFormId: 'form-1', tierTagNames: [] },
+  updated_at: '2024-01-01T00:00:00Z',
 };
 
 const defaultStats = {

--- a/apps/web/src/admin/__tests__/AdminDashboardPage.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminDashboardPage.test.tsx
@@ -95,6 +95,21 @@ describe('AdminDashboardPage', () => {
     expect(screen.getByText('…')).toBeInTheDocument();
   });
 
+  it('shows "—" for marketing email when null after load (error state)', () => {
+    mockUseStats.mockReturnValue({
+      ...defaultStats,
+      marketingEmail: null,
+      loading: false,
+    });
+    render(
+      <MemoryRouter>
+        <AdminDashboardPage />
+      </MemoryRouter>
+    );
+    // At least one '—' rendered for the marketing email error state
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(1);
+  });
+
   it('shows "Not configured" when settings is null', () => {
     mockUseStats.mockReturnValue({
       ...defaultStats,

--- a/apps/web/src/admin/__tests__/useAdminOverviewStats.test.tsx
+++ b/apps/web/src/admin/__tests__/useAdminOverviewStats.test.tsx
@@ -81,12 +81,13 @@ describe('useAdminOverviewStats', () => {
     mockGetMeStats.mockResolvedValue(meStats);
   });
 
-  it('fetches all three stats on mount', async () => {
+  it('fetches all overview stats on mount', async () => {
     const { result } = renderHook(() => useAdminOverviewStats());
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.usersTotal).toBe(18);
     expect(result.current.waitlistPending).toBe(3);
     expect(result.current.signupMode).toBe('waitlist');
+    expect(mockGetMeSettings).toHaveBeenCalledWith(expect.anything(), 'beakerstack');
     expect(result.current.error).toBeNull();
   });
 

--- a/apps/web/src/admin/__tests__/useAdminOverviewStats.test.tsx
+++ b/apps/web/src/admin/__tests__/useAdminOverviewStats.test.tsx
@@ -5,6 +5,10 @@ import {
   getAdminWaitlistSettings,
   listWaitlistEntries,
 } from '@beakerstack/waitlist';
+import {
+  getAdminMarketingEmailSettings,
+  getAdminMarketingEmailQueueStats,
+} from '@beakerstack/marketing-email';
 import { useAdminOverviewStats } from '../hooks/useAdminOverviewStats';
 
 vi.mock('@beakerstack/admin', async importOriginal => {
@@ -21,9 +25,21 @@ vi.mock('@beakerstack/waitlist', async importOriginal => {
   };
 });
 
+vi.mock('@beakerstack/marketing-email', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('@beakerstack/marketing-email')>();
+  return {
+    ...actual,
+    getAdminMarketingEmailSettings: vi.fn(),
+    getAdminMarketingEmailQueueStats: vi.fn(),
+  };
+});
+
 const mockListUsers = vi.mocked(listUsers);
 const mockListWaitlistEntries = vi.mocked(listWaitlistEntries);
 const mockGetSettings = vi.mocked(getAdminWaitlistSettings);
+const mockGetMeSettings = vi.mocked(getAdminMarketingEmailSettings);
+const mockGetMeStats = vi.mocked(getAdminMarketingEmailQueueStats);
 
 const fullSettings = {
   signup_mode: 'waitlist' as const,
@@ -34,6 +50,15 @@ const fullSettings = {
   metadata_schema: [],
   updated_at: '2024-01-01T00:00:00Z',
 };
+
+const meSettings = {
+  product_id: 'test-product',
+  enabled: true,
+  provider: 'kit' as const,
+  config: { namespace: 'ns', kitFormId: 'form-1', tierTagNames: [] },
+};
+
+const meStats = { pending: 0, processing: 0, done: 10, failed: 0 };
 
 describe('useAdminOverviewStats', () => {
   beforeEach(() => {
@@ -51,6 +76,8 @@ describe('useAdminOverviewStats', () => {
       offset: 0,
     });
     mockGetSettings.mockResolvedValue(fullSettings);
+    mockGetMeSettings.mockResolvedValue(meSettings);
+    mockGetMeStats.mockResolvedValue(meStats);
   });
 
   it('fetches all three stats on mount', async () => {
@@ -93,5 +120,32 @@ describe('useAdminOverviewStats', () => {
     expect(result.current.usersTotal).toBeNull();
     expect(result.current.waitlistPending).toBeNull();
     expect(result.current.error).toBeNull();
+  });
+
+  it('populates marketingEmail with settings and stats', async () => {
+    const stats = { pending: 2, processing: 0, done: 5, failed: 1 };
+    mockGetMeStats.mockResolvedValue(stats);
+    const { result } = renderHook(() => useAdminOverviewStats());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.marketingEmail).toEqual({
+      settings: meSettings,
+      stats,
+    });
+  });
+
+  it('sets marketingEmail.settings=null when no settings row exists', async () => {
+    mockGetMeSettings.mockResolvedValue(null);
+    const { result } = renderHook(() => useAdminOverviewStats());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.marketingEmail?.settings).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error when marketing email fetch throws', async () => {
+    mockGetMeSettings.mockRejectedValueOnce(new Error('me network error'));
+    const { result } = renderHook(() => useAdminOverviewStats());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error?.message).toBe('me network error');
+    expect(result.current.marketingEmail).toBeNull();
   });
 });

--- a/apps/web/src/admin/__tests__/useAdminOverviewStats.test.tsx
+++ b/apps/web/src/admin/__tests__/useAdminOverviewStats.test.tsx
@@ -56,6 +56,7 @@ const meSettings = {
   enabled: true,
   provider: 'kit' as const,
   config: { namespace: 'ns', kitFormId: 'form-1', tierTagNames: [] },
+  updated_at: '2024-01-01T00:00:00Z',
 };
 
 const meStats = { pending: 0, processing: 0, done: 10, failed: 0 };

--- a/apps/web/src/admin/hooks/useAdminOverviewStats.ts
+++ b/apps/web/src/admin/hooks/useAdminOverviewStats.ts
@@ -5,13 +5,26 @@ import {
   listWaitlistEntries,
   type SignupMode,
 } from '@beakerstack/waitlist';
+import {
+  getAdminMarketingEmailSettings,
+  getAdminMarketingEmailQueueStats,
+  type MarketingEmailAdminSettings,
+  type MarketingEmailQueueStats,
+} from '@beakerstack/marketing-email';
 import { supabase } from '../../lib/supabase';
 import { adminProductId } from '../adminUsageColumns';
+import { MARKETING_EMAIL_PRODUCT_ID } from '../../marketing-email/beakerstackMarketingEmailConfig';
+
+export interface MarketingEmailOverview {
+  settings: MarketingEmailAdminSettings | null;
+  stats: MarketingEmailQueueStats | null;
+}
 
 interface AdminOverviewStats {
   usersTotal: number | null;
   waitlistPending: number | null;
   signupMode: SignupMode | null;
+  marketingEmail: MarketingEmailOverview | null;
   loading: boolean;
   error: Error | null;
 }
@@ -20,6 +33,8 @@ export function useAdminOverviewStats(): AdminOverviewStats {
   const [usersTotal, setUsersTotal] = useState<number | null>(null);
   const [waitlistPending, setWaitlistPending] = useState<number | null>(null);
   const [signupMode, setSignupMode] = useState<SignupMode | null>(null);
+  const [marketingEmail, setMarketingEmail] =
+    useState<MarketingEmailOverview | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
@@ -32,12 +47,15 @@ export function useAdminOverviewStats(): AdminOverviewStats {
       listUsers(supabase, { limit: 1, offset: 0, productId: adminProductId }),
       listWaitlistEntries(supabase, { limit: 1, offset: 0, status: 'pending' }),
       getAdminWaitlistSettings(supabase),
+      getAdminMarketingEmailSettings(supabase, MARKETING_EMAIL_PRODUCT_ID),
+      getAdminMarketingEmailQueueStats(supabase),
     ])
-      .then(([usersResult, waitlistResult, settings]) => {
+      .then(([usersResult, waitlistResult, settings, meSettings, meStats]) => {
         if (cancelled) return;
         setUsersTotal(usersResult?.total ?? null);
         setWaitlistPending(waitlistResult?.total ?? null);
         setSignupMode(settings?.signup_mode ?? null);
+        setMarketingEmail({ settings: meSettings, stats: meStats });
       })
       .catch((e: unknown) => {
         if (cancelled) return;
@@ -52,5 +70,5 @@ export function useAdminOverviewStats(): AdminOverviewStats {
     };
   }, []);
 
-  return { usersTotal, waitlistPending, signupMode, loading, error };
+  return { usersTotal, waitlistPending, signupMode, marketingEmail, loading, error };
 }

--- a/apps/web/src/admin/pages/AdminDashboardPage.tsx
+++ b/apps/web/src/admin/pages/AdminDashboardPage.tsx
@@ -1,7 +1,11 @@
 import { Link } from 'react-router-dom';
-import { ClipboardList, Settings, Users } from 'lucide-react';
+import { ClipboardList, Mail, Settings, Users } from 'lucide-react';
 import { useAdminOverviewStats } from '../hooks/useAdminOverviewStats';
 import type { SignupMode } from '@beakerstack/waitlist';
+import type {
+  MarketingEmailAdminSettings,
+  MarketingEmailQueueStats,
+} from '@beakerstack/marketing-email';
 
 const SIGNUP_MODE_LABELS: Record<SignupMode, string> = {
   open: 'Open',
@@ -10,12 +14,29 @@ const SIGNUP_MODE_LABELS: Record<SignupMode, string> = {
   closed: 'Closed',
 };
 
+function marketingEmailSubtitle(
+  settings: MarketingEmailAdminSettings | null,
+  stats: MarketingEmailQueueStats | null
+): string {
+  if (!settings) return 'Not configured';
+  const parts: string[] = [settings.enabled ? 'Enabled' : 'Disabled'];
+  if (stats && stats.pending > 0) parts.push(`${stats.pending} pending`);
+  if (stats && stats.failed > 0) parts.push(`${stats.failed} failed`);
+  return parts.join(' · ');
+}
+
+const cardClass =
+  'rounded-lg border border-gray-200 bg-white p-6 shadow-sm hover:border-indigo-300 hover:shadow-md transition-shadow';
+
 export default function AdminOverviewPage() {
-  const { usersTotal, waitlistPending, signupMode, loading } =
+  const { usersTotal, waitlistPending, signupMode, marketingEmail, loading } =
     useAdminOverviewStats();
 
   const stat = (value: number | null) =>
-    loading || value === null ? '\u2014' : String(value);
+    loading || value === null ? '—' : String(value);
+
+  const hasFailed =
+    marketingEmail !== null && (marketingEmail.stats?.failed ?? 0) > 0;
 
   return (
     <div className='space-y-6'>
@@ -27,10 +48,7 @@ export default function AdminOverviewPage() {
       </div>
 
       <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
-        <Link
-          to='/admin/users'
-          className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm hover:border-indigo-300 hover:shadow-md transition-shadow'
-        >
+        <Link to='/admin/users' className={cardClass}>
           <div className='flex items-center gap-3'>
             <span className='inline-flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600'>
               <Users className='h-5 w-5' />
@@ -44,10 +62,7 @@ export default function AdminOverviewPage() {
           </div>
         </Link>
 
-        <Link
-          to='/admin/waitlist'
-          className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm hover:border-indigo-300 hover:shadow-md transition-shadow'
-        >
+        <Link to='/admin/waitlist' className={cardClass}>
           <div className='flex items-center gap-3'>
             <span className='inline-flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600'>
               <ClipboardList className='h-5 w-5' />
@@ -61,10 +76,7 @@ export default function AdminOverviewPage() {
           </div>
         </Link>
 
-        <Link
-          to='/admin/waitlist/settings'
-          className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm hover:border-indigo-300 hover:shadow-md transition-shadow'
-        >
+        <Link to='/admin/waitlist/settings' className={cardClass}>
           <div className='flex items-center gap-3'>
             <span className='inline-flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600'>
               <Settings className='h-5 w-5' />
@@ -73,8 +85,29 @@ export default function AdminOverviewPage() {
               <p className='font-semibold text-gray-900'>Waitlist Settings</p>
               <p className='text-sm text-gray-500'>
                 {loading || signupMode === null
-                  ? '\u2014'
+                  ? '—'
                   : SIGNUP_MODE_LABELS[signupMode]}
+              </p>
+            </div>
+          </div>
+        </Link>
+
+        <Link to='/admin/marketing-email/settings' className={cardClass}>
+          <div className='flex items-center gap-3'>
+            <span className='inline-flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600'>
+              <Mail className='h-5 w-5' />
+            </span>
+            <div>
+              <p className='font-semibold text-gray-900'>Marketing email</p>
+              <p
+                className={`text-sm ${hasFailed ? 'text-red-600' : 'text-gray-500'}`}
+              >
+                {marketingEmail !== null
+                  ? marketingEmailSubtitle(
+                      marketingEmail.settings,
+                      marketingEmail.stats
+                    )
+                  : '…'}
               </p>
             </div>
           </div>

--- a/apps/web/src/admin/pages/AdminDashboardPage.tsx
+++ b/apps/web/src/admin/pages/AdminDashboardPage.tsx
@@ -36,7 +36,8 @@ export default function AdminOverviewPage() {
     loading || value === null ? '—' : String(value);
 
   const hasFailed =
-    marketingEmail !== null && (marketingEmail.stats?.failed ?? 0) > 0;
+    marketingEmail?.settings != null &&
+    (marketingEmail.stats?.failed ?? 0) > 0;
 
   return (
     <div className='space-y-6'>
@@ -47,7 +48,7 @@ export default function AdminOverviewPage() {
         </p>
       </div>
 
-      <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+      <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-2'>
         <Link to='/admin/users' className={cardClass}>
           <div className='flex items-center gap-3'>
             <span className='inline-flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600'>
@@ -102,12 +103,14 @@ export default function AdminOverviewPage() {
               <p
                 className={`text-sm ${hasFailed ? 'text-red-600' : 'text-gray-500'}`}
               >
-                {marketingEmail !== null
-                  ? marketingEmailSubtitle(
-                      marketingEmail.settings,
-                      marketingEmail.stats
-                    )
-                  : '…'}
+                {loading
+                  ? '…'
+                  : marketingEmail !== null
+                    ? marketingEmailSubtitle(
+                        marketingEmail.settings,
+                        marketingEmail.stats
+                      )
+                    : '—'}
               </p>
             </div>
           </div>

--- a/packages/marketing-email/src/__tests__/marketingEmailAdminClient.test.ts
+++ b/packages/marketing-email/src/__tests__/marketingEmailAdminClient.test.ts
@@ -158,6 +158,20 @@ describe('updateAdminMarketingEmailSettings', () => {
     ).toBeNull();
   });
 
+  it('returns null when settings payload is null', async () => {
+    const sb = makeSupabase({
+      data: { ok: true, settings: null },
+      error: null,
+    });
+    expect(
+      await updateAdminMarketingEmailSettings(sb, {
+        product_id: 'beakerstack',
+        enabled: false,
+        config: { namespace: 'ns', kitFormId: 'f', tierTagNames: [] },
+      })
+    ).toBeNull();
+  });
+
   it('returns normalized settings on success', async () => {
     const sb = makeSupabase({
       data: {


### PR DESCRIPTION
## Summary

- Extends `useAdminOverviewStats` hook to fetch marketing email settings and queue stats alongside the existing users/waitlist/signup-mode fetches (single `Promise.all`, follows existing cancelled-flag pattern)
- Adds fourth card to the admin overview dashboard linking to `/admin/marketing-email/settings`
- Subtitle logic: `Not configured` → no row; `Enabled` / `Disabled` base; appends `· N pending` / `· N failed` when counts > 0
- Red (`text-red-600`) styling when `failed > 0` and settings exist, gray otherwise; `…` placeholder while loading, `—` on error
- Grid changed to `sm:grid-cols-2 lg:grid-cols-2` for clean 2×2 layout
- Exports `MarketingEmailOverview` interface from the hook for use in tests

## Test coverage

- `useAdminOverviewStats.test.tsx`: 8 cases covering all five existing stats + new `marketingEmail` field (populated, null settings, marketing email fetch error); asserts `getAdminMarketingEmailSettings` called with correct product id
- `AdminDashboardPage.test.tsx`: 12 cases covering all four cards, all subtitle variants (Not configured, Enabled, Disabled, pending/failed combos), red/gray styling, loading placeholder, and error/null-after-load state

## Test plan

- [ ] CI passes on all web package tests
- [ ] Verify `useAdminOverviewStats` hook tests: all 8 pass
- [ ] Verify `AdminDashboardPage` tests: all 12 pass
- [ ] Check existing waitlist/users card tests still pass (no regressions)

Part of #286
