### PR TITLE
fix(web): scan help package in Tailwind content globs

### DIFF
--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -11,6 +11,7 @@ export default {
     '../../packages/shared/src/config/**/*.{js,ts}',
     '../../packages/articles/src/**/*.{js,ts,jsx,tsx}',
     '../../packages/connections/src/**/*.{js,ts,jsx,tsx}',
+    '../../packages/help/src/**/*.{js,ts,jsx,tsx}',
     '../../adopter/web/**/*.{js,ts,jsx,tsx}',
   ],
   safelist: [


### PR DESCRIPTION
## Summary

Resolves the Copilot review on [#395](https://github.com/Artificer-Innovations/BeakerStack/pull/395) (not covered by [#396](https://github.com/Artificer-Innovations/BeakerStack/pull/396)).

`HelpPage` renders `@beakerstack/help/web` components with Tailwind classes. The web app already scans `packages/articles` and `packages/connections` for JIT classes; this adds `packages/help` so those styles are not purged in production builds.

## Change

```ts
'../../packages/help/src/**/*.{js,ts,jsx,tsx}',
```

in `apps/web/tailwind.config.ts` `content` array.

## Test plan

- [ ] CI green
- [ ] After merge to `develop`, smoke `/help` on staging — accordion, search, and layout styles present
- [ ] Re-run [#395](https://github.com/Artificer-Innovations/BeakerStack/pull/395) develop→main promotion once merged