### PR TITLE
fix(edge): bundle zod in observability edge artifact for Deno deploy

### DIFF
--- a/packages/observability/tsup.config.edge.ts
+++ b/packages/observability/tsup.config.edge.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   clean: true,
   outDir: 'dist',
   external: ['@beakerstack/logger'],
+  noExternal: ['zod'],
 });

--- a/scripts/__tests__/sync-edge-shared.test.mjs
+++ b/scripts/__tests__/sync-edge-shared.test.mjs
@@ -5,6 +5,7 @@ import {
   parseManifest,
   validateImportMapEntries,
   findBareImports,
+  extractImportSpecifiers,
   isAllowedImportSpecifier,
 } from '../sync-edge-shared.mjs';
 
@@ -147,5 +148,38 @@ describe('bare import detection', () => {
   it('allows npm-prefixed specifiers', () => {
     const content = `import { z } from "npm:zod@3.22.0";`;
     assert.deepEqual(findBareImports(content), []);
+  });
+
+  it('flags side-effect bare npm imports', () => {
+    const content = `import "zod";`;
+    assert.deepEqual(findBareImports(content), ['zod']);
+  });
+
+  it('flags dynamic bare npm imports', () => {
+    const content = `const mod = await import("zod");`;
+    assert.deepEqual(findBareImports(content), ['zod']);
+  });
+
+  it('allows side-effect and dynamic npm-prefixed specifiers', () => {
+    const content = `
+      import "npm:zod@3.22.0";
+      const mod = await import('npm:zod@3.22.0');
+    `;
+    assert.deepEqual(findBareImports(content), []);
+  });
+
+  it('extracts specifiers from all supported import forms', () => {
+    const content = `
+      import { z } from "zod";
+      import "side-effect";
+      export { foo } from "./local.js";
+      const mod = import("dynamic");
+    `;
+    assert.deepEqual(extractImportSpecifiers(content), [
+      'zod',
+      './local.js',
+      'side-effect',
+      'dynamic',
+    ]);
   });
 });

--- a/scripts/__tests__/sync-edge-shared.test.mjs
+++ b/scripts/__tests__/sync-edge-shared.test.mjs
@@ -1,28 +1,58 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { topoSort, parseManifest, validateImportMapEntries } from '../sync-edge-shared.mjs';
+import {
+  topoSort,
+  parseManifest,
+  validateImportMapEntries,
+  findBareImports,
+  isAllowedImportSpecifier,
+} from '../sync-edge-shared.mjs';
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('manifest parsing', () => {
   it('parses a valid manifest', () => {
-    const manifest = parseManifest(JSON.stringify({
-      ports: [
-        { id: 'a', package: 'packages/a', entry: 'src/index.ts',
-          tsupConfig: 'tsup.config.ts', outDir: 'supabase/functions/_shared/_generated/a',
-          npmName: '@scope/a', dependsOn: [] },
-      ],
-    }));
+    const manifest = parseManifest(
+      JSON.stringify({
+        ports: [
+          {
+            id: 'a',
+            package: 'packages/a',
+            entry: 'src/index.ts',
+            tsupConfig: 'tsup.config.ts',
+            outDir: 'supabase/functions/_shared/_generated/a',
+            npmName: '@scope/a',
+            dependsOn: [],
+          },
+        ],
+      })
+    );
     assert.equal(manifest.ports.length, 1);
   });
 
   it('throws on missing ports array', () => {
-    assert.throws(() => parseManifest(JSON.stringify({})), /ports must be an array/);
+    assert.throws(
+      () => parseManifest(JSON.stringify({})),
+      /ports must be an array/
+    );
   });
 
   it('throws on port missing id', () => {
     assert.throws(
-      () => parseManifest(JSON.stringify({ ports: [{ package: 'x', entry: 'y', tsupConfig: 'z', outDir: 'o', npmName: 'n' }] })),
+      () =>
+        parseManifest(
+          JSON.stringify({
+            ports: [
+              {
+                package: 'x',
+                entry: 'y',
+                tsupConfig: 'z',
+                outDir: 'o',
+                npmName: 'n',
+              },
+            ],
+          })
+        ),
       /missing required field "id"/
     );
   });
@@ -87,5 +117,35 @@ describe('import map validation', () => {
     const imports = { '@scope/a': './a.js' };
     const missing = validateImportMapEntries(ports, imports);
     assert.deepEqual(missing, ['@scope/missing']);
+  });
+});
+
+describe('bare import detection', () => {
+  it('allows workspace, relative, and npm specifiers', () => {
+    assert.equal(isAllowedImportSpecifier('./schema.js'), true);
+    assert.equal(isAllowedImportSpecifier('../logger/index.js'), true);
+    assert.equal(isAllowedImportSpecifier('@beakerstack/logger'), true);
+    assert.equal(isAllowedImportSpecifier('npm:zod@3.22.0'), true);
+    assert.equal(isAllowedImportSpecifier('jsr:@std/path'), true);
+    assert.equal(isAllowedImportSpecifier('https://example.com/mod.js'), true);
+  });
+
+  it('returns no violations for clean generated-style imports', () => {
+    const content = `
+      import { setupLogging } from "@beakerstack/logger";
+      import { validateConfig } from "./schema.js";
+      export { foo } from "../utils.js";
+    `;
+    assert.deepEqual(findBareImports(content), []);
+  });
+
+  it('flags bare npm specifiers', () => {
+    const content = `import { z } from "zod";`;
+    assert.deepEqual(findBareImports(content), ['zod']);
+  });
+
+  it('allows npm-prefixed specifiers', () => {
+    const content = `import { z } from "npm:zod@3.22.0";`;
+    assert.deepEqual(findBareImports(content), []);
   });
 });

