### PR TITLE
release: promote develop to main (router security, coverage)

### DIFF
--- a/apps/mobile/src/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen.tsx
@@ -24,7 +24,6 @@ import { ProfileStats } from '@beakerstack/shared/components/profile/ProfileStat
 // @ts-ignore - Dynamic imports are supported by Metro, TypeScript error is a false positive
 import type { ProfileEditorProps } from '@beakerstack/shared/components/profile/ProfileEditor.native';
 import { loadProfileEditorModule } from './profileEditorLoader';
-let ProfileEditor: React.ComponentType<ProfileEditorProps> | null = null;
 
 type RootStackParamList = {
   Home: undefined;
@@ -78,28 +77,28 @@ export default function ProfileScreen({ navigation }: Props) {
   }
 
   // Render protected content if authenticated
-  return <ProfileScreenContent navigation={navigation} />;
+  return <ProfileScreenContent />;
 }
 
-function ProfileScreenContent({ navigation: _navigation }: Props) {
+function ProfileScreenContent() {
   const [isEditing, setIsEditing] = useState(false);
-  const [componentsLoaded, setComponentsLoaded] = useState(false);
+  const [ProfileEditor, setProfileEditor] =
+    useState<React.ComponentType<ProfileEditorProps> | null>(null);
   const auth = useAuthContext();
   const profile = useProfileContext();
 
   // Lazy load ProfileEditor only when editing
   useEffect(() => {
-    if (isEditing && !componentsLoaded) {
+    if (isEditing && !ProfileEditor) {
       loadProfileEditorModule()
         .then(module => {
-          ProfileEditor = module.ProfileEditor;
-          setComponentsLoaded(true);
+          setProfileEditor(() => module.ProfileEditor);
         })
         .catch(err => {
           Logger.error('[ProfileScreen] Failed to load ProfileEditor:', err);
         });
     }
-  }, [isEditing, componentsLoaded]);
+  }, [isEditing, ProfileEditor]);
 
   return (
     <SafeAreaView style={styles.container}>
@@ -158,7 +157,7 @@ function ProfileScreenContent({ navigation: _navigation }: Props) {
 
             {isEditing && (
               <View style={styles.card}>
-                {componentsLoaded && ProfileEditor ? (
+                {ProfileEditor ? (
                   <ProfileEditor
                     onSuccess={() => {
                       // Refresh profile data after successful update

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,7 +31,7 @@
     "lucide-react": "^0.460.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-router-dom": "^6.30.3",
+    "react-router-dom": "^6.30.4",
     "zod": "^3.22.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,7 +134,7 @@
         "lucide-react": "^0.460.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-router-dom": "^6.30.3",
+        "react-router-dom": "^6.30.4",
         "zod": "^3.22.0"
       },
       "devDependencies": {
@@ -9653,9 +9653,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -25246,12 +25246,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -25261,13 +25261,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -29719,7 +29719,7 @@
         "jsdom": "^26.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.30.3",
+        "react-router-dom": "^6.30.4",
         "typescript": "^5.3.0",
         "vitest": "^4.1.8"
       },
@@ -29769,7 +29769,7 @@
         "prettier": "^3.1.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-router-dom": "^6.30.3",
+        "react-router-dom": "^6.30.4",
         "tsx": "^4.19.0",
         "typescript": "^5.3.0",
         "vitest": "^4.1.8",
@@ -29778,7 +29778,7 @@
       "peerDependencies": {
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-router-dom": "^6.30.3"
+        "react-router-dom": "^6.30.4"
       },
       "peerDependenciesMeta": {
         "react-dom": {

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -37,7 +37,7 @@
     "jsdom": "^26.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.30.3",
+    "react-router-dom": "^6.30.4",
     "typescript": "^5.3.0",
     "@vitest/coverage-v8": "^4.1.8",
     "vitest": "^4.1.8"

--- a/packages/admin/src/components/AdminDetailDrawer.web.test.tsx
+++ b/packages/admin/src/components/AdminDetailDrawer.web.test.tsx
@@ -307,4 +307,19 @@ describe('AdminDetailDrawer', () => {
     await user.click(screen.getByLabelText('Close'));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it('does not trap Tab when focus is not on the last element', () => {
+    render(
+      <AdminDetailDrawer open title='User' onClose={vi.fn()}>
+        <input aria-label='Notes' />
+        <button type='button'>Save</button>
+      </AdminDetailDrawer>
+    );
+    const notes = screen.getByLabelText('Notes');
+    notes.focus();
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Tab', bubbles: true })
+    );
+    expect(document.activeElement).toBe(notes);
+  });
 });

--- a/packages/admin/src/components/AdminDetailDrawer.web.test.tsx
+++ b/packages/admin/src/components/AdminDetailDrawer.web.test.tsx
@@ -308,7 +308,8 @@ describe('AdminDetailDrawer', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('does not trap Tab when focus is not on the last element', () => {
+  it('does not trap Tab when focus is not on the last element', async () => {
+    const user = userEvent.setup();
     render(
       <AdminDetailDrawer open title='User' onClose={vi.fn()}>
         <input aria-label='Notes' />
@@ -316,10 +317,10 @@ describe('AdminDetailDrawer', () => {
       </AdminDetailDrawer>
     );
     const notes = screen.getByLabelText('Notes');
-    notes.focus();
-    document.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 'Tab', bubbles: true })
-    );
+    const save = screen.getByRole('button', { name: 'Save' });
+    await user.click(notes);
     expect(document.activeElement).toBe(notes);
+    await user.tab();
+    expect(document.activeElement).toBe(save);
   });
 });

--- a/packages/admin/src/components/AdminTable.web.test.tsx
+++ b/packages/admin/src/components/AdminTable.web.test.tsx
@@ -123,4 +123,21 @@ describe('AdminTable', () => {
     await user.click(screen.getByText('Ada'));
     expect(onRowClick).toHaveBeenCalledWith({ id: '1', name: 'Ada' });
   });
+
+  it('ignores non-activation keys on clickable rows', async () => {
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AdminTable
+        columns={columns}
+        rows={[{ id: '1', name: 'Ada' }]}
+        getRowKey={r => r.id}
+        onRowClick={onRowClick}
+      />
+    );
+    const row = screen.getByRole('button', { name: 'View details for 1' });
+    row.focus();
+    await user.keyboard('{ArrowDown}');
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
 });

--- a/packages/articles/package.json
+++ b/packages/articles/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-router-dom": "^6.30.3"
+    "react-router-dom": "^6.30.4"
   },
   "peerDependenciesMeta": {
     "react-dom": {
@@ -50,7 +50,7 @@
     "prettier": "^3.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-router-dom": "^6.30.3",
+    "react-router-dom": "^6.30.4",
     "tsx": "^4.19.0",
     "typescript": "^5.3.0",
     "vitest": "^4.1.8",

--- a/packages/billing/src/BillingProvider.test.tsx
+++ b/packages/billing/src/BillingProvider.test.tsx
@@ -569,7 +569,7 @@ describe('BillingProvider', () => {
     let resolveSession: (value: {
       data: { session: { user: { id: string } } | null };
     }) => void = () => {};
-    auth.getSession.mockImplementation(
+    auth.getSession.mockImplementationOnce(
       () =>
         new Promise(resolve => {
           resolveSession = resolve;
@@ -584,5 +584,106 @@ describe('BillingProvider', () => {
     resolveSession({ data: { session: { user: { id: 'late-user' } } } });
     await Promise.resolve();
     expect(db.maybeSingle).not.toHaveBeenCalled();
+  });
+
+  it('ignores plan query result after unmount', async () => {
+    let resolvePlan: (value: {
+      data: ReturnType<typeof testPlan> | null;
+      error: null;
+    }) => void = () => {};
+    auth.state.session = { user: { id: 'u-plan-unmount' } };
+    const row = {
+      ...testSubscription(),
+      user_id: 'u-plan-unmount',
+      plan_id: 'plan_free',
+    };
+    db.maybeSingle.mockResolvedValue({ data: row, error: null });
+    db.planMaybeSingle.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolvePlan = resolve;
+        })
+    );
+    const { unmount } = render(
+      <BillingProvider config={testBillingConfig} {...providerProps}>
+        <PlanReader />
+      </BillingProvider>
+    );
+    await waitFor(() => expect(db.planMaybeSingle).toHaveBeenCalled());
+    unmount();
+    resolvePlan({ data: testPlan({ display_name: 'Late plan' }), error: null });
+    await Promise.resolve();
+  });
+
+  it('ignores ensure_billing_subscription result after unmount', async () => {
+    let resolveRpc: (value: { error: null }) => void = () => {};
+    auth.state.session = { user: { id: 'u-rpc-unmount' } };
+    db.rpc.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveRpc = resolve;
+        })
+    );
+    const { unmount } = render(
+      <BillingProvider config={testBillingConfig} {...providerProps}>
+        <Reader />
+      </BillingProvider>
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('uid').textContent).toBe('u-rpc-unmount')
+    );
+    await waitFor(() => expect(db.rpc).toHaveBeenCalled());
+    unmount();
+    resolveRpc({ error: null });
+    await Promise.resolve();
+  });
+
+  it('ignores plan query errors after unmount', async () => {
+    let rejectPlan: (error: Error) => void = () => {};
+    auth.state.session = { user: { id: 'u-plan-err-unmount' } };
+    const row = {
+      ...testSubscription(),
+      user_id: 'u-plan-err-unmount',
+      plan_id: 'plan_free',
+    };
+    db.maybeSingle.mockResolvedValue({ data: row, error: null });
+    db.planMaybeSingle.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectPlan = reject;
+        })
+    );
+    const { unmount } = render(
+      <BillingProvider config={testBillingConfig} {...providerProps}>
+        <PlanReader />
+      </BillingProvider>
+    );
+    await waitFor(() => expect(db.planMaybeSingle).toHaveBeenCalled());
+    unmount();
+    rejectPlan(new Error('late plan fail'));
+    await Promise.resolve();
+  });
+
+  it('ignores ensure_billing_subscription errors after unmount', async () => {
+    let rejectRpc: (error: Error) => void = () => {};
+    auth.state.session = { user: { id: 'u-rpc-err-unmount' } };
+    db.rpc.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectRpc = reject;
+        })
+    );
+    const { unmount } = render(
+      <BillingProvider config={testBillingConfig} {...providerProps}>
+        <Reader />
+      </BillingProvider>
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('uid').textContent).toBe('u-rpc-err-unmount')
+    );
+    await waitFor(() => expect(db.rpc).toHaveBeenCalled());
+    unmount();
+    rejectRpc(new Error('late rpc fail'));
+    await Promise.resolve();
   });
 });

--- a/packages/billing/src/BillingProvider.test.tsx
+++ b/packages/billing/src/BillingProvider.test.tsx
@@ -11,6 +11,15 @@ import {
   testSubscription,
 } from './test/billingFixtures.js';
 
+type ConsoleErrorSpy = ReturnType<typeof vi.spyOn<typeof console, 'error'>>;
+
+function expectNoUnmountedConsoleWarnings(consoleSpy: ConsoleErrorSpy) {
+  const unmountedWarnings = consoleSpy.mock.calls.filter(args =>
+    args.some(arg => String(arg).toLowerCase().includes('unmounted'))
+  );
+  expect(unmountedWarnings).toHaveLength(0);
+}
+
 function Reader() {
   const { userId, subscription } = useBillingContext();
   return (
@@ -591,99 +600,138 @@ describe('BillingProvider', () => {
       data: ReturnType<typeof testPlan> | null;
       error: null;
     }) => void = () => {};
-    auth.state.session = { user: { id: 'u-plan-unmount' } };
-    const row = {
-      ...testSubscription(),
-      user_id: 'u-plan-unmount',
-      plan_id: 'plan_free',
-    };
-    db.maybeSingle.mockResolvedValue({ data: row, error: null });
-    db.planMaybeSingle.mockImplementationOnce(
-      () =>
-        new Promise(resolve => {
-          resolvePlan = resolve;
-        })
-    );
-    const { unmount } = render(
-      <BillingProvider config={testBillingConfig} {...providerProps}>
-        <PlanReader />
-      </BillingProvider>
-    );
-    await waitFor(() => expect(db.planMaybeSingle).toHaveBeenCalled());
-    unmount();
-    resolvePlan({ data: testPlan({ display_name: 'Late plan' }), error: null });
-    await Promise.resolve();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      auth.state.session = { user: { id: 'u-plan-unmount' } };
+      const row = {
+        ...testSubscription(),
+        user_id: 'u-plan-unmount',
+        plan_id: 'plan_free',
+      };
+      db.maybeSingle.mockResolvedValue({ data: row, error: null });
+      db.planMaybeSingle.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolvePlan = resolve;
+          })
+      );
+      const { unmount } = render(
+        <BillingProvider config={testBillingConfig} {...providerProps}>
+          <PlanReader />
+        </BillingProvider>
+      );
+      await waitFor(() => expect(db.planMaybeSingle).toHaveBeenCalled());
+      unmount();
+      resolvePlan({
+        data: testPlan({ display_name: 'Late plan' }),
+        error: null,
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expectNoUnmountedConsoleWarnings(consoleSpy);
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 
   it('ignores ensure_billing_subscription result after unmount', async () => {
     let resolveRpc: (value: { error: null }) => void = () => {};
-    auth.state.session = { user: { id: 'u-rpc-unmount' } };
-    db.rpc.mockImplementationOnce(
-      () =>
-        new Promise(resolve => {
-          resolveRpc = resolve;
-        })
-    );
-    const { unmount } = render(
-      <BillingProvider config={testBillingConfig} {...providerProps}>
-        <Reader />
-      </BillingProvider>
-    );
-    await waitFor(() =>
-      expect(screen.getByTestId('uid').textContent).toBe('u-rpc-unmount')
-    );
-    await waitFor(() => expect(db.rpc).toHaveBeenCalled());
-    unmount();
-    resolveRpc({ error: null });
-    await Promise.resolve();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      auth.state.session = { user: { id: 'u-rpc-unmount' } };
+      db.rpc.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveRpc = resolve;
+          })
+      );
+      const { unmount } = render(
+        <BillingProvider config={testBillingConfig} {...providerProps}>
+          <Reader />
+        </BillingProvider>
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId('uid').textContent).toBe('u-rpc-unmount')
+      );
+      await waitFor(() => expect(db.rpc).toHaveBeenCalled());
+      unmount();
+      resolveRpc({ error: null });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expectNoUnmountedConsoleWarnings(consoleSpy);
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 
   it('ignores plan query errors after unmount', async () => {
     let rejectPlan: (error: Error) => void = () => {};
-    auth.state.session = { user: { id: 'u-plan-err-unmount' } };
-    const row = {
-      ...testSubscription(),
-      user_id: 'u-plan-err-unmount',
-      plan_id: 'plan_free',
-    };
-    db.maybeSingle.mockResolvedValue({ data: row, error: null });
-    db.planMaybeSingle.mockImplementationOnce(
-      () =>
-        new Promise((_resolve, reject) => {
-          rejectPlan = reject;
-        })
-    );
-    const { unmount } = render(
-      <BillingProvider config={testBillingConfig} {...providerProps}>
-        <PlanReader />
-      </BillingProvider>
-    );
-    await waitFor(() => expect(db.planMaybeSingle).toHaveBeenCalled());
-    unmount();
-    rejectPlan(new Error('late plan fail'));
-    await Promise.resolve();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      auth.state.session = { user: { id: 'u-plan-err-unmount' } };
+      const row = {
+        ...testSubscription(),
+        user_id: 'u-plan-err-unmount',
+        plan_id: 'plan_free',
+      };
+      db.maybeSingle.mockResolvedValue({ data: row, error: null });
+      db.planMaybeSingle.mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectPlan = reject;
+          })
+      );
+      const { unmount } = render(
+        <BillingProvider config={testBillingConfig} {...providerProps}>
+          <PlanReader />
+        </BillingProvider>
+      );
+      await waitFor(() => expect(db.planMaybeSingle).toHaveBeenCalled());
+      unmount();
+      rejectPlan(new Error('late plan fail'));
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expectNoUnmountedConsoleWarnings(consoleSpy);
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 
   it('ignores ensure_billing_subscription errors after unmount', async () => {
     let rejectRpc: (error: Error) => void = () => {};
-    auth.state.session = { user: { id: 'u-rpc-err-unmount' } };
-    db.rpc.mockImplementationOnce(
-      () =>
-        new Promise((_resolve, reject) => {
-          rejectRpc = reject;
-        })
-    );
-    const { unmount } = render(
-      <BillingProvider config={testBillingConfig} {...providerProps}>
-        <Reader />
-      </BillingProvider>
-    );
-    await waitFor(() =>
-      expect(screen.getByTestId('uid').textContent).toBe('u-rpc-err-unmount')
-    );
-    await waitFor(() => expect(db.rpc).toHaveBeenCalled());
-    unmount();
-    rejectRpc(new Error('late rpc fail'));
-    await Promise.resolve();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      auth.state.session = { user: { id: 'u-rpc-err-unmount' } };
+      db.rpc.mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectRpc = reject;
+          })
+      );
+      const { unmount } = render(
+        <BillingProvider config={testBillingConfig} {...providerProps}>
+          <Reader />
+        </BillingProvider>
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId('uid').textContent).toBe('u-rpc-err-unmount')
+      );
+      await waitFor(() => expect(db.rpc).toHaveBeenCalled());
+      unmount();
+      rejectRpc(new Error('late rpc fail'));
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expectNoUnmountedConsoleWarnings(consoleSpy);
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 });

