### PR TITLE
Fix adopter DB deploy IPv6 failure in CI

### DIFF
--- a/adopter/db/README.md
+++ b/adopter/db/README.md
@@ -34,4 +34,4 @@ A `9*` prefix is **optional** for adopter migrations (visual hint only). Templat
 4. `PRODUCTION_SUPABASE_PROJECT_REF` + `PRODUCTION_SUPABASE_DB_PASSWORD`
 5. Local fallback after `supabase link`: `supabase/.temp/project-ref` + `SUPABASE_DB_PASSWORD` (generic var only — not staging/production variants)
 
-Deploy workflows inject the staging/production project ref and DB password secrets on the adopter migration step. Run after `supabase db push` in deploy workflows.
+Deploy workflows inject the staging/production project ref and DB password secrets on the adopter migration step (after `supabase link`, which writes `supabase/.temp/pooler-url`). When that pooler template exists, `--linked` uses the Supavisor session pooler (IPv4-compatible) instead of the direct `db.{ref}.supabase.co` host. Run after `supabase db push` in deploy workflows.

--- a/adopter/db/README.md
+++ b/adopter/db/README.md
@@ -30,8 +30,9 @@ A `9*` prefix is **optional** for adopter migrations (visual hint only). Templat
 
 1. `DATABASE_URL` — explicit override
 2. `SUPABASE_PROJECT_REF` + `SUPABASE_DB_PASSWORD`
-3. `STAGING_SUPABASE_PROJECT_REF` + `STAGING_SUPABASE_DB_PASSWORD`
-4. `PRODUCTION_SUPABASE_PROJECT_REF` + `PRODUCTION_SUPABASE_DB_PASSWORD`
-5. Local fallback after `supabase link`: `supabase/.temp/project-ref` + `SUPABASE_DB_PASSWORD` (generic var only — not staging/production variants)
+3. `SUPABASE_PREVIEW_PROJECT_REF` + `SUPABASE_PREVIEW_DB_PASSWORD`
+4. `STAGING_SUPABASE_PROJECT_REF` + `STAGING_SUPABASE_DB_PASSWORD`
+5. `PRODUCTION_SUPABASE_PROJECT_REF` + `PRODUCTION_SUPABASE_DB_PASSWORD`
+6. Local fallback after `supabase link`: `supabase/.temp/project-ref` + `SUPABASE_DB_PASSWORD` (generic var only — not staging/production/preview variants)
 
-Deploy workflows inject the staging/production project ref and DB password secrets on the adopter migration step (after `supabase link`, which writes `supabase/.temp/pooler-url`). When that pooler template exists, `--linked` uses the Supavisor session pooler (IPv4-compatible) instead of the direct `db.{ref}.supabase.co` host. Run after `supabase db push` in deploy workflows.
+Deploy workflows inject the staging/production project ref and DB password secrets on the adopter migration step (after `supabase link`, which writes `supabase/.temp/pooler-url`). PR preview runs the same step from `scripts/pr-preview/reset-preview-database.sh` after Supabase reset/link (copies link artifacts into `supabase/.temp/` for pooler resolution). When that pooler template exists, `--linked` uses the Supavisor session pooler (IPv4-compatible) instead of the direct `db.{ref}.supabase.co` host. Run after `supabase db push` in deploy workflows.

--- a/docs/design/adopter-zones/db-migrations.md
+++ b/docs/design/adopter-zones/db-migrations.md
@@ -51,7 +51,7 @@ supabase db push
 npm run db:apply-adopter -- --linked
 ```
 
-`--linked` resolves the remote Postgres URL from `DATABASE_URL` or paired project-ref + DB password env vars (`SUPABASE_*`, `STAGING_SUPABASE_*`, `PRODUCTION_SUPABASE_*`). Deploy workflows already inject the staging/production secrets on this step.
+`--linked` resolves the remote Postgres URL from `DATABASE_URL` or paired project-ref + DB password env vars (`SUPABASE_*`, `STAGING_SUPABASE_*`, `PRODUCTION_SUPABASE_*`). When `supabase link` has written `supabase/.temp/pooler-url`, the resolver uses the Supavisor session pooler (IPv4-compatible on GitHub Actions) instead of direct `db.{ref}.supabase.co`. Deploy workflows already inject the staging/production secrets on this step.
 
 ## Type generation
 

--- a/docs/design/adopter-zones/db-migrations.md
+++ b/docs/design/adopter-zones/db-migrations.md
@@ -51,7 +51,7 @@ supabase db push
 npm run db:apply-adopter -- --linked
 ```
 
-`--linked` resolves the remote Postgres URL from `DATABASE_URL` or paired project-ref + DB password env vars (`SUPABASE_*`, `STAGING_SUPABASE_*`, `PRODUCTION_SUPABASE_*`). When `supabase link` has written `supabase/.temp/pooler-url`, the resolver uses the Supavisor session pooler (IPv4-compatible on GitHub Actions) instead of direct `db.{ref}.supabase.co`. Deploy workflows already inject the staging/production secrets on this step.
+`--linked` resolves the remote Postgres URL from `DATABASE_URL` or paired project-ref + DB password env vars (`SUPABASE_*`, `SUPABASE_PREVIEW_*`, `STAGING_SUPABASE_*`, `PRODUCTION_SUPABASE_*`). When `supabase link` has written `supabase/.temp/pooler-url`, the resolver uses the Supavisor session pooler (IPv4-compatible on GitHub Actions) instead of direct `db.{ref}.supabase.co`. Deploy workflows inject staging/production secrets on this step; PR preview runs it from `reset-preview-database.sh` after template migrations (and after every full reset, since reset drops the `app` schema).
 
 ## Type generation
 