--- a/scripts/sync-edge-shared.mjs
+++ b/scripts/sync-edge-shared.mjs
@@ -3,7 +3,7 @@
 // Run: node scripts/sync-edge-shared.mjs
 // See: supabase/functions/edge-shared.manifest.json
 
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { execSync } from 'child_process';
 import { resolve, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
@@ -25,7 +25,8 @@ function die(msg) {
 
 export function parseManifest(json) {
   const data = JSON.parse(json);
-  if (!Array.isArray(data.ports)) throw new Error('manifest.ports must be an array');
+  if (!Array.isArray(data.ports))
+    throw new Error('manifest.ports must be an array');
   for (const p of data.ports) {
     if (!p.id) throw new Error('port missing required field "id"');
     if (!p.package) throw new Error(`port ${p.id} missing "package"`);
@@ -89,7 +90,8 @@ function buildPort(port) {
   }
 
   const tsupBin = resolve(ROOT, 'node_modules/.bin/tsup');
-  if (!existsSync(tsupBin)) die('tsup not found in node_modules/.bin/tsup — run npm install');
+  if (!existsSync(tsupBin))
+    die('tsup not found in node_modules/.bin/tsup — run npm install');
 
   log(`Building ${port.id} (${port.package}) → ${port.outDir}`);
 
@@ -114,7 +116,6 @@ export function validateImportMapEntries(ports, imports) {
   return missing;
 }
 
-
 function validateImportMap(ports) {
   const denoJsonPath = resolve(ROOT, 'supabase/functions/deno.json');
   if (!existsSync(denoJsonPath)) {
@@ -135,7 +136,10 @@ function validateImportMap(ports) {
   for (const port of ports) {
     const entryBase = basename(port.entry, '.ts') + '.js';
     const expectedRelPath =
-      './' + port.outDir.replace(/^supabase\/functions\//, '') + '/' + entryBase;
+      './' +
+      port.outDir.replace(/^supabase\/functions\//, '') +
+      '/' +
+      entryBase;
 
     const mappedPath = imports[port.npmName];
     if (!mappedPath) {
@@ -164,8 +168,78 @@ function validateImportMap(ports) {
     }
   }
 
-  if (errors > 0) die(`${errors} import map validation error(s) — check output above`);
+  if (errors > 0)
+    die(`${errors} import map validation error(s) — check output above`);
   log('Import map validated OK');
+}
+
+// ── Bare import validation ────────────────────────────────────────────────────
+
+const IMPORT_FROM_REGEX = /\bfrom\s+(['"])([^'"]+)\1/g;
+
+/** Returns true when a module specifier is allowed in generated edge bundles. */
+export function isAllowedImportSpecifier(specifier) {
+  return (
+    specifier.startsWith('./') ||
+    specifier.startsWith('../') ||
+    specifier.startsWith('@beakerstack/') ||
+    specifier.startsWith('npm:') ||
+    specifier.startsWith('jsr:') ||
+    specifier.startsWith('http://') ||
+    specifier.startsWith('https://')
+  );
+}
+
+/** Pure helper: returns bare npm specifiers left unresolved in generated JS. */
+export function findBareImports(fileContent) {
+  const violations = [];
+  let match;
+  IMPORT_FROM_REGEX.lastIndex = 0;
+  while ((match = IMPORT_FROM_REGEX.exec(fileContent)) !== null) {
+    const specifier = match[2];
+    if (!isAllowedImportSpecifier(specifier)) {
+      violations.push(specifier);
+    }
+  }
+  return violations;
+}
+
+function walkJsFiles(dir) {
+  const files = [];
+  if (!existsSync(dir)) return files;
+  for (const entry of readdirSync(dir)) {
+    const full = resolve(dir, entry);
+    if (statSync(full).isDirectory()) {
+      files.push(...walkJsFiles(full));
+    } else if (entry.endsWith('.js')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function validateGeneratedBareImports() {
+  const generatedDir = resolve(ROOT, 'supabase/functions/_shared/_generated');
+  const jsFiles = walkJsFiles(generatedDir);
+  let errors = 0;
+
+  for (const filePath of jsFiles) {
+    const content = readFileSync(filePath, 'utf8');
+    const bareImports = findBareImports(content);
+    for (const specifier of bareImports) {
+      console.error(
+        `[sync-edge-shared] ERROR: bare import "${specifier}" in ${filePath.replace(ROOT + '/', '')} — bundle via tsup noExternal or add npm: specifier`
+      );
+      errors++;
+    }
+  }
+
+  if (errors > 0) {
+    die(
+      `${errors} bare import error(s) in generated edge bundles — check output above`
+    );
+  }
+  log('Generated bundle imports validated OK');
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────
@@ -192,6 +266,7 @@ if (__filename === process.argv[1]) {
   }
 
   validateImportMap(ports);
+  validateGeneratedBareImports();
 
   log(`Done. ${ordered.length} port(s) built successfully.`);
 }

--- a/scripts/sync-edge-shared.mjs
+++ b/scripts/sync-edge-shared.mjs
@@ -175,7 +175,31 @@ function validateImportMap(ports) {
 
 // ── Bare import validation ────────────────────────────────────────────────────
 
+/** Static import/export … from "spec" forms. */
 const IMPORT_FROM_REGEX = /\bfrom\s+(['"])([^'"]+)\1/g;
+/** Side-effect imports: import "spec"; */
+const IMPORT_SIDE_EFFECT_REGEX = /\bimport\s+(['"])([^'"]+)\1\s*;/g;
+/** Dynamic imports: import("spec") */
+const IMPORT_DYNAMIC_REGEX = /\bimport\s*\(\s*(['"])([^'"]+)\1\s*\)/g;
+
+const IMPORT_SPECIFIER_PATTERNS = [
+  IMPORT_FROM_REGEX,
+  IMPORT_SIDE_EFFECT_REGEX,
+  IMPORT_DYNAMIC_REGEX,
+];
+
+/** Collect module specifiers from static, side-effect, and dynamic import syntax. */
+export function extractImportSpecifiers(fileContent) {
+  const specifiers = [];
+  for (const pattern of IMPORT_SPECIFIER_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match;
+    while ((match = pattern.exec(fileContent)) !== null) {
+      specifiers.push(match[2]);
+    }
+  }
+  return specifiers;
+}
 
 /** Returns true when a module specifier is allowed in generated edge bundles. */
 export function isAllowedImportSpecifier(specifier) {
@@ -193,10 +217,7 @@ export function isAllowedImportSpecifier(specifier) {
 /** Pure helper: returns bare npm specifiers left unresolved in generated JS. */
 export function findBareImports(fileContent) {
   const violations = [];
-  let match;
-  IMPORT_FROM_REGEX.lastIndex = 0;
-  while ((match = IMPORT_FROM_REGEX.exec(fileContent)) !== null) {
-    const specifier = match[2];
+  for (const specifier of extractImportSpecifiers(fileContent)) {
     if (!isAllowedImportSpecifier(specifier)) {
       violations.push(specifier);
     }

--- a/supabase/functions/README.md
+++ b/supabase/functions/README.md
@@ -65,6 +65,7 @@ npm run functions:sync-shared
 ```
 
 Run this before:
+
 - `supabase functions serve` (local dev and CI)
 - `supabase functions deploy` (handled automatically by CI deploy jobs)
 
@@ -74,3 +75,14 @@ which have no `dev:*` script, run `npm run functions:sync-shared` manually.
 Import map: `supabase/functions/deno.json`
 Manifest: `supabase/functions/edge-shared.manifest.json`
 Sync script: `scripts/sync-edge-shared.mjs`
+
+### Dependency rules for manifest ports
+
+Generated edge bundles use a two-tier model:
+
+- **`@beakerstack/*` workspace packages** — externalized in tsup and resolved via `deno.json` import map (shared graph across functions).
+- **Third-party npm dependencies** — bundled into the generated artifact via tsup `noExternal` (or equivalent). Do not leave bare specifiers like `"zod"` in generated `.js` files.
+
+When adding a new manifest port, check the tsup config: if the package has npm runtime deps, add them to `noExternal` so they are inlined. The sync script scans `_shared/_generated/` and fails on unmapped bare imports.
+
+**Troubleshooting deploy bundling errors:** If deploy fails with `Relative import path "X" not prefixed with / or ./ or ../ and not in import map`, run `npm run functions:sync-shared` locally and inspect generated files under `_shared/_generated/` for bare npm imports.


### PR DESCRIPTION
## Summary
- Fixes P0 staging deploy failure introduced by PR #357: generated `observability/edge.js` left a bare `import { z } from "zod"` that Deno 2 cannot resolve during `supabase functions deploy`
- Bundles `zod` into the observability edge artifact via tsup `noExternal`
- Adds a sync-time guard that fails CI/deploy when generated edge bundles contain unmapped bare npm imports
- Documents the two-tier edge dependency model (`@beakerstack/*` → import map; npm deps → bundled)

## Test plan
- [x] `npm run functions:sync-shared` — passes, no bare `zod` import in generated observability bundle
- [x] `node --test scripts/__tests__/sync-edge-shared.test.mjs` — 14/14 pass
- [x] `npm run lint:supabase` — clean
- [ ] Merge to `develop` and confirm Deploy Staging succeeds (`waitlist-ops`, `kit-sync` deploy)