### PR TITLE
feat(auth): sync OAuth display name and avatar into user_profiles

### DIFF
--- a/apps/web/src/components/SocialLoginButton.tsx
+++ b/apps/web/src/components/SocialLoginButton.tsx
@@ -4,11 +4,15 @@ import { Logger } from '@beakerstack/logger';
 interface SocialLoginButtonProps {
   onPress: () => Promise<void>;
   mode?: 'signin' | 'signup';
+  disabled?: boolean;
+  provider?: 'Google' | 'Apple';
 }
 
 export function SocialLoginButton({
   onPress,
   mode = 'signin',
+  disabled = false,
+  provider = 'Google',
 }: SocialLoginButtonProps) {
   const [isLoading, setIsLoading] = useState(false);
 
@@ -30,7 +34,13 @@ export function SocialLoginButton({
     <button
       type='button'
       onClick={handleClick}
-      disabled={isLoading}
+      disabled={isLoading || disabled}
+      aria-label={
+        isLoading
+          ? `Connecting to ${provider}`
+          : `${actionText} with ${provider}`
+      }
+      aria-busy={isLoading}
       className={`
         w-full flex items-center justify-center gap-3 px-4 py-2 
         border border-gray-300 dark:border-gray-600 rounded-md shadow-sm
@@ -86,7 +96,9 @@ export function SocialLoginButton({
           />
         </svg>
       )}
-      <span>{isLoading ? 'Connecting...' : `${actionText} with Google`}</span>
+      <span>
+        {isLoading ? 'Connecting...' : `${actionText} with ${provider}`}
+      </span>
     </button>
   );
 }

--- a/apps/web/src/components/__tests__/SocialLoginButton.test.tsx
+++ b/apps/web/src/components/__tests__/SocialLoginButton.test.tsx
@@ -35,6 +35,20 @@ describe('SocialLoginButton', () => {
     expect(screen.getByText('Sign up with Google')).toBeInTheDocument();
   });
 
+  it('uses provider prop for label copy and aria-label', () => {
+    const mockOnPress = vi.fn();
+
+    render(
+      <SocialLoginButton onPress={mockOnPress} provider='Apple' mode='signin' />
+    );
+
+    expect(screen.getByText('Sign in with Apple')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Sign in with Apple'
+    );
+  });
+
   it('calls onPress once per click and displays loading state', async () => {
     const user = userEvent.setup();
     const { promise: pressPromise, resolve: resolvePress } = createDeferred();

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -9,7 +9,24 @@ Beaker Stack ships OAuth UI and session handling for web and mobile. You configu
 - OAuth UI (Google / Apple buttons) on web; native Google Sign-In on mobile
 - **Web:** `signInWithOAuth`, redirect handling, `/auth/callback` route
 - **Mobile:** `@react-native-google-signin/google-signin` → `signInWithIdToken` with Supabase (see `packages/shared/src/hooks/useAuth.native.ts`)
+- **Profile sync:** Google (and Apple) display name and profile photo map into `user_profiles.display_name` and `user_profiles.avatar_url` via DB triggers on `auth.users` — on first signup and on later sign-in when those profile fields are still empty (manual edits in ProfileEditor are preserved)
 - Unit tests for auth flows
+
+### OAuth profile fields
+
+Supabase stores provider claims in `auth.users.raw_user_meta_data`. Beaker Stack copies them into `public.user_profiles` automatically:
+
+| `user_profiles` column | OAuth metadata keys (first non-empty wins) |
+| ---------------------- | ------------------------------------------ |
+| `display_name`         | `full_name`, `name`, then email fallback   |
+| `avatar_url`           | `avatar_url`, `picture`                    |
+
+**When sync runs:**
+
+- **First signup** — `handle_new_user()` trigger creates the profile row with OAuth name and photo.
+- **Returning sign-in** — `sync_oauth_profile_from_auth()` backfills only **empty** (`NULL`) profile fields when Supabase refreshes `raw_user_meta_data`. Non-null values (including user edits) are never overwritten.
+
+Implementation: `supabase/migrations/20260531120200_oauth_profile_sync.sql`. The UI reads `user_profiles` only (`ProfileAvatar`, `UserMenu`, `ProfileHeader`) — no client-side OAuth profile logic is required.
 
 ### What you configure
 

--- a/supabase/migrations/20260531120200_oauth_profile_sync.sql
+++ b/supabase/migrations/20260531120200_oauth_profile_sync.sql
@@ -1,0 +1,84 @@
+-- Sync OAuth provider display name and avatar into user_profiles on signup and sign-in.
+-- Fill-empty-only: never overwrite user-edited profile fields.
+
+CREATE OR REPLACE FUNCTION public.oauth_profile_from_metadata(meta jsonb)
+RETURNS TABLE (display_name text, avatar_url text)
+LANGUAGE sql
+IMMUTABLE
+SET search_path = public
+AS $$
+  SELECT
+    NULLIF(trim(COALESCE(meta->>'full_name', meta->>'name')), '') AS display_name,
+    NULLIF(trim(COALESCE(meta->>'avatar_url', meta->>'picture')), '') AS avatar_url;
+$$;
+
+REVOKE ALL ON FUNCTION public.oauth_profile_from_metadata(jsonb) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+DECLARE
+  oauth_profile record;
+BEGIN
+  SELECT * INTO oauth_profile
+  FROM public.oauth_profile_from_metadata(NEW.raw_user_meta_data);
+
+  INSERT INTO public.user_profiles (user_id, username, display_name, avatar_url)
+  VALUES (
+    NEW.id,
+    public.generate_username(),
+    COALESCE(oauth_profile.display_name, NEW.email),
+    oauth_profile.avatar_url
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+CREATE OR REPLACE FUNCTION public.sync_oauth_profile_from_auth()
+RETURNS TRIGGER AS $$
+DECLARE
+  oauth_profile record;
+  profile_display_name text;
+  profile_avatar_url text;
+  resolved_display_name text;
+BEGIN
+  IF NEW.raw_user_meta_data IS NOT DISTINCT FROM OLD.raw_user_meta_data THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT * INTO oauth_profile
+  FROM public.oauth_profile_from_metadata(NEW.raw_user_meta_data);
+
+  SELECT display_name, avatar_url
+  INTO profile_display_name, profile_avatar_url
+  FROM public.user_profiles
+  WHERE user_id = NEW.id;
+
+  IF NOT FOUND THEN
+    RETURN NEW;
+  END IF;
+
+  resolved_display_name := COALESCE(oauth_profile.display_name, NEW.email);
+
+  -- Update each NULL field independently to avoid touching populated columns.
+  IF profile_display_name IS NULL AND resolved_display_name IS NOT NULL THEN
+    UPDATE public.user_profiles
+    SET display_name = resolved_display_name
+    WHERE user_id = NEW.id;
+  END IF;
+
+  IF profile_avatar_url IS NULL AND oauth_profile.avatar_url IS NOT NULL THEN
+    UPDATE public.user_profiles
+    SET avatar_url = oauth_profile.avatar_url
+    WHERE user_id = NEW.id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+DROP TRIGGER IF EXISTS on_auth_user_updated_sync_oauth_profile ON auth.users;
+
+CREATE TRIGGER on_auth_user_updated_sync_oauth_profile
+  AFTER UPDATE ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_oauth_profile_from_auth();

--- a/supabase/tests/test_user_creation_trigger.sql
+++ b/supabase/tests/test_user_creation_trigger.sql
@@ -4,7 +4,7 @@
 
 BEGIN;
 
-SELECT plan(8);
+SELECT plan(22);
 
 -- Test 1: Verify the trigger function exists
 SELECT has_function(
@@ -20,7 +20,7 @@ SELECT has_function(
     'generate_username function should exist'
 );
 
--- Test 3: Verify the trigger exists
+-- Test 3: Verify the signup trigger exists
 SELECT has_trigger(
     'auth',
     'users',
@@ -28,17 +28,61 @@ SELECT has_trigger(
     'on_auth_user_created trigger should exist on auth.users'
 );
 
--- Test 4: Test that generate_username returns valid format
+-- Test 4: Verify OAuth profile helper exists
+SELECT has_function(
+    'public',
+    'oauth_profile_from_metadata',
+    'oauth_profile_from_metadata function should exist'
+);
+
+-- Test 5: Verify OAuth profile sync function exists
+SELECT has_function(
+    'public',
+    'sync_oauth_profile_from_auth',
+    'sync_oauth_profile_from_auth function should exist'
+);
+
+-- Test 6: Verify the OAuth sync trigger exists
+SELECT has_trigger(
+    'auth',
+    'users',
+    'on_auth_user_updated_sync_oauth_profile',
+    'on_auth_user_updated_sync_oauth_profile trigger should exist on auth.users'
+);
+
+-- Test 7: Test that generate_username returns valid format
 SELECT matches(
     generate_username(),
     '^user_[a-f0-9]{8}$',
     'generate_username should return user_<8 hex chars>'
 );
 
--- Test 5-8: Test the full trigger flow
--- Create a test user in auth.users and verify profile is created
+-- oauth_profile_from_metadata helper coverage
+SELECT is(
+    (SELECT display_name FROM public.oauth_profile_from_metadata('{}'::jsonb)),
+    NULL,
+    'oauth_profile_from_metadata returns null display_name for empty metadata'
+);
 
--- Create a test user
+SELECT is(
+    (SELECT avatar_url FROM public.oauth_profile_from_metadata('{}'::jsonb)),
+    NULL,
+    'oauth_profile_from_metadata returns null avatar_url for empty metadata'
+);
+
+SELECT is(
+    (SELECT display_name FROM public.oauth_profile_from_metadata('{"name":"Fallback Name"}'::jsonb)),
+    'Fallback Name',
+    'oauth_profile_from_metadata falls back to name key'
+);
+
+SELECT is(
+    (SELECT avatar_url FROM public.oauth_profile_from_metadata('{"avatar_url":"https://example.com/a.jpg"}'::jsonb)),
+    'https://example.com/a.jpg',
+    'oauth_profile_from_metadata prefers avatar_url key'
+);
+
+-- Test 8-11: Email signup trigger flow
 INSERT INTO auth.users (
     id,
     instance_id,
@@ -65,37 +109,121 @@ INSERT INTO auth.users (
     'authenticated'
 );
 
--- Test 5: Verify profile was created
 SELECT ok(
     EXISTS (
-        SELECT 1 FROM public.user_profiles 
+        SELECT 1 FROM public.user_profiles
         WHERE user_id = '00000000-0000-0000-0000-000000000001'
     ),
     'Profile should be created automatically by trigger'
 );
 
--- Test 6: Verify username was generated in correct format
 SELECT matches(
     (SELECT username FROM public.user_profiles WHERE user_id = '00000000-0000-0000-0000-000000000001'),
     '^user_[a-f0-9]{8}$',
     'Profile should have auto-generated username in correct format'
 );
 
--- Test 7: Verify display_name is set to email
 SELECT is(
     (SELECT display_name FROM public.user_profiles WHERE user_id = '00000000-0000-0000-0000-000000000001'),
     'trigger-test@example.com',
     'Profile display_name should be set to user email'
 );
 
--- Test 8: Verify profile user_id matches auth user id
 SELECT is(
     (SELECT user_id::text FROM public.user_profiles WHERE user_id = '00000000-0000-0000-0000-000000000001'),
     '00000000-0000-0000-0000-000000000001',
     'Profile user_id should match auth.users id'
 );
 
+-- Test 12-13: Google OAuth signup seeds display_name and avatar_url
+INSERT INTO auth.users (
+    id,
+    instance_id,
+    email,
+    encrypted_password,
+    email_confirmed_at,
+    raw_app_meta_data,
+    raw_user_meta_data,
+    created_at,
+    updated_at,
+    aud,
+    role
+) VALUES (
+    '00000000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000000',
+    'google-user@example.com',
+    crypt('password123', gen_salt('bf')),
+    now(),
+    '{"provider":"google","providers":["google"]}'::jsonb,
+    '{"email":"google-user@example.com","full_name":"Ada Lovelace","picture":"https://lh3.googleusercontent.com/a/example-photo.jpg"}'::jsonb,
+    now(),
+    now(),
+    'authenticated',
+    'authenticated'
+);
+
+SELECT is(
+    (SELECT display_name FROM public.user_profiles WHERE user_id = '00000000-0000-0000-0000-000000000002'),
+    'Ada Lovelace',
+    'Google signup should seed display_name from full_name metadata'
+);
+
+SELECT is(
+    (SELECT avatar_url FROM public.user_profiles WHERE user_id = '00000000-0000-0000-0000-000000000002'),
+    'https://lh3.googleusercontent.com/a/example-photo.jpg',
+    'Google signup should seed avatar_url from picture metadata'
+);
+
+-- Test 14: OAuth sign-in backfills empty avatar without overwriting display_name
+UPDATE auth.users
+SET raw_user_meta_data = '{"email":"trigger-test@example.com","full_name":"Trigger Test","picture":"https://lh3.googleusercontent.com/a/backfill-photo.jpg"}'::jsonb
+WHERE id = '00000000-0000-0000-0000-000000000001';
+
+SELECT is(
+    (SELECT display_name FROM public.user_profiles WHERE user_id = '00000000-0000-0000-0000-000000000001'),
+    'trigger-test@example.com',
+    'OAuth sync should not overwrite existing display_name'
+);
+
+SELECT is(
+    (SELECT avatar_url FROM public.user_profiles WHERE user_id = '00000000-0000-0000-0000-000000000001'),
+    'https://lh3.googleusercontent.com/a/backfill-photo.jpg',
+    'OAuth sync should backfill empty avatar_url'
+);
+
+UPDATE auth.users
+SET updated_at = now()
+WHERE id = '00000000-0000-0000-0000-000000000001';
+
+SELECT is(
+    (SELECT avatar_url FROM public.user_profiles WHERE user_id = '00000000-0000-0000-0000-000000000001'),
+    'https://lh3.googleusercontent.com/a/backfill-photo.jpg',
+    'OAuth sync should skip profile update when raw_user_meta_data is unchanged'
+);
+
+-- Test 15-16: OAuth sign-in does not overwrite user-edited profile fields
+UPDATE public.user_profiles
+SET
+    display_name = 'Custom Name',
+    avatar_url = 'https://example.com/custom-avatar.jpg'
+WHERE user_id = '00000000-0000-0000-0000-000000000002';
+
+UPDATE auth.users
+SET raw_user_meta_data = '{"email":"google-user@example.com","full_name":"Google Name","picture":"https://lh3.googleusercontent.com/a/new-google-photo.jpg"}'::jsonb
+WHERE id = '00000000-0000-0000-0000-000000000002';
+
+SELECT is(
+    (SELECT display_name FROM public.user_profiles WHERE user_id = '00000000-0000-0000-0000-000000000002'),
+    'Custom Name',
+    'OAuth sync should preserve user-edited display_name'
+);
+
+SELECT is(
+    (SELECT avatar_url FROM public.user_profiles WHERE user_id = '00000000-0000-0000-0000-000000000002'),
+    'https://example.com/custom-avatar.jpg',
+    'OAuth sync should preserve user-edited avatar_url'
+);
+
 SELECT * FROM finish();
 
 ROLLBACK;
-


### PR DESCRIPTION
## Summary

- Add DB triggers to copy Google (and Apple) OAuth display name and profile photo from `auth.users.raw_user_meta_data` into `user_profiles.display_name` and `user_profiles.avatar_url`
- Seed both fields on first signup; backfill empty profile fields on later OAuth sign-in without overwriting user edits in ProfileEditor
- Extend pgTAP coverage (22 assertions) and document the mapping in `docs/OAUTH.md`
- Add `provider` prop and accessibility labels to `SocialLoginButton`

## Problem

Google social sign-in authenticates users but only partially seeds `user_profiles`: `display_name` may fall back to email and `avatar_url` is never set. The UI reads `user_profiles` only, so users see initials/email instead of their OAuth name and photo.

## Test plan

- [x] `npm run test:db` (migration filenames + pgTAP, including `test_user_creation_trigger.sql` — 22/22)
- [x] `SocialLoginButton` unit tests (5/5)
- [x] Pre-commit type-check
- [ ] Manual: Google sign-in on web → header shows Google photo + name
- [ ] Manual: edit display name on `/profile` → sign out/in with Google → edited name preserved
- [ ] Manual: mobile Google sign-in → same profile row updated