--- a/packages/billing/src/components/SubscriptionStatusBadge.native.test.tsx
+++ b/packages/billing/src/components/SubscriptionStatusBadge.native.test.tsx
@@ -72,6 +72,15 @@ describe('SubscriptionStatusBadge (native)', () => {
     expect(screen.getAllByLabelText('Active').length).toBeGreaterThan(0);
   });
 
+  it('keeps raw status label for unrecognized statuses', () => {
+    render(
+      <SubscriptionStatusBadge
+        subscription={testSubscription({ status: 'canceled' })}
+      />
+    );
+    expect(screen.getByLabelText('canceled')).toBeInTheDocument();
+  });
+
   it('shows em dash in cancelling label when period end is missing', () => {
     render(
       <SubscriptionStatusBadge

--- a/packages/billing/src/hooks/useBillingState.test.tsx
+++ b/packages/billing/src/hooks/useBillingState.test.tsx
@@ -87,6 +87,15 @@ describe('useBillingState', () => {
     expect(result.current.kind).toBe('trialing');
   });
 
+  it('classifies trialing without trial_end as trialing', () => {
+    hp.subscription = testSubscription({
+      status: 'trialing',
+      trial_end: null,
+    });
+    const { result } = renderHook(() => useBillingState());
+    expect(result.current.kind).toBe('trialing');
+  });
+
   it('classifies cancel_at_period_end without pending target as cancelled_pending', () => {
     hp.subscription = testSubscription({
       status: 'active',

--- a/packages/billing/src/hooks/useInvoices.test.tsx
+++ b/packages/billing/src/hooks/useInvoices.test.tsx
@@ -190,4 +190,41 @@ describe('useInvoices', () => {
     expect(result.current.items).toEqual([]);
     expect(result.current.hasMore).toBe(false);
   });
+
+  it('preserves existing items when loadMore fails', async () => {
+    const inv: BillingInvoiceRow = {
+      id: 'inv1',
+      user_id: 'user-1',
+      stripe_invoice_id: 'in_1',
+      stripe_customer_id: 'cus',
+      stripe_subscription_id: null,
+      amount_due: 100,
+      amount_paid: 0,
+      currency: 'usd',
+      status: 'open',
+      description: null,
+      hosted_invoice_url: null,
+      invoice_pdf_url: null,
+      period_start: null,
+      period_end: null,
+      created_at: '2026-01-02T00:00:00.000Z',
+      finalized_at: null,
+      paid_at: null,
+    };
+    range
+      .mockResolvedValueOnce({
+        data: Array.from({ length: 20 }, (_, i) => ({ ...inv, id: `i${i}` })),
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: new Error('page two failed'),
+      });
+    const { result } = renderHook(() => useInvoices({ pageSize: 20 }));
+    await waitFor(() => expect(result.current.items.length).toBe(20));
+    await result.current.loadMore();
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.items).toHaveLength(20);
+    expect(result.current.hasMore).toBe(false);
+  });
 });

--- a/packages/billing/src/hooks/useUsage.ts
+++ b/packages/billing/src/hooks/useUsage.ts
@@ -33,7 +33,7 @@ export function useUsage<
   const [snap, setSnap] = useState<RpcRow | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<BillingError | null>(null);
-  const fetchUsageRef = useRef<() => Promise<void>>(async () => {});
+  const fetchUsageRef = useRef<(() => Promise<void>) | undefined>(undefined);
 
   const fetchUsage = useCallback(async () => {
     setLoading(true);
@@ -112,7 +112,7 @@ export function useUsage<
           row?.product_id === config.productId &&
           row?.event_type === meterKey
         ) {
-          void fetchUsageRef.current();
+          void fetchUsageRef.current?.();
         }
       }
     ).subscribe();

--- a/packages/billing/src/utils/parseBillingFunctionError.test.ts
+++ b/packages/billing/src/utils/parseBillingFunctionError.test.ts
@@ -34,4 +34,12 @@ describe('parseBillingFunctionError', () => {
     expect(err.kind).toBe('stripe');
     expect(err.message).toBe('Billing request failed');
   });
+
+  it('ignores whitespace-only error strings in the body', () => {
+    const err = parseBillingFunctionError(
+      { error: '   ' },
+      new Error('invoke')
+    );
+    expect(err.message).toContain('invoke');
+  });
 });

--- a/packages/connections/src/hooks/useConnections.test.tsx
+++ b/packages/connections/src/hooks/useConnections.test.tsx
@@ -249,4 +249,55 @@ describe('useConnections', () => {
     expect(channel.on).not.toHaveBeenCalled();
     expect(channel.subscribe).not.toHaveBeenCalled();
   });
+
+  it('refresh reloads connections', async () => {
+    let calls = 0;
+    const supabase = createMockSupabase(async () => {
+      calls += 1;
+      return { data: calls === 1 ? [row] : [], error: null };
+    });
+    const { result } = renderHook(() =>
+      useConnections({ supabase, userId: UUID_A })
+    );
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+    await result.current.refresh();
+    await waitFor(() => expect(result.current.rows).toHaveLength(0));
+    expect(calls).toBe(2);
+  });
+
+  it('ignores debounced reload after unmount', async () => {
+    let debouncedCallback: (() => void) | undefined;
+    const originalSetTimeout = globalThis.setTimeout.bind(globalThis);
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((handler, delay, ...args) => {
+        if (typeof handler === 'function' && delay === 400) {
+          debouncedCallback = handler as () => void;
+        }
+        return originalSetTimeout(handler, delay, ...args);
+      });
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+    try {
+      let calls = 0;
+      const supabase = createMockSupabase(async () => {
+        calls += 1;
+        return { data: [row], error: null };
+      });
+      const { unmount } = renderHook(() =>
+        useConnections({ supabase, userId: UUID_A })
+      );
+      await waitFor(() => expect(calls).toBe(1));
+      emitConnectionChange(supabase);
+      expect(debouncedCallback).toBeDefined();
+      unmount();
+      debouncedCallback?.();
+      await Promise.resolve();
+      expect(calls).toBe(1);
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    } finally {
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+    }
+  });
 });

