### PR TITLE
fix(deps): upgrade react-router-dom to 6.30.4 (CVE-2026-40181)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,7 +31,7 @@
     "lucide-react": "^0.460.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-router-dom": "^6.30.3",
+    "react-router-dom": "^6.30.4",
     "zod": "^3.22.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,7 +134,7 @@
         "lucide-react": "^0.460.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-router-dom": "^6.30.3",
+        "react-router-dom": "^6.30.4",
         "zod": "^3.22.0"
       },
       "devDependencies": {
@@ -9653,9 +9653,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -25246,12 +25246,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -25261,13 +25261,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -29719,7 +29719,7 @@
         "jsdom": "^26.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.30.3",
+        "react-router-dom": "^6.30.4",
         "typescript": "^5.3.0",
         "vitest": "^4.1.8"
       },
@@ -29769,7 +29769,7 @@
         "prettier": "^3.1.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-router-dom": "^6.30.3",
+        "react-router-dom": "^6.30.4",
         "tsx": "^4.19.0",
         "typescript": "^5.3.0",
         "vitest": "^4.1.8",
@@ -29778,7 +29778,7 @@
       "peerDependencies": {
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-router-dom": "^6.30.3"
+        "react-router-dom": "^6.30.4"
       },
       "peerDependenciesMeta": {
         "react-dom": {

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -37,7 +37,7 @@
     "jsdom": "^26.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.30.3",
+    "react-router-dom": "^6.30.4",
     "typescript": "^5.3.0",
     "@vitest/coverage-v8": "^4.1.8",
     "vitest": "^4.1.8"

--- a/packages/articles/package.json
+++ b/packages/articles/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-router-dom": "^6.30.3"
+    "react-router-dom": "^6.30.4"
   },
   "peerDependenciesMeta": {
     "react-dom": {
@@ -50,7 +50,7 @@
     "prettier": "^3.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-router-dom": "^6.30.3",
+    "react-router-dom": "^6.30.4",
     "tsx": "^4.19.0",
     "typescript": "^5.3.0",
     "vitest": "^4.1.8",


### PR DESCRIPTION
## Summary

- Bumps `react-router-dom` from `^6.30.3` to `^6.30.4` in `apps/web`, `@beakerstack/admin`, and `@beakerstack/articles`
- Updates `package-lock.json` so transitive `react-router` resolves to `6.30.4`
- Resolves Dependabot alert #22 (GHSA-2j2x-hqr9-3h42 / CVE-2026-40181): open redirect via protocol-relative URLs in React Router's `redirect()` function

## Test plan

- [ ] `npm install` completes with 0 vulnerabilities
- [ ] Web app routing still works (declarative `<BrowserRouter>` mode is unaffected by this CVE, but upgrade clears the alert)
- [ ] CI passes