### PR TITLE
fix: restore 100% package coverage after Vitest 4 upgrade

### DIFF
--- a/packages/admin/src/components/AdminDetailDrawer.web.test.tsx
+++ b/packages/admin/src/components/AdminDetailDrawer.web.test.tsx
@@ -307,4 +307,19 @@ describe('AdminDetailDrawer', () => {
     await user.click(screen.getByLabelText('Close'));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it('does not trap Tab when focus is not on the last element', () => {
+    render(
+      <AdminDetailDrawer open title='User' onClose={vi.fn()}>
+        <input aria-label='Notes' />
+        <button type='button'>Save</button>
+      </AdminDetailDrawer>
+    );
+    const notes = screen.getByLabelText('Notes');
+    notes.focus();
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Tab', bubbles: true })
+    );
+    expect(document.activeElement).toBe(notes);
+  });
 });

--- a/packages/admin/src/components/AdminTable.web.test.tsx
+++ b/packages/admin/src/components/AdminTable.web.test.tsx
@@ -123,4 +123,21 @@ describe('AdminTable', () => {
     await user.click(screen.getByText('Ada'));
     expect(onRowClick).toHaveBeenCalledWith({ id: '1', name: 'Ada' });
   });
+
+  it('ignores non-activation keys on clickable rows', async () => {
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AdminTable
+        columns={columns}
+        rows={[{ id: '1', name: 'Ada' }]}
+        getRowKey={r => r.id}
+        onRowClick={onRowClick}
+      />
+    );
+    const row = screen.getByRole('button', { name: 'View details for 1' });
+    row.focus();
+    await user.keyboard('{ArrowDown}');
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
 });

--- a/packages/billing/src/BillingProvider.test.tsx
+++ b/packages/billing/src/BillingProvider.test.tsx
@@ -569,7 +569,7 @@ describe('BillingProvider', () => {
     let resolveSession: (value: {
       data: { session: { user: { id: string } } | null };
     }) => void = () => {};
-    auth.getSession.mockImplementation(
+    auth.getSession.mockImplementationOnce(
       () =>
         new Promise(resolve => {
           resolveSession = resolve;
@@ -584,5 +584,106 @@ describe('BillingProvider', () => {
     resolveSession({ data: { session: { user: { id: 'late-user' } } } });
     await Promise.resolve();
     expect(db.maybeSingle).not.toHaveBeenCalled();
+  });
+
+  it('ignores plan query result after unmount', async () => {
+    let resolvePlan: (value: {
+      data: ReturnType<typeof testPlan> | null;
+      error: null;
+    }) => void = () => {};
+    auth.state.session = { user: { id: 'u-plan-unmount' } };
+    const row = {
+      ...testSubscription(),
+      user_id: 'u-plan-unmount',
+      plan_id: 'plan_free',
+    };
+    db.maybeSingle.mockResolvedValue({ data: row, error: null });
+    db.planMaybeSingle.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolvePlan = resolve;
+        })
+    );
+    const { unmount } = render(
+      <BillingProvider config={testBillingConfig} {...providerProps}>
+        <PlanReader />
+      </BillingProvider>
+    );
+    await waitFor(() => expect(db.planMaybeSingle).toHaveBeenCalled());
+    unmount();
+    resolvePlan({ data: testPlan({ display_name: 'Late plan' }), error: null });
+    await Promise.resolve();
+  });
+
+  it('ignores ensure_billing_subscription result after unmount', async () => {
+    let resolveRpc: (value: { error: null }) => void = () => {};
+    auth.state.session = { user: { id: 'u-rpc-unmount' } };
+    db.rpc.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveRpc = resolve;
+        })
+    );
+    const { unmount } = render(
+      <BillingProvider config={testBillingConfig} {...providerProps}>
+        <Reader />
+      </BillingProvider>
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('uid').textContent).toBe('u-rpc-unmount')
+    );
+    await waitFor(() => expect(db.rpc).toHaveBeenCalled());
+    unmount();
+    resolveRpc({ error: null });
+    await Promise.resolve();
+  });
+
+  it('ignores plan query errors after unmount', async () => {
+    let rejectPlan: (error: Error) => void = () => {};
+    auth.state.session = { user: { id: 'u-plan-err-unmount' } };
+    const row = {
+      ...testSubscription(),
+      user_id: 'u-plan-err-unmount',
+      plan_id: 'plan_free',
+    };
+    db.maybeSingle.mockResolvedValue({ data: row, error: null });
+    db.planMaybeSingle.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectPlan = reject;
+        })
+    );
+    const { unmount } = render(
+      <BillingProvider config={testBillingConfig} {...providerProps}>
+        <PlanReader />
+      </BillingProvider>
+    );
+    await waitFor(() => expect(db.planMaybeSingle).toHaveBeenCalled());
+    unmount();
+    rejectPlan(new Error('late plan fail'));
+    await Promise.resolve();
+  });
+
+  it('ignores ensure_billing_subscription errors after unmount', async () => {
+    let rejectRpc: (error: Error) => void = () => {};
+    auth.state.session = { user: { id: 'u-rpc-err-unmount' } };
+    db.rpc.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectRpc = reject;
+        })
+    );
+    const { unmount } = render(
+      <BillingProvider config={testBillingConfig} {...providerProps}>
+        <Reader />
+      </BillingProvider>
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('uid').textContent).toBe('u-rpc-err-unmount')
+    );
+    await waitFor(() => expect(db.rpc).toHaveBeenCalled());
+    unmount();
+    rejectRpc(new Error('late rpc fail'));
+    await Promise.resolve();
   });
 });