--- a/packages/help/scripts/build-help.ts
+++ b/packages/help/scripts/build-help.ts
@@ -111,7 +111,7 @@ export function parseHelpMarkdown(raw: string, legal: Legal): HelpContent {
     sections: sectionBlocks.map(({ title: sectionTitle, body }) => ({
       id: slugify(sectionTitle),
       title: sectionTitle,
-      html: sanitizeHelpHtml(marked.parse(body) as string),
+      html: sanitizeHelpHtml(marked.parser(marked.lexer(body))),
       searchText: markdownToPlainText(body),
     })),
   };

--- a/packages/marketing-email/src/__tests__/kitClient.test.ts
+++ b/packages/marketing-email/src/__tests__/kitClient.test.ts
@@ -123,6 +123,24 @@ describe('KitClient', () => {
         'Kit API POST /forms/f/subscribers → 400 Bad Request'
       );
     });
+
+    it('handles response.text() rejection on HTTP error', async () => {
+      fetchMock.mockReturnValue(
+        Promise.resolve({
+          ok: false,
+          status: 502,
+          statusText: 'Bad Gateway',
+          text: () => Promise.reject(new Error('body unreadable')),
+        } as Response)
+      );
+      const err = await client
+        .subscribeToForm('u@e.com', 'f')
+        .catch(e => e as KitClientError);
+      expect(err.code).toBe('kit_api_502');
+      expect(err.message).toBe(
+        'Kit API POST /forms/f/subscribers → 502 Bad Gateway'
+      );
+    });
   });
 
   describe('applyTag', () => {

--- a/packages/observability/src/__tests__/ObservabilityProvider.web.test.tsx
+++ b/packages/observability/src/__tests__/ObservabilityProvider.web.test.tsx
@@ -142,4 +142,40 @@ describe('ObservabilityProvider (web)', () => {
       expect.any(Function)
     );
   });
+
+  it('ignores Sentry load after unmount', async () => {
+    vi.resetModules();
+
+    let resolvePendingSentry!: (value: typeof SentryMock) => void;
+    const pendingSentry = new Promise<typeof SentryMock>(resolve => {
+      resolvePendingSentry = resolve;
+    });
+    vi.doMock('@sentry/react', () => pendingSentry);
+
+    const { ObservabilityProvider } =
+      await import('../components/ObservabilityProvider.web.js');
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const { unmount } = render(
+        <ObservabilityProvider config={config}>
+          <div>child</div>
+        </ObservabilityProvider>
+      );
+      unmount();
+      resolvePendingSentry(SentryMock);
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      const unmountedWarnings = consoleSpy.mock.calls.filter(([message]) =>
+        String(message).toLowerCase().includes('unmounted')
+      );
+      expect(unmountedWarnings).toHaveLength(0);
+    } finally {
+      consoleSpy.mockRestore();
+      vi.resetModules();
+      vi.doUnmock('@sentry/react');
+    }
+  });
 });

