### PR TITLE
fix: resolve CodeQL findings from promotion PR #377

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -7,8 +7,6 @@ import { branding } from '../../adopter/config/branding';
 
 const viteConfigDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(viteConfigDir, '../..');
-const adopterWebRoot = path.join(repoRoot, 'adopter/web');
-const adopterConfigRoot = path.join(repoRoot, 'adopter/config');
 const criticalThemePath = path.join(
   viteConfigDir,
   'src/styles/critical-theme.css'

--- a/packages/admin/vitest.config.ts
+++ b/packages/admin/vitest.config.ts
@@ -1,8 +1,5 @@
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
-const pkgRoot = path.dirname(fileURLToPath(new URL(import.meta.url)));
 const mergeCoverage = process.env.COVERAGE_MERGE === '1';
 
 export default defineConfig({

--- a/packages/observability/src/components/withErrorBoundary.native.tsx
+++ b/packages/observability/src/components/withErrorBoundary.native.tsx
@@ -5,7 +5,6 @@ const _sentryLoad = import('@sentry/react-native').catch(() => null);
 
 interface ErrorBoundaryState {
   hasError: boolean;
-  error: Error | null;
 }
 
 interface Props {
@@ -16,11 +15,11 @@ interface Props {
 export class ErrorBoundary extends React.Component<Props, ErrorBoundaryState> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false, error: null };
+    this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error };
+  static getDerivedStateFromError(_error: Error) {
+    return { hasError: true };
   }
 
   override componentDidCatch(error: Error, info: React.ErrorInfo) {

--- a/packages/observability/src/components/withErrorBoundary.web.tsx
+++ b/packages/observability/src/components/withErrorBoundary.web.tsx
@@ -5,7 +5,6 @@ const _sentryLoad = import('@sentry/react').catch(() => null);
 
 interface ErrorBoundaryState {
   hasError: boolean;
-  error: Error | null;
 }
 
 interface Props {
@@ -16,11 +15,11 @@ interface Props {
 export class ErrorBoundary extends React.Component<Props, ErrorBoundaryState> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false, error: null };
+    this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error };
+  static getDerivedStateFromError(_error: Error) {
+    return { hasError: true };
   }
 
   override componentDidCatch(error: Error, info: React.ErrorInfo) {

--- a/packages/observability/src/pii.ts
+++ b/packages/observability/src/pii.ts
@@ -8,7 +8,9 @@ export async function hashUserId(id: string): Promise<string> {
   return `u_${hex}`;
 }
 
-const EMAIL_PATTERN = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+// Bounded quantifiers avoid polynomial backtracking on adversarial input (CodeQL).
+const EMAIL_PATTERN =
+  /[a-zA-Z0-9._%+-]{1,64}@[a-zA-Z0-9.-]{1,253}\.[a-zA-Z]{2,63}/g;
 
 export function scrubEmail(str: string): string {
   return str.replace(EMAIL_PATTERN, '[email]');

--- a/scripts/__tests__/setup-route53-email-records.test.mjs
+++ b/scripts/__tests__/setup-route53-email-records.test.mjs
@@ -199,8 +199,8 @@ describe('uncommentSmtpSection', () => {
       'commented header should be gone'
     );
     assert.ok(
-      !result.includes('smtp.sendgrid.net'),
-      'sendgrid placeholder should be gone'
+      !/host\s*=\s*"smtp\.sendgrid\.net"/.test(result),
+      'sendgrid placeholder host should be gone'
     );
     assert.ok(
       !result.includes('# Use a production-ready SMTP server'),


### PR DESCRIPTION
## Summary

Addresses all 7 CodeQL / code-quality findings flagged on the develop→main promotion PR (#377):

- **ReDoS risk** — bounded quantifiers in `scrubEmail` regex (`packages/observability/src/pii.ts`)
- **Incomplete URL substring sanitization** — assert on TOML host assignment instead of bare substring match in Route53 email setup test
- **Unused state** — drop unread `error` from error boundary state (web + native)
- **Dead code** — remove unused path constants in `apps/web/vite.config.ts` and `packages/admin/vitest.config.ts`

## Test plan

- [x] `node --test scripts/__tests__/setup-route53-email-records.test.mjs` — 25/25 passed
- [x] `npm test` in `packages/observability` — 79/79 passed
- [x] `npm test` in `packages/admin` — 87/87 passed
- [ ] CI green on PR (CodeQL alerts should clear)