### PR TITLE
ci: wire Sentry into web deploys

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -188,6 +188,9 @@ jobs:
       STACK_NAME: ${{ vars.PR_PREVIEW_STACK_NAME }}
       VITE_SUPABASE_URL: ${{ secrets.PRODUCTION_SUPABASE_URL }}
       VITE_SUPABASE_ANON_KEY: ${{ secrets.PRODUCTION_SUPABASE_ANON_KEY }}
+      VITE_SENTRY_DSN: ${{ secrets.PRODUCTION_SENTRY_DSN }}
+      VITE_SENTRY_ENVIRONMENT: production
+      VITE_SENTRY_RELEASE: ${{ github.sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -235,6 +238,9 @@ jobs:
         shell: bash
         env:
           AWS_REGION_VALUE: ${{ vars.PR_PREVIEW_AWS_REGION != '' && vars.PR_PREVIEW_AWS_REGION || 'us-east-1' }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         run: |
           set -euo pipefail
           ./scripts/pr-preview/deploy-web.sh \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -190,6 +190,9 @@ jobs:
       STACK_NAME: ${{ vars.PR_PREVIEW_STACK_NAME }}
       VITE_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
       VITE_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
+      VITE_SENTRY_DSN: ${{ secrets.STAGING_SENTRY_DSN }}
+      VITE_SENTRY_ENVIRONMENT: staging
+      VITE_SENTRY_RELEASE: ${{ github.sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -237,6 +240,9 @@ jobs:
         shell: bash
         env:
           AWS_REGION_VALUE: ${{ vars.PR_PREVIEW_AWS_REGION != '' && vars.PR_PREVIEW_AWS_REGION || 'us-east-1' }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         run: |
           set -euo pipefail
           ./scripts/pr-preview/deploy-web.sh \

--- a/.github/workflows/pr-preview-environment.yml
+++ b/.github/workflows/pr-preview-environment.yml
@@ -355,6 +355,9 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           VITE_SUPABASE_URL: ${{ secrets.PREVIEW_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.PREVIEW_SUPABASE_ANON_KEY }}
+          VITE_SENTRY_DSN: ${{ secrets.STAGING_SENTRY_DSN }}
+          VITE_SENTRY_ENVIRONMENT: preview
+          VITE_SENTRY_RELEASE: ${{ github.sha }}
         run: |
           set -euo pipefail
           PR_NUMBER_VALUE="${PR_NUMBER}"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@rolldown/pluginutils": "^1.0.0-beta.47",
+    "@sentry/vite-plugin": "^2.23.1",
     "@tailwindcss/typography": "^0.5.19",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.1.0",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -91,6 +91,11 @@ export default defineConfig(({ mode }) => {
                 assets: './dist/**',
                 filesToDeleteAfterUpload: './dist/**/*.map',
               },
+              // Soft-fail: never block staging/prod deploys on Sentry outages
+              // or bad auth — ship the build, lose symbols for that release.
+              errorHandler: err => {
+                console.warn('[sentry] source map upload failed:', err);
+              },
               telemetry: false,
             }),
           ]

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import path from 'path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig, loadEnv, type Plugin } from 'vite';
+import { sentryVitePlugin } from '@sentry/vite-plugin';
 import react from '@vitejs/plugin-react';
 import { branding } from '../../adopter/config/branding';
 
@@ -20,6 +21,15 @@ export default defineConfig(({ mode }) => {
   const isDev = mode === 'development';
   // Respect VITE_BASE_PATH for asset URLs (defaults to '/' for local development)
   const basePath = env.VITE_BASE_PATH || '/';
+
+  const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN?.trim();
+  const sentryOrg = process.env.SENTRY_ORG?.trim();
+  const sentryProject = process.env.SENTRY_PROJECT?.trim();
+  const sentryRelease =
+    env.VITE_SENTRY_RELEASE?.trim() || process.env.VITE_SENTRY_RELEASE?.trim();
+  const enableSentrySourceMaps = Boolean(
+    sentryAuthToken && sentryOrg && sentryProject && sentryRelease
+  );
 
   const htmlBrandingPlugin: Plugin = {
     name: 'html-branding-transform',
@@ -70,6 +80,21 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react(),
       htmlBrandingPlugin,
+      ...(enableSentrySourceMaps
+        ? [
+            sentryVitePlugin({
+              org: sentryOrg,
+              project: sentryProject,
+              authToken: sentryAuthToken,
+              release: { name: sentryRelease },
+              sourcemaps: {
+                assets: './dist/**',
+                filesToDeleteAfterUpload: './dist/**/*.map',
+              },
+              telemetry: false,
+            }),
+          ]
+        : []),
       // mkcert is disabled - we use HTTP for multi-device development
       // to avoid mixed content issues with Supabase (which runs on HTTP)
     ],
@@ -100,6 +125,8 @@ export default defineConfig(({ mode }) => {
       __DEV__: JSON.stringify(isDev),
     },
     build: {
+      // Hidden: generate maps for Sentry upload without //# sourceMappingURL in bundles.
+      sourcemap: enableSentrySourceMaps ? 'hidden' : false,
       rollupOptions: {
         output: {
           manualChunks(id) {

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -88,14 +88,31 @@ interface ObservabilityConfig {
 
 ## Deployed environments (CI / EAS)
 
-Local wiring is complete in the template. **Preview, staging, and production** require build-time secrets and workflow changes — tracked in [GitHub issue #299](https://github.com/Artificer-Innovations/BeakerStack/issues/299) (`setup:sentry` wizard):
+Staging, production, and PR preview web deploys pass `VITE_SENTRY_*` when GitHub secrets are set. Staging/production also upload source maps via `@sentry/vite-plugin` when `SENTRY_AUTH_TOKEN` + `SENTRY_ORG` + `SENTRY_PROJECT` are present.
 
-- GitHub secrets: `PREVIEW_SENTRY_DSN`, `STAGING_SENTRY_DSN`, `PRODUCTION_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`
-- Workflow env: `VITE_SENTRY_DSN`, `VITE_SENTRY_ENVIRONMENT`, `VITE_SENTRY_RELEASE` on web deploy jobs
-- EAS: `EXPO_PUBLIC_SENTRY_DSN` and related vars in `eas.json` / EAS secrets
-- Post-build source map upload via `@sentry/cli`
+| GitHub setting          | Kind     | Used for                                          |
+| ----------------------- | -------- | ------------------------------------------------- |
+| `STAGING_SENTRY_DSN`    | secret   | `VITE_SENTRY_DSN` on staging + PR preview         |
+| `PRODUCTION_SENTRY_DSN` | secret   | `VITE_SENTRY_DSN` on production                   |
+| `SENTRY_AUTH_TOKEN`     | secret   | Vite plugin source map upload (staging/prod only) |
+| `SENTRY_ORG`            | variable | Sentry org slug                                   |
+| `SENTRY_PROJECT`        | variable | Sentry project slug                               |
 
-Until #299 lands, deployed web/mobile builds will not report to Sentry unless you set secrets manually.
+Workflow mapping:
+
+- **staging** (`deploy-staging.yml`): `VITE_SENTRY_ENVIRONMENT=staging`, release=`github.sha`
+- **production** (`deploy-production.yml`): `VITE_SENTRY_ENVIRONMENT=production`
+- **PR preview** (`pr-preview-environment.yml`): reuses `STAGING_SENTRY_DSN` with `VITE_SENTRY_ENVIRONMENT=preview` (no source-map upload)
+
+EAS / mobile: set `EXPO_PUBLIC_SENTRY_*` in `eas.json` / EAS secrets when enabling native crash reporting.
+
+## Crash symbolication (source maps)
+
+Staging and production builds enable `@sentry/vite-plugin` when auth token, org, project, and release are all set. Maps are generated as `hidden` sourcemaps and deleted after upload (`filesToDeleteAfterUpload`) so `.map` files are not published to S3.
+
+The SDK `release` field (`VITE_SENTRY_RELEASE`) must match the release name used at upload time — workflows set both to `${{ github.sha }}`.
+
+Set `EXPO_PUBLIC_SENTRY_RELEASE` at mobile build time to match if uploading native symbols separately.
 
 ## Sampling and spend control
 
@@ -122,23 +139,6 @@ The scrubbing utilities are exported from the package root for use in other cont
 ```ts
 import { hashUserId, scrubEmail } from '@beakerstack/observability';
 ```
-
-## Crash symbolication (source maps)
-
-To get human-readable stack traces in Sentry you need to upload source maps as part of CI. The SDK `release` field must match the release id used at upload time.
-
-```yaml
-# .github/workflows/deploy.yml (example — see #299 for full wiring)
-- name: Upload source maps to Sentry
-  run: npx @sentry/cli releases files "$RELEASE" upload-sourcemaps ./dist
-  env:
-    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-    SENTRY_ORG: your-org
-    SENTRY_PROJECT: beakerstack
-    RELEASE: ${{ github.sha }}
-```
-
-Set `VITE_SENTRY_RELEASE=${{ github.sha }}` (web) and `EXPO_PUBLIC_SENTRY_RELEASE` (mobile) at build time to match.
 
 ## Using the hook
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -110,6 +110,8 @@ EAS / mobile: set `EXPO_PUBLIC_SENTRY_*` in `eas.json` / EAS secrets when enabli
 
 Staging and production builds enable `@sentry/vite-plugin` when auth token, org, project, and release are all set. Maps are generated as `hidden` sourcemaps and deleted after upload (`filesToDeleteAfterUpload`) so `.map` files are not published to S3.
 
+Upload failures are **soft-failed** (`errorHandler` logs a warning and lets the build continue) so a Sentry outage or expired auth token cannot block a deploy — that release just ships without symbolication.
+
 The SDK `release` field (`VITE_SENTRY_RELEASE`) must match the release name used at upload time — workflows set both to `${{ github.sha }}`.
 
 Set `EXPO_PUBLIC_SENTRY_RELEASE` at mobile build time to match if uploading native symbols separately.

--- a/env.example
+++ b/env.example
@@ -9,11 +9,16 @@ EXPO_PUBLIC_SUPABASE_ANON_KEY=your-local-anon-key
 VITE_SENTRY_DSN=
 # Mobile: apps/mobile/.env.local
 EXPO_PUBLIC_SENTRY_DSN=
-# Set in CI at build time (#299); omit locally unless testing release/source maps
+# Set in CI at build time; omit locally unless testing release/source maps
 VITE_SENTRY_RELEASE=
 VITE_SENTRY_ENVIRONMENT=
 EXPO_PUBLIC_SENTRY_RELEASE=
 EXPO_PUBLIC_SENTRY_ENVIRONMENT=
+# CI-only (GitHub Actions deploy-web jobs + @sentry/vite-plugin) — not baked into the client bundle
+# STAGING_SENTRY_DSN / PRODUCTION_SENTRY_DSN → GitHub secrets; mapped to VITE_SENTRY_DSN in workflows
+# Preview reuses STAGING_SENTRY_DSN with VITE_SENTRY_ENVIRONMENT=preview
+# SENTRY_AUTH_TOKEN → GitHub secret (org Organization Token with org:ci scope)
+# SENTRY_ORG / SENTRY_PROJECT → GitHub repo variables (org + project slugs for source map upload)
 
 SUPABASE_URL=http://localhost:54321
 SUPABASE_ANON_KEY=your-local-anon-key

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,6 +139,7 @@
       },
       "devDependencies": {
         "@rolldown/pluginutils": "^1.0.0-beta.47",
+        "@sentry/vite-plugin": "^2.23.1",
         "@tailwindcss/typography": "^0.5.19",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.1.0",
@@ -400,15 +401,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
@@ -424,15 +416,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
@@ -2398,15 +2381,6 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/preset-flow": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.27.1.tgz",
@@ -4032,17 +4006,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@expo/cli/node_modules/@expo/plist": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.1.3.tgz",
-      "integrity": "sha512-GW/7hVlAylYg1tUrEASclw1MMk9FP4ZwyFAY/SUTJIhPDQHtfOlXREyWV3hhrHdX/K+pS73GNgdfT6E/e+kBbg==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "~0.7.7",
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^14.0.0"
-      }
-    },
     "node_modules/@expo/cli/node_modules/@expo/prebuild-config": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-6.8.1.tgz",
@@ -4136,18 +4099,6 @@
       },
       "peerDependencies": {
         "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@expo/cli/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/@expo/cli/node_modules/ansi-regex": {
@@ -4344,19 +4295,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@expo/cli/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@expo/cli/node_modules/log-symbols": {
@@ -4636,15 +4574,6 @@
       "resolved": "https://registry.npmjs.org/wonka/-/wonka-4.0.15.tgz",
       "integrity": "sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg==",
       "license": "MIT"
-    },
-    "node_modules/@expo/cli/node_modules/xmlbuilder": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
-      "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0"
-      }
     },
     "node_modules/@expo/cli/node_modules/yallist": {
       "version": "4.0.0",
@@ -4998,35 +4927,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/@expo/eas-json/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@expo/eas-json/node_modules/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/eas-json/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -5056,13 +4956,6 @@
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/@expo/eas-json/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/@expo/env": {
       "version": "1.0.7",
@@ -8834,27 +8727,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
     },
-    "node_modules/@react-native-community/cli-server-api/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@react-native-community/cli-tools": {
       "version": "12.3.6",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-12.3.6.tgz",
@@ -9320,15 +9192,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@react-native/dev-middleware/node_modules/ws": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.4.tgz",
-      "integrity": "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/@react-native/gradle-plugin": {
@@ -10052,6 +9915,260 @@
         "node": ">=14.18"
       }
     },
+    "node_modules/@sentry/bundler-plugin-core": {
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-2.23.1.tgz",
+      "integrity": "sha512-JA6utNiwMKv6Jfj0Hmk0DI/XUizSHg7HhhkFETKhRlYEhZAdkyz1atDBg0ncKNgRBKyHeSYWcMFtUyo26VB76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/babel-plugin-component-annotate": "2.23.1",
+        "@sentry/cli": "2.39.1",
+        "dotenv": "^16.3.1",
+        "find-up": "^5.0.0",
+        "glob": "^9.3.2",
+        "magic-string": "0.30.8",
+        "unplugin": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-2.23.1.tgz",
+      "integrity": "sha512-l1z8AvI6k9I+2z49OgvP3SlzB1M0Lw24KtceiJibNaSyQwxsItoT9/XftZ/8BBtkosVmNOTQhL1eUsSkuSv1LA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.39.1.tgz",
+      "integrity": "sha512-JIb3e9vh0+OmQ0KxmexMXg9oZsR/G7HMwxt5BUIKAXZ9m17Xll4ETXTRnRUBT3sf7EpNGAmlQk1xEmVN9pYZYQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.39.1",
+        "@sentry/cli-linux-arm": "2.39.1",
+        "@sentry/cli-linux-arm64": "2.39.1",
+        "@sentry/cli-linux-i686": "2.39.1",
+        "@sentry/cli-linux-x64": "2.39.1",
+        "@sentry/cli-win32-i686": "2.39.1",
+        "@sentry/cli-win32-x64": "2.39.1"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-darwin": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.39.1.tgz",
+      "integrity": "sha512-kiNGNSAkg46LNGatfNH5tfsmI/kCAaPA62KQuFZloZiemTNzhy9/6NJP8HZ/GxGs8GDMxic6wNrV9CkVEgFLJQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-arm": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.39.1.tgz",
+      "integrity": "sha512-DkENbxyRxUrfLnJLXTA4s5UL/GoctU5Cm4ER1eB7XN7p9WsamFJd/yf2KpltkjEyiTuplv0yAbdjl1KX3vKmEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.39.1.tgz",
+      "integrity": "sha512-5VbVJDatolDrWOgaffsEM7znjs0cR8bHt9Bq0mStM3tBolgAeSDHE89NgHggfZR+DJ2VWOy4vgCwkObrUD6NQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-i686": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.39.1.tgz",
+      "integrity": "sha512-pXWVoKXCRrY7N8vc9H7mETiV9ZCz+zSnX65JQCzZxgYrayQPJTc+NPRnZTdYdk5RlAupXaFicBI2GwOCRqVRkg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-x64": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.39.1.tgz",
+      "integrity": "sha512-IwayNZy+it7FWG4M9LayyUmG1a/8kT9+/IEm67sT5+7dkMIMcpmHDqL8rWcPojOXuTKaOBBjkVdNMBTXy0mXlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-win32-i686": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.39.1.tgz",
+      "integrity": "sha512-NglnNoqHSmE+Dz/wHeIVRnV2bLMx7tIn3IQ8vXGO5HWA2f8zYJGktbkLq1Lg23PaQmeZLPGlja3gBQfZYSG10Q==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-win32-x64": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.39.1.tgz",
+      "integrity": "sha512-xv0R2CMf/X1Fte3cMWie1NXuHmUyQPDBfCyIt6k6RPFPxAYUgcqgMPznYwVMwWEA1W43PaOkSn3d8ZylsDaETw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/magic-string": {
+      "version": "0.30.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/minimatch": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+      "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@sentry/cli": {
       "version": "2.58.5",
       "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.5.tgz",
@@ -10224,33 +10341,6 @@
       ],
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@sentry/core": {
@@ -10564,31 +10654,6 @@
         "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
-    "node_modules/@sentry/react-native/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@sentry/react-native/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@sentry/types": {
       "version": "8.55.0",
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.55.0.tgz",
@@ -10629,6 +10694,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-2.23.1.tgz",
+      "integrity": "sha512-avtjtIQ019sZW3FklpmNNsQOnYZjCHpnVxgDGElfZb+AaR4AvtHNlxXLJp+iqEfSK+Xok8MJarJqIgCaWcF40Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugin-core": "2.23.1",
+        "unplugin": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@sideway/address": {
@@ -12396,12 +12475,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -15123,19 +15196,6 @@
         "xmlbuilder": "^14.0.0"
       }
     },
-    "node_modules/eas-cli/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/eas-cli/node_modules/dotenv": {
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
@@ -15186,20 +15246,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/eas-cli/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/eas-cli/node_modules/ignore": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
@@ -15221,19 +15267,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/eas-cli/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eas-cli/node_modules/minipass": {
@@ -15284,22 +15317,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eas-cli/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eas-cli/node_modules/tr46": {
@@ -15353,13 +15370,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/eas-cli/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -22450,27 +22460,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/metro/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -24862,27 +24851,6 @@
         "ws": "^7"
       }
     },
-    "node_modules/react-devtools-core/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -25192,15 +25160,6 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/react-native/node_modules/ws": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.4.tgz",
-      "integrity": "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/react-refresh": {
@@ -28100,6 +28059,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unplugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
+      "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.8.1",
+        "chokidar": "^3.5.3",
+        "webpack-sources": "^3.2.3",
+        "webpack-virtual-modules": "^0.5.0"
+      }
+    },
     "node_modules/untildify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
@@ -28516,6 +28488,23 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+      "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",


### PR DESCRIPTION
## Summary
- Port Skein's Sentry CI wiring into the BeakerStack template so adopters get exception reporting without a separate wizard step
- Deploy workflows pass `VITE_SENTRY_*` for staging, production, and PR preview
- Add `@sentry/vite-plugin` for staging/production source map upload (`filesToDeleteAfterUpload`)
- Update `docs/observability.md` + `env.example` (closes the “until #299” gap for web deploys)

## Adopter setup
```bash
gh secret set STAGING_SENTRY_DSN
gh secret set PRODUCTION_SENTRY_DSN
gh secret set SENTRY_AUTH_TOKEN
gh variable set SENTRY_ORG --body '<org-slug>'
gh variable set SENTRY_PROJECT --body '<project-slug>'
```

Preview reuses `STAGING_SENTRY_DSN` with `VITE_SENTRY_ENVIRONMENT=preview` (same as Skein). CSP report-URI / enforced CSP Sentry hosts remain a separate follow-up.

## Test plan
- [ ] Set secrets/vars on a test adopter or BeakerStack itself
- [ ] Merge → staging deploy embeds DSN; force an error and check Sentry
- [ ] Confirm source maps upload when auth token + org/project vars are set
- [ ] Confirm local builds stay no-op without DSN