### PR TITLE
fix(logger): exclude tsup.config from coverage after #357

### DIFF
--- a/packages/logger/vitest.config.ts
+++ b/packages/logger/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
         '**/*.d.ts',
         '**/dist/**',
         '**/vitest.config.*',
+        '**/tsup.config.*',
         '**/*.{test,spec}.ts',
       ],
       thresholds: {


### PR DESCRIPTION
## Summary
- Adds `**/tsup.config.*` to the logger package vitest coverage exclude list
- Restores 100% coverage after PR #357 introduced `tsup.config.ts` without updating the logger vitest config (other packages in that PR already had this exclusion)

## Test plan
- [x] `npm run test:coverage` in `packages/logger` passes at 100%