--- a/packages/observability/src/__tests__/sentryDynamicImport.coverage.test.ts
+++ b/packages/observability/src/__tests__/sentryDynamicImport.coverage.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+describe('Sentry dynamic import fallbacks', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('@sentry/react');
+    vi.doUnmock('@sentry/react-native');
+  });
+
+  it('ObservabilityProvider survives a rejected @sentry/react import', async () => {
+    vi.doMock('@sentry/react', () => Promise.reject(new Error('chunk failed')));
+    const { ObservabilityProvider } =
+      await import('../components/ObservabilityProvider.web.js');
+    const React = await import('react');
+    const { render, screen } = await import('@testing-library/react');
+
+    render(
+      React.createElement(
+        ObservabilityProvider,
+        { config: { project: 'test', environment: 'test' } },
+        React.createElement('div', null, 'child')
+      )
+    );
+    expect(screen.getByText('child')).toBeInTheDocument();
+  });
+
+  it('withErrorBoundary.web survives a rejected @sentry/react import', async () => {
+    vi.doMock('@sentry/react', () => Promise.reject(new Error('chunk failed')));
+    const { ErrorBoundary } =
+      await import('../components/withErrorBoundary.web.js');
+    const React = await import('react');
+    const { render, screen } = await import('@testing-library/react');
+
+    function Thrower() {
+      throw new Error('boom');
+    }
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      render(
+        React.createElement(ErrorBoundary, null, React.createElement(Thrower))
+      );
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it('withErrorBoundary.native survives a rejected @sentry/react-native import', async () => {
+    vi.doMock('@sentry/react-native', () =>
+      Promise.reject(new Error('chunk failed'))
+    );
+    const { ErrorBoundary } =
+      await import('../components/withErrorBoundary.native.js');
+    const React = await import('react');
+    const { render, screen } = await import('@testing-library/react');
+
+    function Thrower() {
+      throw new Error('boom');
+    }
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      render(
+        React.createElement(ErrorBoundary, null, React.createElement(Thrower))
+      );
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});

--- a/packages/shared-tests/__tests__/components/navigation/UserMenu.test.tsx
+++ b/packages/shared-tests/__tests__/components/navigation/UserMenu.test.tsx
@@ -345,6 +345,23 @@ describe('UserMenu (Web)', () => {
     });
   });
 
