### PR TITLE
Fix AI code quality findings in setup, help, and mobile profile

### DIFF
--- a/apps/mobile/src/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen.tsx
@@ -24,7 +24,6 @@ import { ProfileStats } from '@beakerstack/shared/components/profile/ProfileStat
 // @ts-ignore - Dynamic imports are supported by Metro, TypeScript error is a false positive
 import type { ProfileEditorProps } from '@beakerstack/shared/components/profile/ProfileEditor.native';
 import { loadProfileEditorModule } from './profileEditorLoader';
-let ProfileEditor: React.ComponentType<ProfileEditorProps> | null = null;
 
 type RootStackParamList = {
   Home: undefined;
@@ -78,28 +77,28 @@ export default function ProfileScreen({ navigation }: Props) {
   }
 
   // Render protected content if authenticated
-  return <ProfileScreenContent navigation={navigation} />;
+  return <ProfileScreenContent />;
 }
 
-function ProfileScreenContent({ navigation: _navigation }: Props) {
+function ProfileScreenContent() {
   const [isEditing, setIsEditing] = useState(false);
-  const [componentsLoaded, setComponentsLoaded] = useState(false);
+  const [ProfileEditor, setProfileEditor] =
+    useState<React.ComponentType<ProfileEditorProps> | null>(null);
   const auth = useAuthContext();
   const profile = useProfileContext();
 
   // Lazy load ProfileEditor only when editing
   useEffect(() => {
-    if (isEditing && !componentsLoaded) {
+    if (isEditing && !ProfileEditor) {
       loadProfileEditorModule()
         .then(module => {
-          ProfileEditor = module.ProfileEditor;
-          setComponentsLoaded(true);
+          setProfileEditor(() => module.ProfileEditor);
         })
         .catch(err => {
           Logger.error('[ProfileScreen] Failed to load ProfileEditor:', err);
         });
     }
-  }, [isEditing, componentsLoaded]);
+  }, [isEditing, ProfileEditor]);
 
   return (
     <SafeAreaView style={styles.container}>
@@ -158,7 +157,7 @@ function ProfileScreenContent({ navigation: _navigation }: Props) {
 
             {isEditing && (
               <View style={styles.card}>
-                {componentsLoaded && ProfileEditor ? (
+                {ProfileEditor ? (
                   <ProfileEditor
                     onSuccess={() => {
                       // Refresh profile data after successful update

--- a/packages/help/scripts/build-help.ts
+++ b/packages/help/scripts/build-help.ts
@@ -111,7 +111,7 @@ export function parseHelpMarkdown(raw: string, legal: Legal): HelpContent {
     sections: sectionBlocks.map(({ title: sectionTitle, body }) => ({
       id: slugify(sectionTitle),
       title: sectionTitle,
-      html: sanitizeHelpHtml(marked.parse(body) as string),
+      html: sanitizeHelpHtml(marked.parser(marked.lexer(body))),
       searchText: markdownToPlainText(body),
     })),
   };

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -87,7 +87,10 @@ import {
   runCmd,
 } from './lib/setup-supabase.mjs';
 import { buildNameVariants } from './rename-project.mjs';
-import { detectRepoIdentity, readBrandingSource } from './lib/detect-repo-identity.mjs';
+import {
+  detectRepoIdentity,
+  readBrandingSource,
+} from './lib/detect-repo-identity.mjs';
 import {
   ACM_CLOUDFRONT_REGION,
   discoverIssuedCertsCoveringApexWildcard,
@@ -457,7 +460,9 @@ export function slugBaseFromAppConfigText(text) {
  * @returns {Promise<string>} lowercase alnum segment, e.g. poststack or beakerstack
  */
 async function readSupabaseProjectSlugBase() {
-  const brandingResult = slugBaseFromBrandingText(await readBrandingSource(REPO_ROOT));
+  const brandingResult = slugBaseFromBrandingText(
+    await readBrandingSource(REPO_ROOT)
+  );
   if (brandingResult) return brandingResult;
   try {
     const appConfigResult = slugBaseFromAppConfigText(
@@ -1208,9 +1213,6 @@ async function resolveAwsPreflightConflictsInteractive(
   }
 }
 
-/**
- * @param {CliFlags} flags
- */
 function ghAuthOk() {
   const r = spawnSync('gh', ['auth', 'status'], {
     cwd: REPO_ROOT,
@@ -1220,9 +1222,6 @@ function ghAuthOk() {
   return r.status === 0;
 }
 
-/**
- * @param {CliFlags} flags
- */
 function easWhoamiOk() {
   const r = spawnSync('npx', ['--yes', 'eas-cli', 'whoami'], {
     cwd: MOBILE_DIR,
@@ -2894,7 +2893,7 @@ async function main() {
   }
 }
 
-if (import.meta.url === url.pathToFileURL(process.argv[1] || '').href) {
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
   main().catch(err => {
     console.error(
       '[setup] Fatal:',


### PR DESCRIPTION
## Summary
- Remove stale `@param {CliFlags} flags` JSDoc from `ghAuthOk` and `easWhoamiOk` in `setup-full.mjs`, and fix main-module detection to compare resolved paths via `__filename`.
- Parse help markdown with `marked.lexer` + `marked.parser` so build output is always a synchronous HTML string (avoids `Promise`/`[object Promise]` edge cases and satisfies TypeScript).
- Store lazy-loaded `ProfileEditor` in component state instead of a module-level mutable, and drop the unused `navigation` prop from `ProfileScreenContent`.

## Test plan
- [x] `cd packages/help && npx tsc --noEmit`
- [x] `cd packages/help && npx vitest run build-help.test.ts`
- [x] Pre-commit hook type-check passed (mobile, web, shared, help, etc.)