### PR TITLE
fix(test): address Copilot coverage test quality on #401

### DIFF
--- a/packages/admin/src/components/AdminDetailDrawer.web.test.tsx
+++ b/packages/admin/src/components/AdminDetailDrawer.web.test.tsx
@@ -308,7 +308,8 @@ describe('AdminDetailDrawer', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('does not trap Tab when focus is not on the last element', () => {
+  it('does not trap Tab when focus is not on the last element', async () => {
+    const user = userEvent.setup();
     render(
       <AdminDetailDrawer open title='User' onClose={vi.fn()}>
         <input aria-label='Notes' />
@@ -316,10 +317,10 @@ describe('AdminDetailDrawer', () => {
       </AdminDetailDrawer>
     );
     const notes = screen.getByLabelText('Notes');
-    notes.focus();
-    document.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 'Tab', bubbles: true })
-    );
+    const save = screen.getByRole('button', { name: 'Save' });
+    await user.click(notes);
     expect(document.activeElement).toBe(notes);
+    await user.tab();
+    expect(document.activeElement).toBe(save);
   });
 });

--- a/packages/billing/src/BillingProvider.test.tsx
+++ b/packages/billing/src/BillingProvider.test.tsx
@@ -591,6 +591,7 @@ describe('BillingProvider', () => {
       data: ReturnType<typeof testPlan> | null;
       error: null;
     }) => void = () => {};
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     auth.state.session = { user: { id: 'u-plan-unmount' } };
     const row = {
       ...testSubscription(),
@@ -612,11 +613,20 @@ describe('BillingProvider', () => {
     await waitFor(() => expect(db.planMaybeSingle).toHaveBeenCalled());
     unmount();
     resolvePlan({ data: testPlan({ display_name: 'Late plan' }), error: null });
-    await Promise.resolve();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const unmountedWarnings = consoleSpy.mock.calls.filter(([message]) =>
+      String(message).toLowerCase().includes('unmounted')
+    );
+    expect(unmountedWarnings).toHaveLength(0);
+    consoleSpy.mockRestore();
   });
 
   it('ignores ensure_billing_subscription result after unmount', async () => {
     let resolveRpc: (value: { error: null }) => void = () => {};
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     auth.state.session = { user: { id: 'u-rpc-unmount' } };
     db.rpc.mockImplementationOnce(
       () =>
@@ -635,11 +645,20 @@ describe('BillingProvider', () => {
     await waitFor(() => expect(db.rpc).toHaveBeenCalled());
     unmount();
     resolveRpc({ error: null });
-    await Promise.resolve();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const unmountedWarnings = consoleSpy.mock.calls.filter(([message]) =>
+      String(message).toLowerCase().includes('unmounted')
+    );
+    expect(unmountedWarnings).toHaveLength(0);
+    consoleSpy.mockRestore();
   });
 
   it('ignores plan query errors after unmount', async () => {
     let rejectPlan: (error: Error) => void = () => {};
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     auth.state.session = { user: { id: 'u-plan-err-unmount' } };
     const row = {
       ...testSubscription(),
@@ -661,11 +680,20 @@ describe('BillingProvider', () => {
     await waitFor(() => expect(db.planMaybeSingle).toHaveBeenCalled());
     unmount();
     rejectPlan(new Error('late plan fail'));
-    await Promise.resolve();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const unmountedWarnings = consoleSpy.mock.calls.filter(([message]) =>
+      String(message).toLowerCase().includes('unmounted')
+    );
+    expect(unmountedWarnings).toHaveLength(0);
+    consoleSpy.mockRestore();
   });
 
   it('ignores ensure_billing_subscription errors after unmount', async () => {
     let rejectRpc: (error: Error) => void = () => {};
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     auth.state.session = { user: { id: 'u-rpc-err-unmount' } };
     db.rpc.mockImplementationOnce(
       () =>
@@ -684,6 +712,14 @@ describe('BillingProvider', () => {
     await waitFor(() => expect(db.rpc).toHaveBeenCalled());
     unmount();
     rejectRpc(new Error('late rpc fail'));
-    await Promise.resolve();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const unmountedWarnings = consoleSpy.mock.calls.filter(([message]) =>
+      String(message).toLowerCase().includes('unmounted')
+    );
+    expect(unmountedWarnings).toHaveLength(0);
+    consoleSpy.mockRestore();
   });
 });

--- a/packages/billing/src/BillingProvider.test.tsx
+++ b/packages/billing/src/BillingProvider.test.tsx
@@ -11,6 +11,15 @@ import {
   testSubscription,
 } from './test/billingFixtures.js';
 
+type ConsoleErrorSpy = ReturnType<typeof vi.spyOn<typeof console, 'error'>>;
+
+function expectNoUnmountedConsoleWarnings(consoleSpy: ConsoleErrorSpy) {
+  const unmountedWarnings = consoleSpy.mock.calls.filter(args =>
+    args.some(arg => String(arg).toLowerCase().includes('unmounted'))
+  );
+  expect(unmountedWarnings).toHaveLength(0);
+}
+
 function Reader() {
   const { userId, subscription } = useBillingContext();
   return (
@@ -592,134 +601,137 @@ describe('BillingProvider', () => {
       error: null;
     }) => void = () => {};
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    auth.state.session = { user: { id: 'u-plan-unmount' } };
-    const row = {
-      ...testSubscription(),
-      user_id: 'u-plan-unmount',
-      plan_id: 'plan_free',
-    };
-    db.maybeSingle.mockResolvedValue({ data: row, error: null });
-    db.planMaybeSingle.mockImplementationOnce(
-      () =>
-        new Promise(resolve => {
-          resolvePlan = resolve;
-        })
-    );
-    const { unmount } = render(
-      <BillingProvider config={testBillingConfig} {...providerProps}>
-        <PlanReader />
-      </BillingProvider>
-    );
-    await waitFor(() => expect(db.planMaybeSingle).toHaveBeenCalled());
-    unmount();
-    resolvePlan({ data: testPlan({ display_name: 'Late plan' }), error: null });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    try {
+      auth.state.session = { user: { id: 'u-plan-unmount' } };
+      const row = {
+        ...testSubscription(),
+        user_id: 'u-plan-unmount',
+        plan_id: 'plan_free',
+      };
+      db.maybeSingle.mockResolvedValue({ data: row, error: null });
+      db.planMaybeSingle.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolvePlan = resolve;
+          })
+      );
+      const { unmount } = render(
+        <BillingProvider config={testBillingConfig} {...providerProps}>
+          <PlanReader />
+        </BillingProvider>
+      );
+      await waitFor(() => expect(db.planMaybeSingle).toHaveBeenCalled());
+      unmount();
+      resolvePlan({
+        data: testPlan({ display_name: 'Late plan' }),
+        error: null,
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
 
-    const unmountedWarnings = consoleSpy.mock.calls.filter(([message]) =>
-      String(message).toLowerCase().includes('unmounted')
-    );
-    expect(unmountedWarnings).toHaveLength(0);
-    consoleSpy.mockRestore();
+      expectNoUnmountedConsoleWarnings(consoleSpy);
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 
   it('ignores ensure_billing_subscription result after unmount', async () => {
     let resolveRpc: (value: { error: null }) => void = () => {};
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    auth.state.session = { user: { id: 'u-rpc-unmount' } };
-    db.rpc.mockImplementationOnce(
-      () =>
-        new Promise(resolve => {
-          resolveRpc = resolve;
-        })
-    );
-    const { unmount } = render(
-      <BillingProvider config={testBillingConfig} {...providerProps}>
-        <Reader />
-      </BillingProvider>
-    );
-    await waitFor(() =>
-      expect(screen.getByTestId('uid').textContent).toBe('u-rpc-unmount')
-    );
-    await waitFor(() => expect(db.rpc).toHaveBeenCalled());
-    unmount();
-    resolveRpc({ error: null });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    try {
+      auth.state.session = { user: { id: 'u-rpc-unmount' } };
+      db.rpc.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveRpc = resolve;
+          })
+      );
+      const { unmount } = render(
+        <BillingProvider config={testBillingConfig} {...providerProps}>
+          <Reader />
+        </BillingProvider>
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId('uid').textContent).toBe('u-rpc-unmount')
+      );
+      await waitFor(() => expect(db.rpc).toHaveBeenCalled());
+      unmount();
+      resolveRpc({ error: null });
+      await act(async () => {
+        await Promise.resolve();
+      });
 
-    const unmountedWarnings = consoleSpy.mock.calls.filter(([message]) =>
-      String(message).toLowerCase().includes('unmounted')
-    );
-    expect(unmountedWarnings).toHaveLength(0);
-    consoleSpy.mockRestore();
+      expectNoUnmountedConsoleWarnings(consoleSpy);
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 
   it('ignores plan query errors after unmount', async () => {
     let rejectPlan: (error: Error) => void = () => {};
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    auth.state.session = { user: { id: 'u-plan-err-unmount' } };
-    const row = {
-      ...testSubscription(),
-      user_id: 'u-plan-err-unmount',
-      plan_id: 'plan_free',
-    };
-    db.maybeSingle.mockResolvedValue({ data: row, error: null });
-    db.planMaybeSingle.mockImplementationOnce(
-      () =>
-        new Promise((_resolve, reject) => {
-          rejectPlan = reject;
-        })
-    );
-    const { unmount } = render(
-      <BillingProvider config={testBillingConfig} {...providerProps}>
-        <PlanReader />
-      </BillingProvider>
-    );
-    await waitFor(() => expect(db.planMaybeSingle).toHaveBeenCalled());
-    unmount();
-    rejectPlan(new Error('late plan fail'));
-    await act(async () => {
-      await Promise.resolve();
-    });
+    try {
+      auth.state.session = { user: { id: 'u-plan-err-unmount' } };
+      const row = {
+        ...testSubscription(),
+        user_id: 'u-plan-err-unmount',
+        plan_id: 'plan_free',
+      };
+      db.maybeSingle.mockResolvedValue({ data: row, error: null });
+      db.planMaybeSingle.mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectPlan = reject;
+          })
+      );
+      const { unmount } = render(
+        <BillingProvider config={testBillingConfig} {...providerProps}>
+          <PlanReader />
+        </BillingProvider>
+      );
+      await waitFor(() => expect(db.planMaybeSingle).toHaveBeenCalled());
+      unmount();
+      rejectPlan(new Error('late plan fail'));
+      await act(async () => {
+        await Promise.resolve();
+      });
 
-    const unmountedWarnings = consoleSpy.mock.calls.filter(([message]) =>
-      String(message).toLowerCase().includes('unmounted')
-    );
-    expect(unmountedWarnings).toHaveLength(0);
-    consoleSpy.mockRestore();
+      expectNoUnmountedConsoleWarnings(consoleSpy);
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 
   it('ignores ensure_billing_subscription errors after unmount', async () => {
     let rejectRpc: (error: Error) => void = () => {};
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    auth.state.session = { user: { id: 'u-rpc-err-unmount' } };
-    db.rpc.mockImplementationOnce(
-      () =>
-        new Promise((_resolve, reject) => {
-          rejectRpc = reject;
-        })
-    );
-    const { unmount } = render(
-      <BillingProvider config={testBillingConfig} {...providerProps}>
-        <Reader />
-      </BillingProvider>
-    );
-    await waitFor(() =>
-      expect(screen.getByTestId('uid').textContent).toBe('u-rpc-err-unmount')
-    );
-    await waitFor(() => expect(db.rpc).toHaveBeenCalled());
-    unmount();
-    rejectRpc(new Error('late rpc fail'));
-    await act(async () => {
-      await Promise.resolve();
-    });
+    try {
+      auth.state.session = { user: { id: 'u-rpc-err-unmount' } };
+      db.rpc.mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectRpc = reject;
+          })
+      );
+      const { unmount } = render(
+        <BillingProvider config={testBillingConfig} {...providerProps}>
+          <Reader />
+        </BillingProvider>
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId('uid').textContent).toBe('u-rpc-err-unmount')
+      );
+      await waitFor(() => expect(db.rpc).toHaveBeenCalled());
+      unmount();
+      rejectRpc(new Error('late rpc fail'));
+      await act(async () => {
+        await Promise.resolve();
+      });
 
-    const unmountedWarnings = consoleSpy.mock.calls.filter(([message]) =>
-      String(message).toLowerCase().includes('unmounted')
-    );
-    expect(unmountedWarnings).toHaveLength(0);
-    consoleSpy.mockRestore();
+      expectNoUnmountedConsoleWarnings(consoleSpy);
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 });

--- a/packages/waitlist/src/hooks/useSignupMode.test.tsx
+++ b/packages/waitlist/src/hooks/useSignupMode.test.tsx
@@ -31,6 +31,7 @@ describe('useSignupMode', () => {
           resolveSettings = resolve;
         })
     );
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const supabase = {} as never;
     const { unmount } = renderHook(() => useSignupMode(supabase));
     await waitFor(() =>
@@ -39,6 +40,13 @@ describe('useSignupMode', () => {
     unmount();
     resolveSettings({ signup_mode: 'open', copy: {}, metadata_schema: [] });
     await Promise.resolve();
+
+    const unmountedWarnings = consoleSpy.mock.calls.filter(([message]) =>
+      String(message).toLowerCase().includes('unmounted')
+    );
+    expect(unmountedWarnings).toHaveLength(0);
+
+    consoleSpy.mockRestore();
     vi.restoreAllMocks();
   });
 });

--- a/packages/waitlist/src/hooks/useSignupMode.test.tsx
+++ b/packages/waitlist/src/hooks/useSignupMode.test.tsx
@@ -3,6 +3,15 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { useSignupMode } from './useSignupMode.js';
 import * as client from '../waitlistClient.js';
 
+type ConsoleErrorSpy = ReturnType<typeof vi.spyOn<typeof console, 'error'>>;
+
+function expectNoUnmountedConsoleWarnings(consoleSpy: ConsoleErrorSpy) {
+  const unmountedWarnings = consoleSpy.mock.calls.filter(args =>
+    args.some(arg => String(arg).toLowerCase().includes('unmounted'))
+  );
+  expect(unmountedWarnings).toHaveLength(0);
+}
+
 describe('useSignupMode', () => {
   it('loads public settings and exposes mode flags', async () => {
     vi.spyOn(client, 'getPublicWaitlistSettings').mockResolvedValue({
@@ -32,21 +41,20 @@ describe('useSignupMode', () => {
         })
     );
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const supabase = {} as never;
-    const { unmount } = renderHook(() => useSignupMode(supabase));
-    await waitFor(() =>
-      expect(client.getPublicWaitlistSettings).toHaveBeenCalled()
-    );
-    unmount();
-    resolveSettings({ signup_mode: 'open', copy: {}, metadata_schema: [] });
-    await Promise.resolve();
+    try {
+      const supabase = {} as never;
+      const { unmount } = renderHook(() => useSignupMode(supabase));
+      await waitFor(() =>
+        expect(client.getPublicWaitlistSettings).toHaveBeenCalled()
+      );
+      unmount();
+      resolveSettings({ signup_mode: 'open', copy: {}, metadata_schema: [] });
+      await Promise.resolve();
 
-    const unmountedWarnings = consoleSpy.mock.calls.filter(([message]) =>
-      String(message).toLowerCase().includes('unmounted')
-    );
-    expect(unmountedWarnings).toHaveLength(0);
-
-    consoleSpy.mockRestore();
-    vi.restoreAllMocks();
+      expectNoUnmountedConsoleWarnings(consoleSpy);
+    } finally {
+      consoleSpy.mockRestore();
+      vi.restoreAllMocks();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Addresses all six Copilot review comments on the promotion PR #401. The coverage tests added in #400 exercised unmount/cancellation paths for coverage but lacked assertions that would catch regressions.

## Changes

- **AdminDetailDrawer:** Replace raw `KeyboardEvent` Tab dispatch with `userEvent.tab()` and assert focus advances from Notes → Save (verifies Tab is not trapped when focus is not on the last element).
- **useSignupMode:** Spy on `console.error` and assert no unmounted-component warnings after resolving settings post-unmount.
- **BillingProvider:** Add the same `console.error` unmount-warning assertions to four post-unmount async tests (plan query resolve/reject, RPC resolve/reject), using `act()` to flush updates.

Pattern matches `ObservabilityProvider.web.test.tsx` from #400.

## Test plan

- [x] `packages/admin` — `AdminDetailDrawer.web.test.tsx` (17 tests)
- [x] `packages/waitlist` — `useSignupMode.test.tsx` (2 tests)
- [x] `packages/billing` — `BillingProvider.test.tsx` (24 tests)

Closes Copilot feedback on #401; merge this into `develop` before promoting to `main`.