--- a/docs/pr-preview-setup.md
+++ b/docs/pr-preview-setup.md
@@ -157,9 +157,10 @@ Triggered for `opened`, `reopened`, `synchronize`, `ready_for_review`.
    - Syncs shared error page and exports outputs.
 4. Run `scripts/pr-preview/reset-preview-database.sh`
    - Links to preview Supabase project.
-   - Resets migrations + seed data.
-   - Generates TypeScript types for all packages.
-   - Uses `--skip-if-unchanged` to avoid contacting Supabase when no migrations changed.
+   - Resets template migrations + seed data when `supabase/` changed.
+   - Applies adopter migrations (`npm run db:apply-adopter -- --linked`) when `adopter/db/` changed or after a full reset.
+   - Generates TypeScript types for all packages when template migrations ran.
+   - Uses `--skip-if-unchanged` to avoid contacting Supabase when neither `supabase/` nor `adopter/db/` changed.
 5. Deploy billing Edge functions for preview:
    - Sets preview project Edge secrets (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`).
    - Deploys `stripe-webhook` and `billing-stripe`.
@@ -188,13 +189,13 @@ Triggered when a PR is `closed` (merged or abandoned).
 
 ## Helper Scripts
 
-| Script                      | Purpose                                                              |
-| --------------------------- | -------------------------------------------------------------------- |
-| `bootstrap-aws-stack.sh`    | Deploys/validates CloudFormation stack and exports outputs.          |
-| `reset-preview-database.sh` | Resets Supabase preview project (migrations, seeds, types).          |
-| `deploy-web.sh`             | Builds web app, uploads to S3, invalidates CloudFront, verifies URL. |
-| `deploy-mobile.sh`          | Publishes Expo EAS update to PR-specific channel.                    |
-| `teardown.sh`               | Deletes S3 prefix, CloudFront cache, Supabase schema, Expo channel.  |
+| Script                      | Purpose                                                                                  |
+| --------------------------- | ---------------------------------------------------------------------------------------- |
+| `bootstrap-aws-stack.sh`    | Deploys/validates CloudFormation stack and exports outputs.                              |
+| `reset-preview-database.sh` | Resets Supabase preview project (template migrations, adopter migrations, seeds, types). |
+| `deploy-web.sh`             | Builds web app, uploads to S3, invalidates CloudFront, verifies URL.                     |
+| `deploy-mobile.sh`          | Publishes Expo EAS update to PR-specific channel.                                        |
+| `teardown.sh`               | Deletes S3 prefix, CloudFront cache, Supabase schema, Expo channel.                      |
 
 All scripts support `--dry-run` and write outputs to `GITHUB_OUTPUT` (CI) or
 `--env-file` (local usage).

--- a/scripts/__tests__/resolve-adopter-database-url.test.mjs
+++ b/scripts/__tests__/resolve-adopter-database-url.test.mjs
@@ -42,6 +42,46 @@ test('resolveLinkedCredentials prefers generic env vars', () => {
   });
 });
 
+test('resolveLinkedCredentials uses preview env vars', () => {
+  const creds = resolveLinkedCredentials({
+    SUPABASE_PREVIEW_PROJECT_REF: 'preview-ref',
+    SUPABASE_PREVIEW_DB_PASSWORD: 'preview-pass',
+  });
+  assert.deepEqual(creds, {
+    projectRef: 'preview-ref',
+    dbPassword: 'preview-pass',
+  });
+});
+
+test('resolveLinkedCredentials prefers generic env vars over preview', () => {
+  const creds = resolveLinkedCredentials({
+    SUPABASE_PROJECT_REF: 'generic-ref',
+    SUPABASE_DB_PASSWORD: 'generic-pass',
+    SUPABASE_PREVIEW_PROJECT_REF: 'preview-ref',
+    SUPABASE_PREVIEW_DB_PASSWORD: 'preview-pass',
+  });
+  assert.deepEqual(creds, {
+    projectRef: 'generic-ref',
+    dbPassword: 'generic-pass',
+  });
+});
+
+test('resolveAdopterDatabaseUrl linked uses preview secrets', () => {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), 'adopter-db-'));
+  const url = resolveAdopterDatabaseUrl({
+    linked: true,
+    repoRoot,
+    env: {
+      SUPABASE_PREVIEW_PROJECT_REF: 'abc123preview',
+      SUPABASE_PREVIEW_DB_PASSWORD: 'secret',
+    },
+  });
+  assert.equal(
+    url,
+    'postgresql://postgres:secret@db.abc123preview.supabase.co:5432/postgres?sslmode=require'
+  );
+});
+
 test('resolveLinkedCredentials uses staging env vars', () => {
   const creds = resolveLinkedCredentials({
     STAGING_SUPABASE_PROJECT_REF: 'staging-ref',

--- a/scripts/__tests__/resolve-adopter-database-url.test.mjs
+++ b/scripts/__tests__/resolve-adopter-database-url.test.mjs
@@ -9,6 +9,7 @@ import {
   buildLinkedConnectionUri,
   isPostgresUrl,
   isScriptMain,
+  poolerTemplateMatchesProjectRef,
   readLinkedConnectionUri,
   readPoolerUrlTemplate,
   resolveAdopterDatabaseUrl,
@@ -282,6 +283,69 @@ test('applyPoolerPassword injects password and sslmode', () => {
     url,
     'postgresql://postgres.linked-ref:p%40ss%26word@aws-1-us-east-2.pooler.supabase.com:5432/postgres?sslmode=require'
   );
+});
+
+test('applyPoolerPassword preserves postgres:// scheme from template', () => {
+  const url = applyPoolerPassword(
+    'postgres://postgres.linked-ref@aws-1-us-east-2.pooler.supabase.com:5432/postgres',
+    'secret'
+  );
+  assert.match(url, /^postgres:\/\//);
+  assert.match(url, /sslmode=require/);
+});
+
+test('applyPoolerPassword throws when pooler template is invalid', () => {
+  assert.throws(
+    () => applyPoolerPassword('not-a-url', 'secret'),
+    /Invalid pooler URL template from supabase link/
+  );
+});
+
+test('poolerTemplateMatchesProjectRef matches Supavisor username', () => {
+  assert.equal(
+    poolerTemplateMatchesProjectRef(
+      'postgresql://postgres.abc123@aws-1-us-east-2.pooler.supabase.com:5432/postgres',
+      'abc123'
+    ),
+    true
+  );
+  assert.equal(
+    poolerTemplateMatchesProjectRef(
+      'postgresql://postgres.other-ref@aws-1-us-east-2.pooler.supabase.com:5432/postgres',
+      'abc123'
+    ),
+    false
+  );
+});
+
+test('buildLinkedConnectionUri ignores stale pooler-url for a different project', () => {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), 'adopter-db-'));
+  const tempDir = path.join(repoRoot, 'supabase', '.temp');
+  mkdirSync(tempDir, { recursive: true });
+  writeFileSync(
+    path.join(tempDir, 'pooler-url'),
+    'postgresql://postgres.other-ref@aws-1-us-east-2.pooler.supabase.com:5432/postgres'
+  );
+  writeFileSync(path.join(tempDir, 'project-ref'), 'target-ref\n');
+
+  const url = buildLinkedConnectionUri(repoRoot, 'secret', 'target-ref');
+  assert.match(url, /db\.target-ref\.supabase\.co/);
+  assert.doesNotMatch(url, /pooler\.supabase\.com/);
+});
+
+test('buildLinkedConnectionUri ignores pooler when project-ref file disagrees with env ref', () => {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), 'adopter-db-'));
+  const tempDir = path.join(repoRoot, 'supabase', '.temp');
+  mkdirSync(tempDir, { recursive: true });
+  writeFileSync(
+    path.join(tempDir, 'pooler-url'),
+    'postgresql://postgres.target-ref@aws-1-us-east-2.pooler.supabase.com:5432/postgres'
+  );
+  writeFileSync(path.join(tempDir, 'project-ref'), 'stale-ref\n');
+
+  const url = buildLinkedConnectionUri(repoRoot, 'secret', 'target-ref');
+  assert.match(url, /db\.target-ref\.supabase\.co/);
+  assert.doesNotMatch(url, /pooler\.supabase\.com/);
 });
 
 test('readPoolerUrlTemplate reads supabase/.temp/pooler-url', () => {

--- a/scripts/__tests__/resolve-adopter-database-url.test.mjs
+++ b/scripts/__tests__/resolve-adopter-database-url.test.mjs
@@ -6,12 +6,15 @@ import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 import {
   assertPostgresUrl,
+  buildLinkedConnectionUri,
   isPostgresUrl,
   isScriptMain,
   readLinkedConnectionUri,
+  readPoolerUrlTemplate,
   resolveAdopterDatabaseUrl,
   resolveLinkedCredentials,
 } from '../lib/resolve-adopter-database-url.mjs';
+import { applyPoolerPassword } from '../lib/setup-supabase.mjs';
 
 test('isPostgresUrl accepts postgres and postgresql schemes', () => {
   assert.equal(isPostgresUrl('postgresql://user:pass@host:5432/db'), true);
@@ -82,8 +85,10 @@ test('resolveLinkedCredentials returns empty object when incomplete', () => {
 });
 
 test('resolveAdopterDatabaseUrl linked uses staging secrets', () => {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), 'adopter-db-'));
   const url = resolveAdopterDatabaseUrl({
     linked: true,
+    repoRoot,
     env: {
       STAGING_SUPABASE_PROJECT_REF: 'abc123staging',
       STAGING_SUPABASE_DB_PASSWORD: 'p@ss&word',
@@ -91,13 +96,38 @@ test('resolveAdopterDatabaseUrl linked uses staging secrets', () => {
   });
   assert.equal(
     url,
-    'postgresql://postgres:p%40ss%26word@db.abc123staging.supabase.co:5432/postgres'
+    'postgresql://postgres:p%40ss%26word@db.abc123staging.supabase.co:5432/postgres?sslmode=require'
+  );
+});
+
+test('resolveAdopterDatabaseUrl linked prefers Supavisor pooler URL from supabase link', () => {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), 'adopter-db-'));
+  const tempDir = path.join(repoRoot, 'supabase', '.temp');
+  mkdirSync(tempDir, { recursive: true });
+  writeFileSync(
+    path.join(tempDir, 'pooler-url'),
+    'postgresql://postgres.abc123staging@aws-1-us-east-2.pooler.supabase.com:5432/postgres\n'
+  );
+
+  const url = resolveAdopterDatabaseUrl({
+    linked: true,
+    repoRoot,
+    env: {
+      STAGING_SUPABASE_PROJECT_REF: 'abc123staging',
+      STAGING_SUPABASE_DB_PASSWORD: 'p@ss&word',
+    },
+  });
+  assert.equal(
+    url,
+    'postgresql://postgres.abc123staging:p%40ss%26word@aws-1-us-east-2.pooler.supabase.com:5432/postgres?sslmode=require'
   );
 });
 
 test('resolveAdopterDatabaseUrl linked uses production secrets', () => {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), 'adopter-db-'));
   const url = resolveAdopterDatabaseUrl({
     linked: true,
+    repoRoot,
     env: {
       PRODUCTION_SUPABASE_PROJECT_REF: 'abc123prod',
       PRODUCTION_SUPABASE_DB_PASSWORD: 'secret',
@@ -105,7 +135,7 @@ test('resolveAdopterDatabaseUrl linked uses production secrets', () => {
   });
   assert.equal(
     url,
-    'postgresql://postgres:secret@db.abc123prod.supabase.co:5432/postgres'
+    'postgresql://postgres:secret@db.abc123prod.supabase.co:5432/postgres?sslmode=require'
   );
 });
 
@@ -170,7 +200,7 @@ test('readLinkedConnectionUri uses supabase/.temp/project-ref fallback', () => {
   });
   assert.equal(
     url,
-    'postgresql://postgres:linked-pass@db.linked-ref.supabase.co:5432/postgres'
+    'postgresql://postgres:linked-pass@db.linked-ref.supabase.co:5432/postgres?sslmode=require'
   );
 });
 
@@ -199,8 +229,48 @@ test('resolveAdopterDatabaseUrl linked falls back to linked project ref file', (
   });
   assert.equal(
     url,
-    'postgresql://postgres:linked-pass@db.linked-ref.supabase.co:5432/postgres'
+    'postgresql://postgres:linked-pass@db.linked-ref.supabase.co:5432/postgres?sslmode=require'
   );
+});
+
+test('applyPoolerPassword injects password and sslmode', () => {
+  const url = applyPoolerPassword(
+    'postgresql://postgres.linked-ref@aws-1-us-east-2.pooler.supabase.com:5432/postgres',
+    'p@ss&word'
+  );
+  assert.equal(
+    url,
+    'postgresql://postgres.linked-ref:p%40ss%26word@aws-1-us-east-2.pooler.supabase.com:5432/postgres?sslmode=require'
+  );
+});
+
+test('readPoolerUrlTemplate reads supabase/.temp/pooler-url', () => {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), 'adopter-db-'));
+  const tempDir = path.join(repoRoot, 'supabase', '.temp');
+  mkdirSync(tempDir, { recursive: true });
+  writeFileSync(
+    path.join(tempDir, 'pooler-url'),
+    'postgresql://postgres.linked-ref@aws-1-us-east-2.pooler.supabase.com:5432/postgres'
+  );
+
+  assert.equal(
+    readPoolerUrlTemplate(repoRoot),
+    'postgresql://postgres.linked-ref@aws-1-us-east-2.pooler.supabase.com:5432/postgres'
+  );
+});
+
+test('buildLinkedConnectionUri prefers pooler template when present', () => {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), 'adopter-db-'));
+  const tempDir = path.join(repoRoot, 'supabase', '.temp');
+  mkdirSync(tempDir, { recursive: true });
+  writeFileSync(
+    path.join(tempDir, 'pooler-url'),
+    'postgresql://postgres.linked-ref@aws-1-us-east-2.pooler.supabase.com:5432/postgres'
+  );
+
+  const url = buildLinkedConnectionUri(repoRoot, 'secret', 'linked-ref');
+  assert.match(url, /pooler\.supabase\.com/);
+  assert.match(url, /sslmode=require/);
 });
 
 test('isScriptMain returns true when argv matches import meta url', () => {

--- a/scripts/lib/resolve-adopter-database-url.mjs
+++ b/scripts/lib/resolve-adopter-database-url.mjs
@@ -2,7 +2,10 @@ import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
-import { postgresConnectionUri } from './setup-supabase.mjs';
+import {
+  applyPoolerPassword,
+  postgresConnectionUri,
+} from './setup-supabase.mjs';
 
 const LOCAL_DEFAULT_URL =
   'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
@@ -53,6 +56,38 @@ export function resolveLinkedCredentials(env = process.env) {
 }
 
 /**
+ * @param {string} repoRoot
+ * @returns {string | undefined}
+ */
+export function readPoolerUrlTemplate(repoRoot) {
+  const poolerPath = path.join(repoRoot, 'supabase', '.temp', 'pooler-url');
+  if (!existsSync(poolerPath)) {
+    return undefined;
+  }
+
+  const template = readFileSync(poolerPath, 'utf8').trim();
+  return template || undefined;
+}
+
+/**
+ * Prefer Supavisor pooler URL (IPv4-compatible) when `supabase link` wrote
+ * supabase/.temp/pooler-url; fall back to direct db.{ref}.supabase.co.
+ *
+ * @param {string} repoRoot
+ * @param {string} dbPassword
+ * @param {string} projectRef
+ * @returns {string}
+ */
+export function buildLinkedConnectionUri(repoRoot, dbPassword, projectRef) {
+  const poolerTemplate = readPoolerUrlTemplate(repoRoot);
+  if (poolerTemplate) {
+    return applyPoolerPassword(poolerTemplate, dbPassword);
+  }
+
+  return postgresConnectionUri(projectRef, dbPassword);
+}
+
+/**
  * Local-dev fallback after `supabase link`: read project ref from disk and pair
  * with SUPABASE_DB_PASSWORD only (not STAGING_/PRODUCTION_ variants).
  *
@@ -78,7 +113,7 @@ export function readLinkedConnectionUri(repoRoot, env = process.env) {
     );
   }
 
-  return postgresConnectionUri(projectRef, dbPassword);
+  return buildLinkedConnectionUri(repoRoot, dbPassword, projectRef);
 }
 
 /**
@@ -100,7 +135,9 @@ export function resolveAdopterDatabaseUrl(options = {}) {
   if (linked) {
     const { projectRef, dbPassword } = resolveLinkedCredentials(env);
     if (projectRef && dbPassword) {
-      return assertPostgresUrl(postgresConnectionUri(projectRef, dbPassword));
+      return assertPostgresUrl(
+        buildLinkedConnectionUri(repoRoot, dbPassword, projectRef)
+      );
     }
 
     const linkedUrl = readLinkedConnectionUri(repoRoot, env);

--- a/scripts/lib/resolve-adopter-database-url.mjs
+++ b/scripts/lib/resolve-adopter-database-url.mjs
@@ -36,6 +36,8 @@ export function assertPostgresUrl(url) {
  * @returns {{ projectRef?: string; dbPassword?: string }}
  */
 export function resolveLinkedCredentials(env = process.env) {
+  // Generic SUPABASE_* wins for local/dev ergonomics. Preview CI clears those vars
+  // before calling --linked so SUPABASE_PREVIEW_* is used (see reset-preview-database.sh).
   const pairs = [
     ['SUPABASE_PROJECT_REF', 'SUPABASE_DB_PASSWORD'],
     ['SUPABASE_PREVIEW_PROJECT_REF', 'SUPABASE_PREVIEW_DB_PASSWORD'],
@@ -69,6 +71,36 @@ export function readPoolerUrlTemplate(repoRoot) {
 }
 
 /**
+ * @param {string} repoRoot
+ * @returns {string | undefined}
+ */
+export function readLinkedProjectRef(repoRoot) {
+  const refPath = path.join(repoRoot, 'supabase', '.temp', 'project-ref');
+  if (!existsSync(refPath)) {
+    return undefined;
+  }
+
+  const projectRef = readFileSync(refPath, 'utf8').trim();
+  return projectRef || undefined;
+}
+
+/**
+ * Supavisor session pooler usernames are `postgres.{projectRef}`.
+ *
+ * @param {string} poolerUrlTemplate
+ * @param {string} projectRef
+ * @returns {boolean}
+ */
+export function poolerTemplateMatchesProjectRef(poolerUrlTemplate, projectRef) {
+  try {
+    const url = new URL(poolerUrlTemplate.trim());
+    return url.username === `postgres.${projectRef}`;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Prefer Supavisor pooler URL (IPv4-compatible) when `supabase link` wrote
  * supabase/.temp/pooler-url; fall back to direct db.{ref}.supabase.co.
  *
@@ -79,7 +111,13 @@ export function readPoolerUrlTemplate(repoRoot) {
  */
 export function buildLinkedConnectionUri(repoRoot, dbPassword, projectRef) {
   const poolerTemplate = readPoolerUrlTemplate(repoRoot);
-  if (poolerTemplate) {
+  const linkedRef = readLinkedProjectRef(repoRoot);
+  const linkedRefMatches = !linkedRef || linkedRef === projectRef;
+  const poolerMatches =
+    poolerTemplate &&
+    poolerTemplateMatchesProjectRef(poolerTemplate, projectRef);
+
+  if (poolerTemplate && poolerMatches && linkedRefMatches) {
     return applyPoolerPassword(poolerTemplate, dbPassword);
   }
 
@@ -95,12 +133,7 @@ export function buildLinkedConnectionUri(repoRoot, dbPassword, projectRef) {
  * @returns {string | undefined}
  */
 export function readLinkedConnectionUri(repoRoot, env = process.env) {
-  const refPath = path.join(repoRoot, 'supabase', '.temp', 'project-ref');
-  if (!existsSync(refPath)) {
-    return undefined;
-  }
-
-  const projectRef = readFileSync(refPath, 'utf8').trim();
+  const projectRef = readLinkedProjectRef(repoRoot);
   if (!projectRef) {
     return undefined;
   }

--- a/scripts/lib/resolve-adopter-database-url.mjs
+++ b/scripts/lib/resolve-adopter-database-url.mjs
@@ -36,10 +36,9 @@ export function assertPostgresUrl(url) {
  * @returns {{ projectRef?: string; dbPassword?: string }}
  */
 export function resolveLinkedCredentials(env = process.env) {
-  // PREVIEW_SUPABASE_* is intentionally omitted — PR preview does not run adopter
-  // migrations today. Add a pair here if that workflow starts calling --linked.
   const pairs = [
     ['SUPABASE_PROJECT_REF', 'SUPABASE_DB_PASSWORD'],
+    ['SUPABASE_PREVIEW_PROJECT_REF', 'SUPABASE_PREVIEW_DB_PASSWORD'],
     ['STAGING_SUPABASE_PROJECT_REF', 'STAGING_SUPABASE_DB_PASSWORD'],
     ['PRODUCTION_SUPABASE_PROJECT_REF', 'PRODUCTION_SUPABASE_DB_PASSWORD'],
   ];
@@ -146,7 +145,7 @@ export function resolveAdopterDatabaseUrl(options = {}) {
     }
 
     throw new Error(
-      'Failed to resolve remote database URL for --linked. Set DATABASE_URL or project ref + DB password env vars (SUPABASE_*, STAGING_SUPABASE_*, or PRODUCTION_SUPABASE_*).'
+      'Failed to resolve remote database URL for --linked. Set DATABASE_URL or project ref + DB password env vars (SUPABASE_*, SUPABASE_PREVIEW_*, STAGING_SUPABASE_*, or PRODUCTION_SUPABASE_*).'
     );
   }
 

--- a/scripts/lib/setup-supabase.mjs
+++ b/scripts/lib/setup-supabase.mjs
@@ -41,11 +41,7 @@ export function runCmd(cmd, args, opts = {}) {
  */
 export function postgresConnectionUri(projectRef, dbPassword) {
   const enc = encodeURIComponent(dbPassword);
-  const url = new URL(
-    `postgresql://postgres:${enc}@db.${projectRef}.supabase.co:5432/postgres`
-  );
-  url.searchParams.set('sslmode', 'require');
-  return url.toString();
+  return `postgresql://postgres:${enc}@db.${projectRef}.supabase.co:5432/postgres?sslmode=require`;
 }
 
 /**
@@ -54,10 +50,18 @@ export function postgresConnectionUri(projectRef, dbPassword) {
  * @param {string} dbPassword
  */
 export function applyPoolerPassword(poolerUrlTemplate, dbPassword) {
-  const url = new URL(poolerUrlTemplate.trim());
+  let url;
+  try {
+    url = new URL(poolerUrlTemplate.trim());
+  } catch {
+    throw new Error(
+      `Invalid pooler URL template from supabase link: ${String(poolerUrlTemplate).slice(0, 80)}`
+    );
+  }
   const enc = encodeURIComponent(dbPassword);
   url.searchParams.set('sslmode', 'require');
-  return `postgresql://${url.username}:${enc}@${url.host}${url.pathname}${url.search}`;
+  // url.username is percent-decoded; Supabase pooler usernames (postgres.{ref}) are alphanumeric.
+  return `${url.protocol}//${url.username}:${enc}@${url.host}${url.pathname}${url.search}`;
 }
 
 /**

--- a/scripts/lib/setup-supabase.mjs
+++ b/scripts/lib/setup-supabase.mjs
@@ -22,14 +22,14 @@ export function runCmd(cmd, args, opts = {}) {
     });
     let stdout = '';
     let stderr = '';
-    child.stdout?.on('data', (d) => {
+    child.stdout?.on('data', d => {
       stdout += d.toString();
     });
-    child.stderr?.on('data', (d) => {
+    child.stderr?.on('data', d => {
       stderr += d.toString();
     });
     child.on('error', reject);
-    child.on('close', (code) => {
+    child.on('close', code => {
       resolve({ stdout, stderr, code: code ?? 1 });
     });
   });
@@ -41,7 +41,23 @@ export function runCmd(cmd, args, opts = {}) {
  */
 export function postgresConnectionUri(projectRef, dbPassword) {
   const enc = encodeURIComponent(dbPassword);
-  return `postgresql://postgres:${enc}@db.${projectRef}.supabase.co:5432/postgres`;
+  const url = new URL(
+    `postgresql://postgres:${enc}@db.${projectRef}.supabase.co:5432/postgres`
+  );
+  url.searchParams.set('sslmode', 'require');
+  return url.toString();
+}
+
+/**
+ * Inject password into a Supavisor pooler URL template (from supabase link).
+ * @param {string} poolerUrlTemplate
+ * @param {string} dbPassword
+ */
+export function applyPoolerPassword(poolerUrlTemplate, dbPassword) {
+  const url = new URL(poolerUrlTemplate.trim());
+  const enc = encodeURIComponent(dbPassword);
+  url.searchParams.set('sslmode', 'require');
+  return `postgresql://${url.username}:${enc}@${url.host}${url.pathname}${url.search}`;
 }
 
 /**
@@ -58,7 +74,10 @@ export function projectApiUrl(projectRef) {
 export function parseApiKeysJson(json) {
   const data = JSON.parse(json);
   if (data && typeof data === 'object' && !Array.isArray(data)) {
-    if (typeof data.anon === 'string' && typeof data.service_role === 'string') {
+    if (
+      typeof data.anon === 'string' &&
+      typeof data.service_role === 'string'
+    ) {
       return { anon: data.anon, service_role: data.service_role };
     }
   }
@@ -72,7 +91,8 @@ export function parseApiKeysJson(json) {
   }
   return {
     anon: out.anon || out['anon key'] || '',
-    service_role: out.service_role || out.serviceRole || out['service_role'] || '',
+    service_role:
+      out.service_role || out.serviceRole || out['service_role'] || '',
   };
 }
 
@@ -106,7 +126,9 @@ function normalizeSlugLike(s) {
  * @param {string} s
  */
 function compactAlnum(s) {
-  return String(s).toLowerCase().replace(/[^a-z0-9]/g, '');
+  return String(s)
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
 }
 
 /**
@@ -129,7 +151,8 @@ export function scoreSupabaseProjectForTier(project, tier, slugBase) {
   const base = String(slugBase || '').toLowerCase();
   if (!base) return 0;
   const expected = `${base}-${tier}`;
-  const slugField = project.slug != null ? String(project.slug).trim().toLowerCase() : '';
+  const slugField =
+    project.slug != null ? String(project.slug).trim().toLowerCase() : '';
   if (slugField && slugField === expected) return 100;
 
   const displayName = String(project.name || '').trim();
@@ -175,10 +198,12 @@ export function pickRecommendedSupabaseProject(choices, tier, slugBase) {
 export function parseProjectsListJson(stdout) {
   const data = JSON.parse(stdout);
   if (!Array.isArray(data)) return [];
-  return data.map((p) => {
+  return data.map(p => {
     const rawSlug = p.slug;
     const slug =
-      typeof rawSlug === 'string' && rawSlug.trim() ? String(rawSlug).trim() : undefined;
+      typeof rawSlug === 'string' && rawSlug.trim()
+        ? String(rawSlug).trim()
+        : undefined;
     return {
       id: p.id || p.ref || p.project_id,
       name: p.name || p.slug || '',
@@ -195,7 +220,7 @@ export function parseProjectsListJson(stdout) {
 export function parseOrgsListJson(stdout) {
   const data = JSON.parse(stdout);
   if (!Array.isArray(data)) return [];
-  return data.map((o) => ({
+  return data.map(o => ({
     id: o.id,
     name: o.name || '',
   }));
@@ -212,6 +237,7 @@ export function parseProjectCreateJson(stdout) {
     data.project_id ||
     data.project_ref ||
     (data.project && (data.project.id || data.project.ref));
-  if (!id) throw new Error('Could not parse new project id from Supabase CLI output');
+  if (!id)
+    throw new Error('Could not parse new project id from Supabase CLI output');
   return { id: String(id), raw: data };
 }

--- a/scripts/pr-preview/reset-preview-database.sh
+++ b/scripts/pr-preview/reset-preview-database.sh
@@ -448,6 +448,13 @@ sync_link_artifacts() {
   fi
 
   mkdir -p "${repo_temp_dir}"
+  local link_resolved repo_resolved
+  link_resolved="$(cd "${link_temp_dir}" && pwd -P)"
+  repo_resolved="$(cd "${repo_temp_dir}" && pwd -P)"
+  if [[ "${link_resolved}" == "${repo_resolved}" ]]; then
+    return
+  fi
+
   cp -a "${link_temp_dir}/." "${repo_temp_dir}/"
 }
 
@@ -470,14 +477,32 @@ apply_adopter_migrations() {
 
 unlink_supabase() {
   log "INFO" "Unlinking Supabase project..."
+  if [[ "${DRY_RUN}" == true ]]; then
+    log "DRY" "cd ${SUPABASE_RUNTIME_DIR} && supabase unlink --yes"
+    return 0
+  fi
+
+  local tmp
+  tmp="$(mktemp)"
+  local status=0
   (
     cd "${SUPABASE_RUNTIME_DIR}"
-    supabase_run --allow-fail "Supabase unlink" env \
-      SUPABASE_DISABLE_KEYRING=1 \
+    env SUPABASE_DISABLE_KEYRING=1 \
       SUPABASE_ACCESS_TOKEN="${SUPABASE_ACCESS_TOKEN}" \
-      supabase unlink \
-        --yes
-  )
+      supabase unlink --yes
+  ) >"${tmp}" 2>&1 || status=$?
+
+  cat "${tmp}"
+
+  if (( status != 0 )); then
+    if grep -qiE 'Cannot find project ref|failed to delete credentials' "${tmp}"; then
+      log "WARN" "Supabase unlink non-fatal: project already unlinked or keyring unavailable in CI."
+    else
+      log "WARN" "Supabase unlink failed (exit ${status}); continuing."
+    fi
+  fi
+
+  rm -f "${tmp}"
 }
 
 cleanup() {

--- a/scripts/pr-preview/reset-preview-database.sh
+++ b/scripts/pr-preview/reset-preview-database.sh
@@ -126,9 +126,11 @@ ensure_prereqs() {
     log "ERROR" "node is required."
     exit 1
   }
+}
 
+ensure_psql_prereq() {
   command -v psql >/dev/null 2>&1 || {
-    log "ERROR" "psql is required for adopter database migrations."
+    log "ERROR" "psql is required for adopter database migrations (db-apply-adopter.mjs shells out to psql)."
     exit 1
   }
 }
@@ -465,13 +467,16 @@ apply_adopter_migrations() {
     return 0
   fi
 
+  ensure_psql_prereq
   sync_link_artifacts
 
   (
     cd "${REPO_ROOT}"
-    SUPABASE_PREVIEW_PROJECT_REF="${PROJECT_REF}" \
-    SUPABASE_PREVIEW_DB_PASSWORD="${DB_PASSWORD}" \
-    npm run db:apply-adopter -- --linked
+    # Clear generic SUPABASE_* so resolveLinkedCredentials uses preview creds below.
+    env -u SUPABASE_PROJECT_REF -u SUPABASE_DB_PASSWORD \
+      SUPABASE_PREVIEW_PROJECT_REF="${PROJECT_REF}" \
+      SUPABASE_PREVIEW_DB_PASSWORD="${DB_PASSWORD}" \
+      npm run db:apply-adopter -- --linked
   )
 }
 
@@ -587,6 +592,7 @@ main() {
       fi
     fi
 
+    # Re-apply adopter schema after any Supabase reset (reset drops app.*), not only when adopter/db changed.
     if [[ "${supabase_ok}" == true && ( "${ADOPTER_HAS_CHANGES}" == true || "${SUPABASE_HAS_CHANGES}" == true ) ]]; then
       if apply_adopter_migrations; then
         log "INFO" "Adopter database migrations applied successfully."

--- a/scripts/pr-preview/reset-preview-database.sh
+++ b/scripts/pr-preview/reset-preview-database.sh
@@ -26,6 +26,7 @@ SUPABASE_RUNTIME_DIR="${DEFAULT_SUPABASE_CONFIG_DIR}"
 TEMP_SUPABASE_DIR=""
 SKIP_IF_UNCHANGED=false
 SUPABASE_HAS_CHANGES=true
+ADOPTER_HAS_CHANGES=true
 GENERATE_TYPES=true
 RUN_SEED=true
 OUTPUT_ENV=""
@@ -118,6 +119,16 @@ ensure_prereqs() {
 
   command -v rsync >/dev/null 2>&1 || {
     log "ERROR" "rsync is required."
+    exit 1
+  }
+
+  command -v node >/dev/null 2>&1 || {
+    log "ERROR" "node is required."
+    exit 1
+  }
+
+  command -v psql >/dev/null 2>&1 || {
+    log "ERROR" "psql is required for adopter database migrations."
     exit 1
   }
 }
@@ -223,13 +234,34 @@ checkout_baseline() {
   fi
 
   if [[ "${SKIP_IF_UNCHANGED}" == true ]]; then
-    # Compare against the checkout ref (which might be origin/main or just main)
+    local supabase_unchanged=false
+    local adopter_unchanged=false
+
     if git diff --quiet "${checkout_ref}" HEAD -- supabase 2>/dev/null || \
        git diff --quiet "${fetch_ref}" HEAD -- supabase 2>/dev/null; then
+      supabase_unchanged=true
       SUPABASE_HAS_CHANGES=false
-      log "INFO" "No Supabase directory changes detected relative to ${BASELINE_REF}; skipping Supabase reset."
+    fi
+
+    if git diff --quiet "${checkout_ref}" HEAD -- adopter/db 2>/dev/null || \
+       git diff --quiet "${fetch_ref}" HEAD -- adopter/db 2>/dev/null; then
+      adopter_unchanged=true
+      ADOPTER_HAS_CHANGES=false
+    fi
+
+    if [[ "${supabase_unchanged}" == true && "${adopter_unchanged}" == true ]]; then
+      log "INFO" "No Supabase or adopter/db changes detected relative to ${BASELINE_REF}; skipping database prep."
       return
     fi
+
+    if [[ "${supabase_unchanged}" == true ]]; then
+      log "INFO" "No Supabase directory changes detected relative to ${BASELINE_REF}; skipping Supabase reset."
+    fi
+  fi
+
+  if [[ "${SUPABASE_HAS_CHANGES}" != true ]]; then
+    SUPABASE_RUNTIME_DIR="${REPO_ROOT}/supabase"
+    return
   fi
 
   # Use a temporary worktree so we don't disturb the current workspace
@@ -406,6 +438,36 @@ restore_types_from_baseline() {
   fi
 }
 
+sync_link_artifacts() {
+  local link_temp_dir="${SUPABASE_RUNTIME_DIR}/.temp"
+  local repo_temp_dir="${REPO_ROOT}/supabase/.temp"
+
+  if [[ ! -d "${link_temp_dir}" ]]; then
+    log "WARN" "Supabase link artifacts not found at ${link_temp_dir}; adopter URL may fall back to direct host."
+    return
+  fi
+
+  mkdir -p "${repo_temp_dir}"
+  cp -a "${link_temp_dir}/." "${repo_temp_dir}/"
+}
+
+apply_adopter_migrations() {
+  log "INFO" "Applying adopter database migrations..."
+  if [[ "${DRY_RUN}" == true ]]; then
+    log "DRY" "env SUPABASE_PREVIEW_PROJECT_REF=*** SUPABASE_PREVIEW_DB_PASSWORD=*** npm run db:apply-adopter -- --linked"
+    return 0
+  fi
+
+  sync_link_artifacts
+
+  (
+    cd "${REPO_ROOT}"
+    SUPABASE_PREVIEW_PROJECT_REF="${PROJECT_REF}" \
+    SUPABASE_PREVIEW_DB_PASSWORD="${DB_PASSWORD}" \
+    npm run db:apply-adopter -- --linked
+  )
+}
+
 unlink_supabase() {
   log "INFO" "Unlinking Supabase project..."
   (
@@ -470,39 +532,61 @@ main() {
   log "INFO" "Restoring type files from baseline branch as a safety measure..."
   restore_types_from_baseline || log "WARN" "Could not restore types from baseline (this is OK if types don't exist yet)."
 
-  # If no changes detected, skip database operations
-  if [[ "${SUPABASE_HAS_CHANGES}" != true ]]; then
-    log "INFO" "Supabase changes skipped; retaining existing preview database and types."
-    db_success=true  # Consider this success since we're intentionally skipping
+  # If no DB-related changes detected, skip database operations
+  if [[ "${SUPABASE_HAS_CHANGES}" != true && "${ADOPTER_HAS_CHANGES}" != true ]]; then
+    log "INFO" "Database prep skipped; retaining existing preview database and types."
+    db_success=true
   else
     # Temporarily disable exit-on-error for database operations
     set +e
-    
-    # Attempt database operations - continue even if they fail
-    log "INFO" "Attempting Supabase database operations..."
-    
-    if link_supabase && reset_database && seed_database; then
-      db_success=true
-      log "INFO" "Database reset and seeding completed successfully."
-      
-      # Generate types only if database operations succeeded
-      if generate_types; then
-        log "INFO" "TypeScript types generated successfully (overwriting baseline types)."
+
+    log "INFO" "Attempting Supabase preview database operations..."
+
+    local supabase_ok=true
+    local adopter_ok=true
+
+    if [[ "${SUPABASE_HAS_CHANGES}" == true ]]; then
+      if link_supabase && reset_database && seed_database; then
+        log "INFO" "Database reset and seeding completed successfully."
       else
-        log "WARN" "Type generation failed; using baseline types (already restored)."
-        db_success=false
+        supabase_ok=false
+        log "WARN" "Supabase reset/seed failed (likely network/connectivity issue)."
+      fi
+    elif [[ "${ADOPTER_HAS_CHANGES}" == true ]]; then
+      if link_supabase; then
+        log "INFO" "Linked preview Supabase project for adopter migrations."
+      else
+        supabase_ok=false
+        adopter_ok=false
+        log "WARN" "Failed to link preview Supabase project for adopter migrations."
+      fi
+    fi
+
+    if [[ "${supabase_ok}" == true && ( "${ADOPTER_HAS_CHANGES}" == true || "${SUPABASE_HAS_CHANGES}" == true ) ]]; then
+      if apply_adopter_migrations; then
+        log "INFO" "Adopter database migrations applied successfully."
+      else
+        adopter_ok=false
+        log "WARN" "Adopter database migrations failed."
+      fi
+    fi
+
+    if [[ "${supabase_ok}" == true && "${adopter_ok}" == true ]]; then
+      db_success=true
+      if [[ "${SUPABASE_HAS_CHANGES}" == true ]]; then
+        if generate_types; then
+          log "INFO" "TypeScript types generated successfully (overwriting baseline types)."
+        else
+          log "WARN" "Type generation failed; using baseline types (already restored)."
+          db_success=false
+        fi
       fi
     else
-      log "WARN" "Database operations failed (likely network/connectivity issue)."
-      log "WARN" "This may be due to Supabase connection timeouts from CI runners."
       log "WARN" "Skipping type generation - using baseline types (already restored)."
       db_success=false
     fi
 
-    # Always try to unlink (non-blocking)
     unlink_supabase || true
-    
-    # Re-enable exit-on-error for output operations
     set -e
   fi
 


### PR DESCRIPTION
## Summary
- Follow-up to #375: staging deploy still failed after URL resolution was fixed because `psql` connected to direct `db.{ref}.supabase.co`, which resolves to IPv6 — GitHub Actions has no IPv6 route.
- Prefer the Supavisor session pooler URL from `supabase/.temp/pooler-url` (written by the prior `supabase link` step in deploy workflows) when resolving `--linked` database URLs.
- Fall back to direct `db.{ref}.supabase.co` only when the pooler template is absent.

## Test plan
- [x] `npm run test:adopter`
- [ ] Re-run Deploy Staging and confirm `Apply adopter database migrations` succeeds