--- a/packages/billing/src/components/SubscriptionStatusBadge.native.test.tsx
+++ b/packages/billing/src/components/SubscriptionStatusBadge.native.test.tsx
@@ -72,6 +72,15 @@ describe('SubscriptionStatusBadge (native)', () => {
     expect(screen.getAllByLabelText('Active').length).toBeGreaterThan(0);
   });
 
+  it('keeps raw status label for unrecognized statuses', () => {
+    render(
+      <SubscriptionStatusBadge
+        subscription={testSubscription({ status: 'canceled' })}
+      />
+    );
+    expect(screen.getByLabelText('canceled')).toBeInTheDocument();
+  });
+
   it('shows em dash in cancelling label when period end is missing', () => {
     render(
       <SubscriptionStatusBadge

--- a/packages/billing/src/hooks/useBillingState.test.tsx
+++ b/packages/billing/src/hooks/useBillingState.test.tsx
@@ -87,6 +87,15 @@ describe('useBillingState', () => {
     expect(result.current.kind).toBe('trialing');
   });
 
+  it('classifies trialing without trial_end as trialing', () => {
+    hp.subscription = testSubscription({
+      status: 'trialing',
+      trial_end: null,
+    });
+    const { result } = renderHook(() => useBillingState());
+    expect(result.current.kind).toBe('trialing');
+  });
+
   it('classifies cancel_at_period_end without pending target as cancelled_pending', () => {
     hp.subscription = testSubscription({
       status: 'active',

--- a/packages/billing/src/hooks/useInvoices.test.tsx
+++ b/packages/billing/src/hooks/useInvoices.test.tsx
@@ -190,4 +190,41 @@ describe('useInvoices', () => {
     expect(result.current.items).toEqual([]);
     expect(result.current.hasMore).toBe(false);
   });
+
+  it('preserves existing items when loadMore fails', async () => {
+    const inv: BillingInvoiceRow = {
+      id: 'inv1',
+      user_id: 'user-1',
+      stripe_invoice_id: 'in_1',
+      stripe_customer_id: 'cus',
+      stripe_subscription_id: null,
+      amount_due: 100,
+      amount_paid: 0,
+      currency: 'usd',
+      status: 'open',
+      description: null,
+      hosted_invoice_url: null,
+      invoice_pdf_url: null,
+      period_start: null,
+      period_end: null,
+      created_at: '2026-01-02T00:00:00.000Z',
+      finalized_at: null,
+      paid_at: null,
+    };
+    range
+      .mockResolvedValueOnce({
+        data: Array.from({ length: 20 }, (_, i) => ({ ...inv, id: `i${i}` })),
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: new Error('page two failed'),
+      });
+    const { result } = renderHook(() => useInvoices({ pageSize: 20 }));
+    await waitFor(() => expect(result.current.items.length).toBe(20));
+    await result.current.loadMore();
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.items).toHaveLength(20);
+    expect(result.current.hasMore).toBe(false);
+  });
 });

--- a/packages/billing/src/hooks/useUsage.ts
+++ b/packages/billing/src/hooks/useUsage.ts
@@ -33,7 +33,7 @@ export function useUsage<
   const [snap, setSnap] = useState<RpcRow | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<BillingError | null>(null);
-  const fetchUsageRef = useRef<() => Promise<void>>(async () => {});
+  const fetchUsageRef = useRef<(() => Promise<void>) | undefined>(undefined);
 
   const fetchUsage = useCallback(async () => {
     setLoading(true);
@@ -112,7 +112,7 @@ export function useUsage<
           row?.product_id === config.productId &&
           row?.event_type === meterKey
         ) {
-          void fetchUsageRef.current();
+          void fetchUsageRef.current?.();
         }
       }
     ).subscribe();

--- a/packages/billing/src/utils/parseBillingFunctionError.test.ts
+++ b/packages/billing/src/utils/parseBillingFunctionError.test.ts
@@ -34,4 +34,12 @@ describe('parseBillingFunctionError', () => {
     expect(err.kind).toBe('stripe');
     expect(err.message).toBe('Billing request failed');
   });
+
+  it('ignores whitespace-only error strings in the body', () => {
+    const err = parseBillingFunctionError(
+      { error: '   ' },
+      new Error('invoke')
+    );
+    expect(err.message).toContain('invoke');
+  });
 });

--- a/packages/connections/src/hooks/useConnections.test.tsx
+++ b/packages/connections/src/hooks/useConnections.test.tsx
@@ -249,4 +249,44 @@ describe('useConnections', () => {
     expect(channel.on).not.toHaveBeenCalled();
     expect(channel.subscribe).not.toHaveBeenCalled();
   });
+
+  it('refresh reloads connections', async () => {
+    let calls = 0;
+    const supabase = createMockSupabase(async () => {
+      calls += 1;
+      return { data: calls === 1 ? [row] : [], error: null };
+    });
+    const { result } = renderHook(() =>
+      useConnections({ supabase, userId: UUID_A })
+    );
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+    await result.current.refresh();
+    await waitFor(() => expect(result.current.rows).toHaveLength(0));
+    expect(calls).toBe(2);
+  });
+
+  it('ignores debounced reload after unmount', async () => {
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi
+      .spyOn(globalThis, 'clearTimeout')
+      .mockImplementation(() => undefined);
+    try {
+      let calls = 0;
+      const supabase = createMockSupabase(async () => {
+        calls += 1;
+        return { data: [row], error: null };
+      });
+      const { unmount } = renderHook(() =>
+        useConnections({ supabase, userId: UUID_A })
+      );
+      await vi.waitFor(() => expect(calls).toBe(1));
+      emitConnectionChange(supabase);
+      unmount();
+      await vi.advanceTimersByTimeAsync(450);
+      expect(calls).toBe(1);
+    } finally {
+      clearTimeoutSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/connections/src/hooks/useConnections.test.tsx
+++ b/packages/connections/src/hooks/useConnections.test.tsx
@@ -266,10 +266,18 @@ describe('useConnections', () => {
   });
 
   it('ignores debounced reload after unmount', async () => {
-    vi.useFakeTimers();
-    const clearTimeoutSpy = vi
-      .spyOn(globalThis, 'clearTimeout')
-      .mockImplementation(() => undefined);
+    let debouncedCallback: (() => void) | undefined;
+    const originalSetTimeout = globalThis.setTimeout.bind(globalThis);
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((handler, delay, ...args) => {
+        if (typeof handler === 'function' && delay === 400) {
+          debouncedCallback = handler as () => void;
+        }
+        return originalSetTimeout(handler, delay, ...args);
+      });
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
     try {
       let calls = 0;
       const supabase = createMockSupabase(async () => {
@@ -279,14 +287,17 @@ describe('useConnections', () => {
       const { unmount } = renderHook(() =>
         useConnections({ supabase, userId: UUID_A })
       );
-      await vi.waitFor(() => expect(calls).toBe(1));
+      await waitFor(() => expect(calls).toBe(1));
       emitConnectionChange(supabase);
+      expect(debouncedCallback).toBeDefined();
       unmount();
-      await vi.advanceTimersByTimeAsync(450);
+      debouncedCallback?.();
+      await Promise.resolve();
       expect(calls).toBe(1);
+      expect(clearTimeoutSpy).toHaveBeenCalled();
     } finally {
+      setTimeoutSpy.mockRestore();
       clearTimeoutSpy.mockRestore();
-      vi.useRealTimers();
     }
   });
 });

--- a/packages/marketing-email/src/__tests__/kitClient.test.ts
+++ b/packages/marketing-email/src/__tests__/kitClient.test.ts
@@ -123,6 +123,24 @@ describe('KitClient', () => {
         'Kit API POST /forms/f/subscribers → 400 Bad Request'
       );
     });
+
+    it('handles response.text() rejection on HTTP error', async () => {
+      fetchMock.mockReturnValue(
+        Promise.resolve({
+          ok: false,
+          status: 502,
+          statusText: 'Bad Gateway',
+          text: () => Promise.reject(new Error('body unreadable')),
+        } as Response)
+      );
+      const err = await client
+        .subscribeToForm('u@e.com', 'f')
+        .catch(e => e as KitClientError);
+      expect(err.code).toBe('kit_api_502');
+      expect(err.message).toBe(
+        'Kit API POST /forms/f/subscribers → 502 Bad Gateway'
+      );
+    });
   });
 
   describe('applyTag', () => {

--- a/packages/observability/src/__tests__/ObservabilityProvider.web.test.tsx
+++ b/packages/observability/src/__tests__/ObservabilityProvider.web.test.tsx
@@ -142,4 +142,17 @@ describe('ObservabilityProvider (web)', () => {
       expect.any(Function)
     );
   });
+
+  it('ignores Sentry load after unmount', async () => {
+    const { unmount } = render(
+      <ObservabilityProvider config={config}>
+        <div>child</div>
+      </ObservabilityProvider>
+    );
+    unmount();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(SentryMock.setUser).not.toHaveBeenCalled();
+  });
 });

--- a/packages/observability/src/__tests__/ObservabilityProvider.web.test.tsx
+++ b/packages/observability/src/__tests__/ObservabilityProvider.web.test.tsx
@@ -144,15 +144,38 @@ describe('ObservabilityProvider (web)', () => {
   });
 
   it('ignores Sentry load after unmount', async () => {
-    const { unmount } = render(
-      <ObservabilityProvider config={config}>
-        <div>child</div>
-      </ObservabilityProvider>
-    );
-    unmount();
-    await act(async () => {
-      await Promise.resolve();
+    vi.resetModules();
+
+    let resolvePendingSentry!: (value: typeof SentryMock) => void;
+    const pendingSentry = new Promise<typeof SentryMock>(resolve => {
+      resolvePendingSentry = resolve;
     });
-    expect(SentryMock.setUser).not.toHaveBeenCalled();
+    vi.doMock('@sentry/react', () => pendingSentry);
+
+    const { ObservabilityProvider } =
+      await import('../components/ObservabilityProvider.web.js');
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const { unmount } = render(
+        <ObservabilityProvider config={config}>
+          <div>child</div>
+        </ObservabilityProvider>
+      );
+      unmount();
+      resolvePendingSentry(SentryMock);
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      const unmountedWarnings = consoleSpy.mock.calls.filter(([message]) =>
+        String(message).toLowerCase().includes('unmounted')
+      );
+      expect(unmountedWarnings).toHaveLength(0);
+    } finally {
+      consoleSpy.mockRestore();
+      vi.resetModules();
+      vi.doUnmock('@sentry/react');
+    }
   });
 });

--- a/packages/observability/src/__tests__/sentryDynamicImport.coverage.test.ts
+++ b/packages/observability/src/__tests__/sentryDynamicImport.coverage.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+describe('Sentry dynamic import fallbacks', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('@sentry/react');
+    vi.doUnmock('@sentry/react-native');
+  });
+
+  it('ObservabilityProvider survives a rejected @sentry/react import', async () => {
+    vi.doMock('@sentry/react', () => Promise.reject(new Error('chunk failed')));
+    const { ObservabilityProvider } =
+      await import('../components/ObservabilityProvider.web.js');
+    const React = await import('react');
+    const { render, screen } = await import('@testing-library/react');
+
+    render(
+      React.createElement(
+        ObservabilityProvider,
+        { config: { project: 'test', environment: 'test' } },
+        React.createElement('div', null, 'child')
+      )
+    );
+    expect(screen.getByText('child')).toBeInTheDocument();
+  });
+
+  it('withErrorBoundary.web survives a rejected @sentry/react import', async () => {
+    vi.doMock('@sentry/react', () => Promise.reject(new Error('chunk failed')));
+    const { ErrorBoundary } =
+      await import('../components/withErrorBoundary.web.js');
+    const React = await import('react');
+    const { render, screen } = await import('@testing-library/react');
+
+    function Thrower() {
+      throw new Error('boom');
+    }
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      render(
+        React.createElement(ErrorBoundary, null, React.createElement(Thrower))
+      );
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it('withErrorBoundary.native survives a rejected @sentry/react-native import', async () => {
+    vi.doMock('@sentry/react-native', () =>
+      Promise.reject(new Error('chunk failed'))
+    );
+    const { ErrorBoundary } =
+      await import('../components/withErrorBoundary.native.js');
+    const React = await import('react');
+    const { render, screen } = await import('@testing-library/react');
+
+    function Thrower() {
+      throw new Error('boom');
+    }
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      render(
+        React.createElement(ErrorBoundary, null, React.createElement(Thrower))
+      );
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});

--- a/packages/shared-tests/__tests__/components/navigation/UserMenu.test.tsx
+++ b/packages/shared-tests/__tests__/components/navigation/UserMenu.test.tsx
@@ -345,6 +345,23 @@ describe('UserMenu (Web)', () => {
     });
   });
 
