### PR TITLE
fix: resolve CodeQL findings before develop→main promotion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -299,7 +299,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
       "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^2.1.3",
@@ -313,7 +312,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
@@ -3026,7 +3024,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
       "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3046,7 +3043,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
       "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3070,7 +3066,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
       "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3098,7 +3093,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3121,7 +3115,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
       "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14383,7 +14376,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
       "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^3.2.0",
@@ -14410,7 +14402,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
       "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^4.0.0",
@@ -14541,7 +14532,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/decode-uri-component": {
@@ -15468,7 +15458,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -18382,7 +18371,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
       "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-encoding": "^3.1.1"
@@ -18449,7 +18437,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -19163,7 +19150,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -20821,7 +20807,6 @@
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssstyle": "^4.2.1",
@@ -23160,7 +23145,6 @@
       "version": "2.2.23",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
       "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nyc": {
@@ -23885,7 +23869,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -25869,7 +25852,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -25989,7 +25971,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -26005,7 +25986,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -27185,7 +27165,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
@@ -27532,7 +27511,6 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
       "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^6.1.86"
@@ -27545,7 +27523,6 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tmp": {
@@ -27589,7 +27566,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
       "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"
@@ -27602,7 +27578,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
       "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -29173,7 +29148,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -29214,7 +29188,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -29225,7 +29198,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -29238,7 +29210,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -29257,7 +29228,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -29267,7 +29237,6 @@
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
       "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^5.1.0",
@@ -29575,7 +29544,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -29631,7 +29599,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/xtend": {
@@ -29783,7 +29750,8 @@
       "name": "@beakerstack/articles",
       "version": "1.0.0",
       "dependencies": {
-        "dompurify": "^3.4.7"
+        "dompurify": "^3.4.7",
+        "jsdom": "^26.1.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",
@@ -29797,7 +29765,6 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "gray-matter": "^4.0.3",
-        "jsdom": "^26.1.0",
         "marked": "^12.0.2",
         "prettier": "^3.1.0",
         "react": "18.2.0",
@@ -29935,7 +29902,8 @@
       "name": "@beakerstack/help",
       "version": "1.0.0",
       "dependencies": {
-        "dompurify": "^3.4.7"
+        "dompurify": "^3.4.7",
+        "jsdom": "^26.1.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",
@@ -29949,7 +29917,6 @@
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
-        "jsdom": "^26.1.0",
         "marked": "^12.0.2",
         "prettier": "^3.1.0",
         "react": "18.2.0",

--- a/packages/articles/package.json
+++ b/packages/articles/package.json
@@ -21,7 +21,8 @@
     "test:coverage": "vitest --coverage --run"
   },
   "dependencies": {
-    "dompurify": "^3.4.7"
+    "dompurify": "^3.4.7",
+    "jsdom": "^26.1.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
@@ -45,7 +46,6 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "gray-matter": "^4.0.3",
-    "jsdom": "^26.1.0",
     "marked": "^12.0.2",
     "prettier": "^3.1.0",
     "react": "18.2.0",

--- a/packages/articles/src/articleUtils.test.ts
+++ b/packages/articles/src/articleUtils.test.ts
@@ -25,6 +25,12 @@ describe('articleUtils', () => {
     expect(markdownToPlainText('- item\n\n# Title')).toContain('item');
   });
 
+  it('leaves malformed bracket syntax unchanged', () => {
+    expect(markdownToPlainText('[unclosed')).toBe('[unclosed');
+    expect(markdownToPlainText('[not a link]')).toBe('[not a link]');
+    expect(markdownToPlainText('[open](no-close')).toBe('[open](no-close');
+  });
+
   it('builds excerpts and truncates long copy', () => {
     expect(buildExcerpt('Short text')).toBe('Short text');
     const long = 'word '.repeat(80);

--- a/packages/articles/src/articleUtils.ts
+++ b/packages/articles/src/articleUtils.ts
@@ -13,19 +13,40 @@ export function slugifyTag(tag: string): string {
     .replace(/^-|-$/g, '');
 }
 
+/** Linear-time markdown link label extraction (avoids ReDoS-prone link regexes). */
+function stripMarkdownLinks(text: string): string {
+  let out = '';
+  let i = 0;
+  while (i < text.length) {
+    if (text[i] === '[') {
+      const labelStart = i + 1;
+      const bracketEnd = text.indexOf(']', labelStart);
+      if (bracketEnd !== -1 && text[bracketEnd + 1] === '(') {
+        const urlEnd = text.indexOf(')', bracketEnd + 2);
+        if (urlEnd !== -1) {
+          out += text.slice(labelStart, bracketEnd);
+          i = urlEnd + 1;
+          continue;
+        }
+      }
+    }
+    out += text[i];
+    i += 1;
+  }
+  return out;
+}
+
 export function computeReadingTimeMinutes(markdown: string): number {
-  const words = markdown
-    .replace(/```[\s\S]*?```/g, ' ')
-    .replace(/`[^`]+`/g, ' ')
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+  const words = stripMarkdownLinks(
+    markdown.replace(/```[\s\S]*?```/g, ' ').replace(/`[^`]+`/g, ' ')
+  )
     .split(/\s+/)
     .filter(Boolean).length;
   return Math.max(1, Math.ceil(words / 200));
 }
 
 export function markdownToPlainText(markdown: string): string {
-  return markdown
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+  return stripMarkdownLinks(markdown)
     .replace(/^[ \t]*[-*+] /gm, '')
     .replace(/[#*_`>~]/g, '')
     .replace(/\n+/g, ' ')

--- a/packages/articles/src/extractInternalLinks.test.ts
+++ b/packages/articles/src/extractInternalLinks.test.ts
@@ -14,6 +14,11 @@ See [MCP](/articles/what-is-mcp) and <a href="/articles/oauth-vs-api-keys-mcp">O
       'what-is-mcp',
     ]);
   });
+
+  it('ignores the tags listing slug', () => {
+    const body = 'Browse [tags](/articles/tags) and [post](/articles/my-post).';
+    expect(extractInternalArticleLinks(body)).toEqual(['my-post']);
+  });
 });
 
 describe('validateInternalLinks', () => {

--- a/packages/articles/src/sanitizeArticleHtml.test.ts
+++ b/packages/articles/src/sanitizeArticleHtml.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { sanitizeArticleHtml } from './sanitizeArticleHtml.js';
 
 describe('sanitizeArticleHtml', () => {
-  it('strips script tags', () => {
+  it('strips script tags including spaced end tags', () => {
     expect(
-      sanitizeArticleHtml('<p><script>alert(1)</script>Hello</p>')
-    ).not.toContain('<script>');
+      sanitizeArticleHtml('<p><script >alert(1)</script >Hello</p>')
+    ).not.toContain('<script');
     expect(sanitizeArticleHtml('<p><script>alert(1)</script>Hello</p>')).toBe(
       '<p>Hello</p>'
     );
@@ -20,6 +20,5 @@ describe('sanitizeArticleHtml', () => {
   it('neutralises javascript: hrefs', () => {
     const output = sanitizeArticleHtml('<a href="javascript:alert(1)">x</a>');
     expect(output).not.toContain('javascript:');
-    expect(output).toContain('href="#"');
   });
 });

--- a/packages/articles/src/sanitizeArticleHtml.ts
+++ b/packages/articles/src/sanitizeArticleHtml.ts
@@ -1,8 +1,9 @@
 import { JSDOM } from 'jsdom';
 import DOMPurify from 'dompurify';
 
+const purify = DOMPurify(new JSDOM('').window);
+
 /** Sanitize article HTML generated from trusted repo markdown at build time. */
 export function sanitizeArticleHtml(html: string): string {
-  const window = new JSDOM('').window;
-  return DOMPurify(window).sanitize(html);
+  return purify.sanitize(html);
 }

--- a/packages/connections/vitest.config.ts
+++ b/packages/connections/vitest.config.ts
@@ -1,8 +1,5 @@
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
-const pkgRoot = path.dirname(fileURLToPath(import.meta.url));
 const mergeCoverage = process.env.COVERAGE_MERGE === '1';
 
 export default defineConfig({

--- a/packages/help/package.json
+++ b/packages/help/package.json
@@ -21,7 +21,8 @@
     "test:coverage": "vitest --coverage --run"
   },
   "dependencies": {
-    "dompurify": "^3.4.7"
+    "dompurify": "^3.4.7",
+    "jsdom": "^26.1.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
@@ -44,7 +45,6 @@
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
-    "jsdom": "^26.1.0",
     "marked": "^12.0.2",
     "prettier": "^3.1.0",
     "react": "18.2.0",

--- a/packages/help/scripts/build-help.test.ts
+++ b/packages/help/scripts/build-help.test.ts
@@ -99,6 +99,12 @@ OAuth-secured MCP-compatible row-level access.
     );
   });
 
+  it('leaves malformed bracket syntax unchanged', () => {
+    expect(markdownToPlainText('[unclosed')).toBe('[unclosed');
+    expect(markdownToPlainText('[not a link]')).toBe('[not a link]');
+    expect(markdownToPlainText('[open](no-close')).toBe('[open](no-close');
+  });
+
   it('lineAt returns empty string for out-of-range indexes', () => {
     expect(lineAt(['a'], 3)).toBe('');
   });

--- a/packages/help/scripts/build-help.ts
+++ b/packages/help/scripts/build-help.ts
@@ -5,6 +5,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { marked } from 'marked';
 import { format, resolveConfig } from 'prettier';
 import type { Legal } from '../../../adopter/config/legal.ts';
+import { sanitizeHelpHtml } from '../src/sanitizeHelpHtml.js';
 import type { HelpContent } from '../src/types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -34,21 +35,35 @@ export function lineAt(lines: readonly string[], index: number): string {
   return lines.at(index) ?? '';
 }
 
+function stripMarkdownLinks(text: string): string {
+  let out = '';
+  let i = 0;
+  while (i < text.length) {
+    if (text[i] === '[') {
+      const labelStart = i + 1;
+      const bracketEnd = text.indexOf(']', labelStart);
+      if (bracketEnd !== -1 && text[bracketEnd + 1] === '(') {
+        const urlEnd = text.indexOf(')', bracketEnd + 2);
+        if (urlEnd !== -1) {
+          out += text.slice(labelStart, bracketEnd);
+          i = urlEnd + 1;
+          continue;
+        }
+      }
+    }
+    out += text[i];
+    i += 1;
+  }
+  return out;
+}
+
 export function markdownToPlainText(markdown: string): string {
-  return markdown
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+  return stripMarkdownLinks(markdown)
     .replace(/^[ \t]*[-*+] /gm, '')
     .replace(/[#*_`>~]/g, '')
     .replace(/\n+/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
-}
-
-function sanitizeHelpHtml(html: string): string {
-  return html
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-    .replace(/\s(on\w+)=("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
-    .replace(/href\s*=\s*["']javascript:[^"']*["']/gi, 'href="#"');
 }
 
 export function parseHelpMarkdown(raw: string, legal: Legal): HelpContent {

--- a/packages/help/src/sanitizeHelpHtml.test.ts
+++ b/packages/help/src/sanitizeHelpHtml.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeHelpHtml } from './sanitizeHelpHtml.js';
+
+describe('sanitizeHelpHtml', () => {
+  it('strips script tags including spaced end tags', () => {
+    expect(
+      sanitizeHelpHtml('<p><script >alert(1)</script >Hello</p>')
+    ).not.toContain('<script');
+    expect(sanitizeHelpHtml('<p><script>alert(1)</script>Hello</p>')).toBe(
+      '<p>Hello</p>'
+    );
+  });
+
+  it('removes event handler attributes', () => {
+    expect(sanitizeHelpHtml('<img src="x" onerror="alert(1)">')).not.toContain(
+      'onerror'
+    );
+  });
+
+  it('neutralises javascript: hrefs', () => {
+    const output = sanitizeHelpHtml('<a href="javascript:alert(1)">x</a>');
+    expect(output).not.toContain('javascript:');
+  });
+});

--- a/packages/help/src/sanitizeHelpHtml.ts
+++ b/packages/help/src/sanitizeHelpHtml.ts
@@ -1,8 +1,8 @@
 import { JSDOM } from 'jsdom';
 import DOMPurify from 'dompurify';
 
-/** Sanitize article HTML generated from trusted repo markdown at build time. */
-export function sanitizeArticleHtml(html: string): string {
+/** Sanitize help HTML generated from trusted repo markdown at build time. */
+export function sanitizeHelpHtml(html: string): string {
   const window = new JSDOM('').window;
   return DOMPurify(window).sanitize(html);
 }

--- a/packages/help/src/sanitizeHelpHtml.ts
+++ b/packages/help/src/sanitizeHelpHtml.ts
@@ -1,8 +1,9 @@
 import { JSDOM } from 'jsdom';
 import DOMPurify from 'dompurify';
 
+const purify = DOMPurify(new JSDOM('').window);
+
 /** Sanitize help HTML generated from trusted repo markdown at build time. */
 export function sanitizeHelpHtml(html: string): string {
-  const window = new JSDOM('').window;
-  return DOMPurify(window).sanitize(html);
+  return purify.sanitize(html);
 }


### PR DESCRIPTION
## Summary

Addresses [CodeQL](https://github.com/Artificer-Innovations/BeakerStack/pull/395) and [code quality](https://github.com/Artificer-Innovations/BeakerStack/pull/395) review comments blocking the develop→main promotion in #395.

- **HTML sanitization** — Replace regex-based script/event-handler stripping in `@beakerstack/articles` and `@beakerstack/help` with DOMPurify + JSDOM at build time (same library already used at render time).
- **ReDoS** — Replace polynomial markdown link regex in `articleUtils` / `build-help` with linear `stripMarkdownLinks` parsing.
- **Lint** — Remove unused `pkgRoot` and path imports from `packages/connections/vitest.config.ts`.

## Test plan

- [x] `packages/articles` — `npm test` (71 tests)
- [x] `packages/help` — `npm test` (41 tests)
- [x] `packages/connections` — `npm test` (56 tests)
- [ ] CI CodeQL check passes on this PR
- [ ] Merge to `develop`, then re-run #395 promotion