+  it('should close menu when Connections link is clicked', async () => {
+    renderWithProviders(<UserMenu user={mockUser} profile={mockProfile} />);
+    const menuButton = screen.getByLabelText('User menu');
+    fireEvent.click(menuButton);
+    await waitFor(() =>
+      expect(
+        screen.getByRole('link', { name: 'Connections' })
+      ).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Connections' }));
+
+    await waitFor(() => {
+      expect(menuButton).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
   it('should not render email row when user has no email', async () => {
     const userWithoutEmail: User = { ...mockUser, email: undefined };
     renderWithProviders(

--- a/packages/waitlist/src/hooks/useSignupMode.test.tsx
+++ b/packages/waitlist/src/hooks/useSignupMode.test.tsx
@@ -18,4 +18,27 @@ describe('useSignupMode', () => {
     expect(result.current.isOpen).toBe(false);
     vi.restoreAllMocks();
   });
+
+  it('ignores settings result after unmount', async () => {
+    let resolveSettings: (value: {
+      signup_mode: 'open';
+      copy: Record<string, never>;
+      metadata_schema: never[];
+    }) => void = () => {};
+    vi.spyOn(client, 'getPublicWaitlistSettings').mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveSettings = resolve;
+        })
+    );
+    const supabase = {} as never;
+    const { unmount } = renderHook(() => useSignupMode(supabase));
+    await waitFor(() =>
+      expect(client.getPublicWaitlistSettings).toHaveBeenCalled()
+    );
+    unmount();
+    resolveSettings({ signup_mode: 'open', copy: {}, metadata_schema: [] });
+    await Promise.resolve();
+    vi.restoreAllMocks();
+  });
 });

--- a/packages/waitlist/src/hooks/useSignupMode.test.tsx
+++ b/packages/waitlist/src/hooks/useSignupMode.test.tsx
@@ -3,6 +3,15 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { useSignupMode } from './useSignupMode.js';
 import * as client from '../waitlistClient.js';
 
+type ConsoleErrorSpy = ReturnType<typeof vi.spyOn<typeof console, 'error'>>;
+
+function expectNoUnmountedConsoleWarnings(consoleSpy: ConsoleErrorSpy) {
+  const unmountedWarnings = consoleSpy.mock.calls.filter(args =>
+    args.some(arg => String(arg).toLowerCase().includes('unmounted'))
+  );
+  expect(unmountedWarnings).toHaveLength(0);
+}
+
 describe('useSignupMode', () => {
   it('loads public settings and exposes mode flags', async () => {
     vi.spyOn(client, 'getPublicWaitlistSettings').mockResolvedValue({
@@ -31,14 +40,21 @@ describe('useSignupMode', () => {
           resolveSettings = resolve;
         })
     );
-    const supabase = {} as never;
-    const { unmount } = renderHook(() => useSignupMode(supabase));
-    await waitFor(() =>
-      expect(client.getPublicWaitlistSettings).toHaveBeenCalled()
-    );
-    unmount();
-    resolveSettings({ signup_mode: 'open', copy: {}, metadata_schema: [] });
-    await Promise.resolve();
-    vi.restoreAllMocks();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const supabase = {} as never;
+      const { unmount } = renderHook(() => useSignupMode(supabase));
+      await waitFor(() =>
+        expect(client.getPublicWaitlistSettings).toHaveBeenCalled()
+      );
+      unmount();
+      resolveSettings({ signup_mode: 'open', copy: {}, metadata_schema: [] });
+      await Promise.resolve();
+
+      expectNoUnmountedConsoleWarnings(consoleSpy);
+    } finally {
+      consoleSpy.mockRestore();
+      vi.restoreAllMocks();
+    }
   });
 });

--- a/scripts/setup-full.mjs
+++ b/scripts/setup-full.mjs
@@ -87,7 +87,10 @@ import {
   runCmd,
 } from './lib/setup-supabase.mjs';
 import { buildNameVariants } from './rename-project.mjs';
-import { detectRepoIdentity, readBrandingSource } from './lib/detect-repo-identity.mjs';
+import {
+  detectRepoIdentity,
+  readBrandingSource,
+} from './lib/detect-repo-identity.mjs';
 import {
   ACM_CLOUDFRONT_REGION,
   discoverIssuedCertsCoveringApexWildcard,
@@ -457,7 +460,9 @@ export function slugBaseFromAppConfigText(text) {
  * @returns {Promise<string>} lowercase alnum segment, e.g. poststack or beakerstack
  */
 async function readSupabaseProjectSlugBase() {
-  const brandingResult = slugBaseFromBrandingText(await readBrandingSource(REPO_ROOT));
+  const brandingResult = slugBaseFromBrandingText(
+    await readBrandingSource(REPO_ROOT)
+  );
   if (brandingResult) return brandingResult;
   try {
     const appConfigResult = slugBaseFromAppConfigText(
@@ -1208,9 +1213,6 @@ async function resolveAwsPreflightConflictsInteractive(
   }
 }
 
-/**
- * @param {CliFlags} flags
- */
 function ghAuthOk() {
   const r = spawnSync('gh', ['auth', 'status'], {
     cwd: REPO_ROOT,
@@ -1220,9 +1222,6 @@ function ghAuthOk() {
   return r.status === 0;
 }
 
-/**
- * @param {CliFlags} flags
- */
 function easWhoamiOk() {
   const r = spawnSync('npx', ['--yes', 'eas-cli', 'whoami'], {
     cwd: MOBILE_DIR,
@@ -2894,7 +2893,7 @@ async function main() {
   }
 }
 
-if (import.meta.url === url.pathToFileURL(process.argv[1] || '').href) {
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
   main().catch(err => {
     console.error(
       '[setup] Fatal:',


### PR DESCRIPTION
## CalVer release notes

### Summary

This promotion brings three commits to production since CalVer tag **2026.005**: a security patch for React Router, targeted code-quality fixes in setup and mobile help flows, and restored 100% package test coverage after the Vitest 4 upgrade. The headline change for adopters is upgrading `react-router-dom` to **6.30.4**, which addresses open-redirect vulnerability **CVE-2026-40181**. There are no new database migrations, required secrets, or pending npm changesets in this release.

### Highlights

- **Security:** Upgrade `react-router-dom` to 6.30.4 across web, admin, and articles packages (CVE-2026-40181) (#398)
- **Mobile:** Scope lazy-loaded `ProfileEditor` state to the component instead of module-level mutable state (#399)
- **Setup & help:** Use path-based main-module detection in `setup-full.mjs`; parse help markdown synchronously via `marked.lexer` / `marked.parser` (#399)
- **Testing / CI:** Restore 100% package coverage under Vitest 4 with targeted tests for async cancellation, dynamic import fallbacks, and edge-case branches in billing, admin, connections, observability, kit, shared, and waitlist packages (#400)

**Stats:** 3 commits, +453 / −42 lines across 21 files.

### Adopter notes

| Area                       | Action |
| -------------------------- | ------ |
| **Secrets**                | None new |
| **Database**               | No new migrations |
| **Likely merge conflicts** | `package-lock.json`, `apps/web/package.json`, `packages/admin/package.json`, `packages/articles/package.json` (react-router bump); fork-customized `scripts/setup-full.mjs`, `apps/mobile/src/screens/ProfileScreen.tsx` |
| **npm packages**           | None — no pending changesets |

- **Landing:** https://beakerstack.com
- **Quick start:** https://github.com/Artificer-Innovations/BeakerStack/blob/main/QUICKSTART.md
- **Feedback:** https://github.com/Artificer-Innovations/BeakerStack/discussions
- **Upgrade guide:** https://github.com/Artificer-Innovations/BeakerStack/blob/main/docs/UPGRADING.md

---

## Maintainer checklist

<!-- Not published on the GitHub Release — for reviewers and releasers only. -->

### Merge instructions

**Use “Create a merge commit” — do NOT squash.** Required by [CONTRIBUTING.md](../../CONTRIBUTING.md) and enforced by [check-merge-strategy.yml](../workflows/check-merge-strategy.yml).

### Post-merge

1. Monitor **Deploy Production** workflow on `main`
2. Review auto-opened **“chore: release packages”** PR from changesets (if any); merge if correct
3. Run **Release Template** workflow on `main` (uses this PR’s CalVer section + git-cliff changelog)

### Test plan

- [ ] CI green on `develop` at promotion SHA
- [ ] Staging smoke: auth, dashboard, billing
- [ ] After merge: production deploy succeeds
- [ ] After **Release Template**: GitHub Release body matches **CalVer release notes** above + changelog