+  it('should close menu when Connections link is clicked', async () => {
+    renderWithProviders(<UserMenu user={mockUser} profile={mockProfile} />);
+    const menuButton = screen.getByLabelText('User menu');
+    fireEvent.click(menuButton);
+    await waitFor(() =>
+      expect(
+        screen.getByRole('link', { name: 'Connections' })
+      ).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Connections' }));
+
+    await waitFor(() => {
+      expect(menuButton).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
   it('should not render email row when user has no email', async () => {
     const userWithoutEmail: User = { ...mockUser, email: undefined };
     renderWithProviders(

--- a/packages/waitlist/src/hooks/useSignupMode.test.tsx
+++ b/packages/waitlist/src/hooks/useSignupMode.test.tsx
@@ -18,4 +18,27 @@ describe('useSignupMode', () => {
     expect(result.current.isOpen).toBe(false);
     vi.restoreAllMocks();
   });
+
+  it('ignores settings result after unmount', async () => {
+    let resolveSettings: (value: {
+      signup_mode: 'open';
+      copy: Record<string, never>;
+      metadata_schema: never[];
+    }) => void = () => {};
+    vi.spyOn(client, 'getPublicWaitlistSettings').mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveSettings = resolve;
+        })
+    );
+    const supabase = {} as never;
+    const { unmount } = renderHook(() => useSignupMode(supabase));
+    await waitFor(() =>
+      expect(client.getPublicWaitlistSettings).toHaveBeenCalled()
+    );
+    unmount();
+    resolveSettings({ signup_mode: 'open', copy: {}, metadata_schema: [] });
+    await Promise.resolve();
+    vi.restoreAllMocks();
+  });
 });


### PR DESCRIPTION
## Summary
- Restores 100/100/100/100 coverage (statements, branches, functions, lines) across all Vitest packages after the Vitest 4.1.8 upgrade introduced stricter v8 branch counting.
- Adds targeted tests for async cancellation guards, dynamic Sentry import fallbacks, debounced realtime reloads, and other edge-case branches in billing, admin, connections, observability, waitlist, marketing-email, and shared-tests.
- Fixes a `BillingProvider` test mock leak (`getSession` hanging mock) and a minor `useUsage` ref typing issue uncovered by type-check.

## Test plan
- [x] `npm run test:coverage` — all package shards report 100% on statements, branches, functions, and lines
- [x] Pre-commit hooks pass (eslint, prettier, full monorepo type-check)
- [ ] CI unit-coverage-shard jobs pass on PR