### PR TITLE
release: promote develop to main (vip comps and dep pins)

### DIFF
--- a/adopter/config/__tests__/billing.vip-parity.test.ts
+++ b/adopter/config/__tests__/billing.vip-parity.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { billingConfig } from '../billing';
+
+describe('billing VIP plan parity', () => {
+  it('beakerstack_vip matches beakerstack_max features and usage limits', () => {
+    const max = billingConfig.plans.find(p => p.id === 'beakerstack_max');
+    const vip = billingConfig.plans.find(p => p.id === 'beakerstack_vip');
+    expect(max).toBeDefined();
+    expect(vip).toBeDefined();
+    expect(vip?.isPublic).toBe(false);
+    expect(vip?.billingPeriod).toBe('monthly');
+    expect(vip?.features).toEqual(max?.features);
+    expect(vip?.usageLimits).toEqual(max?.usageLimits);
+  });
+});

--- a/adopter/config/billing.ts
+++ b/adopter/config/billing.ts
@@ -5,6 +5,17 @@ import {
 import { branding } from './branding';
 import { appIdentity } from './app-identity';
 
+const beakerstackMaxFeatures = {
+  containers_per_account_max: -1,
+  items_per_container_max: -1,
+  feature_a: true,
+  feature_b: true,
+} as const;
+
+const beakerstackMaxUsageLimits = {
+  ai_summarize: -1,
+} as const;
+
 /**
  * Adopter-owned billing config (Free / Pro / Max). IDs match `supabase/seed.sql`.
  * Stripe price IDs live in `public.billing_plans` (synced via `npm run billing:sync-stripe`).
@@ -70,18 +81,28 @@ export const billingConfig = defineBillingConfig({
       stripePriceIdMonthly: null,
       stripePriceIdAnnual: null,
       stripeProductId: null,
-      features: {
-        containers_per_account_max: -1,
-        items_per_container_max: -1,
-        feature_a: true,
-        feature_b: true,
-      },
-      usageLimits: {
-        ai_summarize: -1,
-      },
+      features: { ...beakerstackMaxFeatures },
+      usageLimits: { ...beakerstackMaxUsageLimits },
       trialPeriodDays: 5,
       isPublic: true,
       displayOrder: 3,
+    },
+    {
+      id: 'beakerstack_vip',
+      displayName: 'VIP (complimentary)',
+      description:
+        'Complimentary Max-equivalent access (operator-granted only)',
+      planCardTagline: 'Complimentary access',
+      priceCents: 0,
+      billingPeriod: 'monthly',
+      stripePriceIdMonthly: null,
+      stripePriceIdAnnual: null,
+      stripeProductId: null,
+      features: { ...beakerstackMaxFeatures },
+      usageLimits: { ...beakerstackMaxUsageLimits },
+      trialPeriodDays: 0,
+      isPublic: false,
+      displayOrder: 99,
     },
   ],
   planFeatureRows: [

--- a/adopter/config/waitlist-billing.ts
+++ b/adopter/config/waitlist-billing.ts
@@ -1,0 +1,8 @@
+import { appIdentity } from './app-identity';
+import type { WaitlistBillingConfig } from '@beakerstack/waitlist-billing';
+
+export const waitlistBillingConfig = {
+  productId: appIdentity.productId,
+  compPlanIds: ['beakerstack_vip'],
+  defaultCompPlanId: 'beakerstack_vip',
+} satisfies WaitlistBillingConfig;

--- a/adopter/db/migrations/20260630120000_beakerstack_billing_comp_grants.sql
+++ b/adopter/db/migrations/20260630120000_beakerstack_billing_comp_grants.sql
@@ -1,0 +1,35 @@
+-- BeakerStack: VIP comp catalog plan (Max-equivalent, operator-granted only).
+
+INSERT INTO public.billing_plans (
+    id, product_id, display_name, description, price_cents, billing_period,
+    stripe_price_id_monthly, stripe_price_id_annual, stripe_product_id,
+    features, usage_limits, trial_period_days, is_public, display_order
+)
+VALUES (
+    'beakerstack_vip',
+    'beakerstack',
+    'VIP (complimentary)',
+    'Complimentary Max-equivalent access (operator-granted only)',
+    0,
+    'monthly',
+    NULL,
+    NULL,
+    NULL,
+    '{"containers_per_account_max": -1, "items_per_container_max": -1, "feature_a": true, "feature_b": true}'::jsonb,
+    '{"ai_summarize": -1}'::jsonb,
+    0,
+    false,
+    99
+)
+ON CONFLICT (id) DO UPDATE SET
+    product_id = EXCLUDED.product_id,
+    display_name = EXCLUDED.display_name,
+    description = EXCLUDED.description,
+    price_cents = EXCLUDED.price_cents,
+    billing_period = EXCLUDED.billing_period,
+    features = EXCLUDED.features,
+    usage_limits = EXCLUDED.usage_limits,
+    trial_period_days = EXCLUDED.trial_period_days,
+    is_public = EXCLUDED.is_public,
+    display_order = EXCLUDED.display_order,
+    updated_at = now();

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -89,7 +89,7 @@
     "patch-package": "^8.0.0",
     "react-refresh": "^0.18.0",
     "react-test-renderer": "18.2.0",
-    "sharp": "^0.34.5",
+    "sharp": "^0.35.0",
     "typescript": "^5.3.0"
   },
   "jest": {

--- a/apps/web/src/admin/__tests__/AdminInviteByEmailPanel.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminInviteByEmailPanel.test.tsx
@@ -192,4 +192,84 @@ describe('AdminInviteByEmailPanel', () => {
       expect.stringContaining('/signup/invite#token=secret')
     );
   });
+
+  it('requires a VIP reason when complimentary access is enabled', async () => {
+    const user = userEvent.setup();
+    render(<AdminInviteByEmailPanel />);
+    await screen.findByText(/signup is invite-only/i);
+    await user.click(
+      screen.getByRole('checkbox', {
+        name: /grant complimentary vip on signup/i,
+      })
+    );
+    await user.type(screen.getByLabelText(/email address/i), 'vip@example.com');
+    await user.click(screen.getByRole('button', { name: /send invite/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /reason when granting vip access/i
+    );
+    expect(mockInvite).not.toHaveBeenCalled();
+  });
+
+  it('sends invite with provisioning intent when VIP is enabled', async () => {
+    const user = userEvent.setup();
+    render(<AdminInviteByEmailPanel />);
+    await screen.findByText(/signup is invite-only/i);
+    await user.click(
+      screen.getByRole('checkbox', {
+        name: /grant complimentary vip on signup/i,
+      })
+    );
+    await user.type(
+      screen.getByLabelText(/^reason \(required\)$/i),
+      'Design partner'
+    );
+    await user.type(screen.getByLabelText(/email address/i), 'vip@example.com');
+    await user.click(screen.getByRole('button', { name: /send invite/i }));
+    await waitFor(() => expect(mockInvite).toHaveBeenCalled());
+    expect(mockInvite).toHaveBeenCalledWith(
+      expect.anything(),
+      'vip@example.com',
+      expect.objectContaining({
+        provisioningIntent: {
+          kind: 'billing_comp',
+          planId: 'beakerstack_vip',
+          reason: 'Design partner',
+        },
+      })
+    );
+  });
+
+  it('maps invalid_reason and plan_not_allowed invite errors', async () => {
+    mockInvite.mockResolvedValueOnce({ error: 'invalid_reason' });
+    const user = userEvent.setup();
+    render(<AdminInviteByEmailPanel />);
+    await user.type(screen.getByLabelText(/email address/i), 'a@b.com');
+    await user.click(screen.getByRole('button', { name: /send invite/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /reason when granting vip access/i
+    );
+
+    mockInvite.mockResolvedValueOnce({ error: 'plan_not_allowed' });
+    await user.click(screen.getByRole('button', { name: /send invite/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /not allowed for waitlist invites/i
+    );
+  });
+
+  it('shows email_not_configured message when invite email cannot be sent', async () => {
+    mockInvoke.mockResolvedValueOnce({
+      data: { error: 'email_not_configured' },
+      error: null,
+    });
+    const user = userEvent.setup();
+    render(<AdminInviteByEmailPanel />);
+    await user.type(
+      screen.getByLabelText(/email address/i),
+      'invitee@example.com'
+    );
+    await user.click(screen.getByRole('button', { name: /send invite/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /email delivery is not configured/i
+    );
+  });
 });

--- a/apps/web/src/admin/__tests__/AdminUserDetailDrawer.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminUserDetailDrawer.test.tsx
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { getUser, grantOperator, revokeOperator } from '@beakerstack/admin';
+import {
+  getUser,
+  grantOperator,
+  revokeOperator,
+  grantBillingComp,
+  revokeBillingComp,
+} from '@beakerstack/admin';
 import { AdminUserDetailDrawer } from '../components/AdminUserDetailDrawer.web';
 
 vi.mock('@beakerstack/admin', async importOriginal => {
@@ -11,6 +17,8 @@ vi.mock('@beakerstack/admin', async importOriginal => {
     getUser: vi.fn(),
     grantOperator: vi.fn(),
     revokeOperator: vi.fn(),
+    grantBillingComp: vi.fn(),
+    revokeBillingComp: vi.fn(),
   };
 });
 
@@ -21,6 +29,8 @@ vi.mock('../../lib/supabase', () => ({
 const mockGetUser = vi.mocked(getUser);
 const mockGrantOperator = vi.mocked(grantOperator);
 const mockRevokeOperator = vi.mocked(revokeOperator);
+const mockGrantBillingComp = vi.mocked(grantBillingComp);
+const mockRevokeBillingComp = vi.mocked(revokeBillingComp);
 
 const sampleDetail = {
   auth: {
@@ -70,6 +80,8 @@ describe('AdminUserDetailDrawer', () => {
     mockGetUser.mockResolvedValue(sampleDetail);
     mockGrantOperator.mockResolvedValue(undefined);
     mockRevokeOperator.mockResolvedValue(undefined);
+    mockGrantBillingComp.mockResolvedValue(undefined);
+    mockRevokeBillingComp.mockResolvedValue(undefined);
   });
 
   it('loads and displays user detail when open', async () => {
@@ -493,5 +505,148 @@ describe('AdminUserDetailDrawer', () => {
     await screen.findByText('Profile');
     const dashes = screen.getAllByText('—');
     expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it('grants complimentary VIP with a required reason', async () => {
+    const user = userEvent.setup();
+    render(
+      <AdminUserDetailDrawer open userId='u1' title='User' onClose={vi.fn()} />
+    );
+    await screen.findByText('No admin access');
+    await user.click(
+      screen.getByRole('button', { name: /grant complimentary vip/i })
+    );
+    expect(screen.getByRole('button', { name: /^confirm$/i })).toBeDisabled();
+    await user.type(screen.getByTestId('comp-grant-reason'), 'Design partner');
+    await user.click(screen.getByRole('button', { name: /^confirm$/i }));
+    await waitFor(() =>
+      expect(mockGrantBillingComp).toHaveBeenCalledWith(expect.anything(), {
+        userId: 'u1',
+        productId: 'beakerstack',
+        planId: 'beakerstack_vip',
+        reason: 'Design partner',
+      })
+    );
+  });
+
+  it('shows comp grant metadata and revokes complimentary access', async () => {
+    const user = userEvent.setup();
+    mockGetUser.mockResolvedValue({
+      ...sampleDetail,
+      subscription: { plan_id: 'beakerstack_vip', status: 'comped' },
+      comp_grant: {
+        id: 'cg1',
+        plan_id: 'beakerstack_vip',
+        comped_by: 'admin1',
+        comp_reason: 'Press access',
+        comped_by_email: 'admin@example.com',
+        comped_at: '2024-06-01T00:00:00Z',
+        comp_expires_at: '2025-06-01T00:00:00Z',
+      },
+    });
+    render(
+      <AdminUserDetailDrawer open userId='u1' title='User' onClose={vi.fn()} />
+    );
+    await screen.findByText('Complimentary access');
+    expect(screen.getByText('Press access')).toBeInTheDocument();
+    expect(screen.getByText('admin@example.com')).toBeInTheDocument();
+    await user.click(
+      screen.getByRole('button', { name: /revoke complimentary access/i })
+    );
+    await user.click(screen.getByRole('button', { name: /^confirm$/i }));
+    await waitFor(() =>
+      expect(mockRevokeBillingComp).toHaveBeenCalledWith(expect.anything(), {
+        userId: 'u1',
+        productId: 'beakerstack',
+      })
+    );
+  });
+
+  it('shows comp grant metadata without granter email', async () => {
+    mockGetUser.mockResolvedValue({
+      ...sampleDetail,
+      subscription: { plan_id: 'beakerstack_vip', status: 'comped' },
+      comp_grant: {
+        id: 'cg2',
+        plan_id: 'beakerstack_vip',
+        comped_by: 'admin1',
+        comp_reason: 'Beta tester',
+        comped_by_email: null,
+        comped_at: '2024-06-01T00:00:00Z',
+        comp_expires_at: null,
+      },
+    });
+    render(
+      <AdminUserDetailDrawer open userId='u1' title='User' onClose={vi.fn()} />
+    );
+    await screen.findByText('Beta tester');
+    expect(screen.queryByText(/granted by/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/expires/i)).not.toBeInTheDocument();
+  });
+
+  it('shows friendly comp grant error for stripe_subscription_active', async () => {
+    const user = userEvent.setup();
+    mockGrantBillingComp.mockRejectedValueOnce(
+      new Error('stripe_subscription_active')
+    );
+    render(
+      <AdminUserDetailDrawer open userId='u1' title='User' onClose={vi.fn()} />
+    );
+    await screen.findByText('No admin access');
+    await user.click(
+      screen.getByRole('button', { name: /grant complimentary vip/i })
+    );
+    await user.type(screen.getByTestId('comp-grant-reason'), 'Should fail');
+    await user.click(screen.getByRole('button', { name: /^confirm$/i }));
+    expect(
+      await screen.findByText(/active Stripe subscription/i)
+    ).toBeInTheDocument();
+  });
+
+  it('maps invalid_reason comp grant errors', async () => {
+    const user = userEvent.setup();
+    mockGrantBillingComp.mockRejectedValueOnce(new Error('invalid_reason'));
+    render(
+      <AdminUserDetailDrawer open userId='u1' title='User' onClose={vi.fn()} />
+    );
+    await screen.findByText('No admin access');
+    await user.click(
+      screen.getByRole('button', { name: /grant complimentary vip/i })
+    );
+    await user.type(screen.getByTestId('comp-grant-reason'), 'Test reason');
+    await user.click(screen.getByRole('button', { name: /^confirm$/i }));
+    expect(await screen.findByText(/reason is required/i)).toBeInTheDocument();
+  });
+
+  it('maps invalid_plan comp grant errors', async () => {
+    const user = userEvent.setup();
+    mockGrantBillingComp.mockRejectedValueOnce(new Error('invalid_plan'));
+    render(
+      <AdminUserDetailDrawer open userId='u1' title='User' onClose={vi.fn()} />
+    );
+    await screen.findByText('No admin access');
+    await user.click(
+      screen.getByRole('button', { name: /grant complimentary vip/i })
+    );
+    await user.type(screen.getByTestId('comp-grant-reason'), 'Test reason');
+    await user.click(screen.getByRole('button', { name: /^confirm$/i }));
+    expect(
+      await screen.findByText(/invalid complimentary plan/i)
+    ).toBeInTheDocument();
+  });
+
+  it('maps no_free_plan comp grant errors', async () => {
+    const user = userEvent.setup();
+    mockGrantBillingComp.mockRejectedValueOnce(new Error('no_free_plan'));
+    render(
+      <AdminUserDetailDrawer open userId='u1' title='User' onClose={vi.fn()} />
+    );
+    await screen.findByText('No admin access');
+    await user.click(
+      screen.getByRole('button', { name: /grant complimentary vip/i })
+    );
+    await user.type(screen.getByTestId('comp-grant-reason'), 'Test reason');
+    await user.click(screen.getByRole('button', { name: /^confirm$/i }));
+    expect(await screen.findByText(/public free plan/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/admin/__tests__/AdminWaitlistDetailDrawer.test.tsx
+++ b/apps/web/src/admin/__tests__/AdminWaitlistDetailDrawer.test.tsx
@@ -20,6 +20,18 @@ vi.mock('@beakerstack/waitlist', async importOriginal => {
   };
 });
 
+const mockSetProvisioningIntent = vi.fn();
+
+vi.mock('@beakerstack/waitlist-billing/web', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('@beakerstack/waitlist-billing/web')>();
+  return {
+    ...actual,
+    setWaitlistEntryProvisioningIntent: (...args: unknown[]) =>
+      mockSetProvisioningIntent(...args),
+  };
+});
+
 const mockApprove = vi.mocked(approveWaitlistEntry);
 const mockReject = vi.mocked(rejectWaitlistEntry);
 const mockResend = vi.mocked(resendWaitlistInvite);
@@ -50,6 +62,7 @@ describe('AdminWaitlistDetailDrawer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     invokeMock.mockResolvedValue({ data: {}, error: null });
+    mockSetProvisioningIntent.mockResolvedValue({ ok: true });
     mockApprove.mockResolvedValue({
       invite_token: 'tok',
       email: 'wait@example.com',
@@ -425,5 +438,92 @@ describe('AdminWaitlistDetailDrawer', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('/signup/invite#token=tok')
     );
+  });
+
+  it('approves with VIP provisioning intent when enabled', async () => {
+    const user = userEvent.setup();
+    render(
+      <AdminWaitlistDetailDrawer
+        entry={pendingEntry}
+        open
+        onClose={vi.fn()}
+        onUpdated={vi.fn()}
+      />
+    );
+    await user.click(
+      screen.getByRole('checkbox', {
+        name: /grant complimentary vip on signup/i,
+      })
+    );
+    await user.type(
+      screen.getByLabelText(/^reason \(required\)$/i),
+      'Founder friend'
+    );
+    await user.click(screen.getByRole('button', { name: /^approve$/i }));
+    await waitFor(() => expect(mockApprove).toHaveBeenCalled());
+    expect(mockApprove).toHaveBeenCalledWith(
+      expect.anything(),
+      'e1',
+      expect.objectContaining({
+        provisioningIntent: {
+          kind: 'billing_comp',
+          planId: 'beakerstack_vip',
+          reason: 'Founder friend',
+        },
+      })
+    );
+  });
+
+  it('requires VIP reason before approving pending entry', async () => {
+    const user = userEvent.setup();
+    render(
+      <AdminWaitlistDetailDrawer
+        entry={pendingEntry}
+        open
+        onClose={vi.fn()}
+        onUpdated={vi.fn()}
+      />
+    );
+    await user.click(
+      screen.getByRole('checkbox', {
+        name: /grant complimentary vip on signup/i,
+      })
+    );
+    await user.click(screen.getByRole('button', { name: /^approve$/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /reason when granting vip access/i
+    );
+    expect(mockApprove).not.toHaveBeenCalled();
+  });
+
+  it('saves VIP provisioning intent on approved entries', async () => {
+    const onUpdated = vi.fn();
+    const user = userEvent.setup();
+    const approvedEntry = {
+      ...pendingEntry,
+      status: 'approved' as const,
+      approved_at: '2024-01-02T00:00:00Z',
+      has_active_invite: true,
+    };
+    render(
+      <AdminWaitlistDetailDrawer
+        entry={approvedEntry}
+        open
+        onClose={vi.fn()}
+        onUpdated={onUpdated}
+      />
+    );
+    await user.click(
+      screen.getByRole('checkbox', {
+        name: /grant complimentary vip on signup/i,
+      })
+    );
+    await user.type(
+      screen.getByLabelText(/^reason \(required\)$/i),
+      'Retroactive VIP'
+    );
+    await user.click(screen.getByRole('button', { name: /save vip intent/i }));
+    await waitFor(() => expect(mockSetProvisioningIntent).toHaveBeenCalled());
+    expect(onUpdated).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/admin/components/AdminInviteByEmailPanel.web.tsx
+++ b/apps/web/src/admin/components/AdminInviteByEmailPanel.web.tsx
@@ -3,10 +3,15 @@ import {
   buildInviteUrl,
   emitLifecycleEvent,
   getAdminWaitlistSettings,
-  inviteWaitlistEmail,
 } from '@beakerstack/waitlist';
+import {
+  inviteWaitlistEmailWithIntent,
+  WaitlistVipInviteFields,
+  type WaitlistProvisioningIntentInput,
+} from '@beakerstack/waitlist-billing/web';
 import { supabase } from '../../lib/supabase';
 import { waitlistConfig } from '@adopter/config/waitlist';
+import { waitlistBillingConfig } from '@adopter/config/waitlist-billing';
 
 function mapInviteError(code: string): string {
   switch (code) {
@@ -14,6 +19,10 @@ function mapInviteError(code: string): string {
       return 'Enter a valid email address.';
     case 'already_converted':
       return 'This email already completed signup.';
+    case 'invalid_reason':
+      return 'Enter a reason when granting VIP access.';
+    case 'plan_not_allowed':
+      return 'That VIP plan is not allowed for waitlist invites.';
     case 'not_found':
       return 'You do not have permission to send invites.';
     default:
@@ -33,6 +42,11 @@ export function AdminInviteByEmailPanel({
   const [invite, setInvite] = useState<{ link: string; email: string } | null>(
     null
   );
+  const [provisioningIntent, setProvisioningIntent] =
+    useState<WaitlistProvisioningIntentInput | null>(null);
+  const [vipTouched, setVipTouched] = useState(false);
+  const [vipEnabled, setVipEnabled] = useState(false);
+  const [vipFormKey, setVipFormKey] = useState(0);
 
   useEffect(() => {
     void getAdminWaitlistSettings(supabase).then(settings => {
@@ -40,35 +54,62 @@ export function AdminInviteByEmailPanel({
     });
   }, []);
 
-  const sendInviteEmail = async (inviteUrl: string, to: string) => {
+  const sendInviteEmail = async (
+    inviteUrl: string,
+    to: string,
+    entryId: string
+  ) => {
     const logoUrl = `${waitlistConfig.appOrigin}/email-logo.png`;
     const html = waitlistConfig.emailTemplates.inviteHtml.replace(
       /{{logoUrl}}/g,
       logoUrl
     );
-    await supabase.functions.invoke(waitlistConfig.opsFunctionName, {
-      body: {
-        action: 'send_invite_email',
-        email: to,
-        inviteUrl,
-        subject: waitlistConfig.emailTemplates.inviteSubject,
-        html,
-      },
-    });
+    const { data, error: fnErr } = await supabase.functions.invoke(
+      waitlistConfig.opsFunctionName,
+      {
+        body: {
+          action: 'send_invite_email',
+          entryId,
+          email: to,
+          inviteUrl,
+          subject: waitlistConfig.emailTemplates.inviteSubject,
+          html,
+        },
+      }
+    );
+    if (fnErr) throw new Error(fnErr.message);
+    const body = data as { error?: string };
+    if (body?.error === 'email_not_configured') {
+      throw new Error(
+        'Email delivery is not configured. Copy the invite link below.'
+      );
+    }
+    if (body?.error) throw new Error(body.error);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = email.trim();
     if (!trimmed) return;
+    if (vipEnabled && !provisioningIntent) {
+      setError('Enter a reason when granting VIP access.');
+      return;
+    }
 
     setBusy(true);
     setError(null);
     setInvite(null);
     try {
-      const result = await inviteWaitlistEmail(supabase, trimmed);
+      const result = await inviteWaitlistEmailWithIntent(
+        supabase,
+        waitlistBillingConfig,
+        trimmed,
+        {
+          provisioningIntent: vipTouched ? provisioningIntent : undefined,
+        }
+      );
       if (result?.error) throw new Error(mapInviteError(result.error));
-      if (!result?.invite_token || !result.email) {
+      if (!result?.invite_token || !result.email || !result.entry_id) {
         throw new Error('Invite was not created.');
       }
 
@@ -77,12 +118,16 @@ export function AdminInviteByEmailPanel({
         result.invite_token
       );
       setInvite({ link, email: result.email });
-      await sendInviteEmail(link, result.email);
+      await sendInviteEmail(link, result.email, result.entry_id);
       await emitLifecycleEvent('waitlist.approved', {
         email: result.email,
         entryId: result.entry_id,
       });
       setEmail('');
+      setProvisioningIntent(null);
+      setVipTouched(false);
+      setVipEnabled(false);
+      setVipFormKey(k => k + 1);
       onInvited?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Could not create invite.');
@@ -115,31 +160,44 @@ export function AdminInviteByEmailPanel({
       </p>
 
       <form
-        className='mt-4 flex flex-col gap-3 sm:flex-row sm:items-end'
+        className='mt-4 flex flex-col gap-3'
         onSubmit={e => void handleSubmit(e)}
       >
-        <div className='flex-1'>
-          <label htmlFor='admin-invite-email' className='sr-only'>
-            Email address
-          </label>
-          <input
-            id='admin-invite-email'
-            type='email'
-            autoComplete='email'
-            value={email}
-            onChange={e => setEmail(e.target.value)}
-            placeholder='name@example.com'
-            disabled={busy}
-            className='w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 disabled:opacity-50'
-          />
+        <div className='flex flex-col gap-3 sm:flex-row sm:items-end'>
+          <div className='flex-1'>
+            <label htmlFor='admin-invite-email' className='sr-only'>
+              Email address
+            </label>
+            <input
+              id='admin-invite-email'
+              type='email'
+              autoComplete='email'
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              placeholder='name@example.com'
+              disabled={busy}
+              className='w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 disabled:opacity-50'
+            />
+          </div>
+          <button
+            type='submit'
+            disabled={busy || !email.trim()}
+            className='shrink-0 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50'
+          >
+            {busy ? 'Sending…' : 'Send invite'}
+          </button>
         </div>
-        <button
-          type='submit'
-          disabled={busy || !email.trim()}
-          className='shrink-0 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50'
-        >
-          {busy ? 'Sending…' : 'Send invite'}
-        </button>
+
+        <WaitlistVipInviteFields
+          key={vipFormKey}
+          defaultCompPlanId={waitlistBillingConfig.defaultCompPlanId}
+          disabled={busy}
+          onChange={intent => {
+            setVipTouched(true);
+            setProvisioningIntent(intent);
+          }}
+          onVipEnabledChange={setVipEnabled}
+        />
       </form>
 
       {error ? (

--- a/apps/web/src/admin/components/AdminUserDetailDrawer.web.tsx
+++ b/apps/web/src/admin/components/AdminUserDetailDrawer.web.tsx
@@ -1,13 +1,22 @@
 import { useEffect, useState } from 'react';
 import {
   getUser,
+  grantBillingComp,
   grantOperator,
+  revokeBillingComp,
   revokeOperator,
   type AdminUserDetail,
 } from '@beakerstack/admin';
 import { AdminDetailDrawer } from '@beakerstack/admin/web';
+import { billingConfig } from '@adopter/config/billing';
 import { supabase } from '../../lib/supabase';
 import { adminProductId } from '../adminUsageColumns';
+
+const COMP_VIP_PLAN_ID = 'beakerstack_vip';
+
+type OperatorAction = 'grant' | 'revoke';
+type CompAction = 'grant_comp' | 'revoke_comp';
+type PendingAction = OperatorAction | CompAction | null;
 
 function formatDate(value: string | null | undefined) {
   if (!value) return '—';
@@ -16,6 +25,20 @@ function formatDate(value: string | null | undefined) {
   } catch {
     return value;
   }
+}
+
+function compErrorMessage(code: string): string {
+  switch (code) {
+    case 'stripe_subscription_active':
+      return 'User has an active Stripe subscription. Cancel or migrate billing before granting complimentary access.';
+    case 'invalid_reason':
+      return 'Reason is required (max 500 characters).';
+    case 'invalid_plan':
+      return 'Invalid complimentary plan.';
+    case 'no_free_plan':
+      return 'No public free plan configured for this product.';
+  }
+  return code;
 }
 
 export function AdminUserDetailDrawer({
@@ -36,9 +59,8 @@ export function AdminUserDetailDrawer({
   const [detail, setDetail] = useState<AdminUserDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [actionPending, setActionPending] = useState<'grant' | 'revoke' | null>(
-    null
-  );
+  const [actionPending, setActionPending] = useState<PendingAction>(null);
+  const [compReason, setCompReason] = useState('');
   const [actionLoading, setActionLoading] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
 
@@ -46,6 +68,7 @@ export function AdminUserDetailDrawer({
     if (!open || !userId) {
       setDetail(null);
       setActionPending(null);
+      setCompReason('');
       setActionError(null);
       return;
     }
@@ -79,6 +102,12 @@ export function AdminUserDetailDrawer({
     }
   };
 
+  const dismissDialog = () => {
+    setActionPending(null);
+    setCompReason('');
+    setActionError(null);
+  };
+
   const handleConfirmAction = async () => {
     if (!userId || !actionPending) return;
     setActionLoading(true);
@@ -86,19 +115,38 @@ export function AdminUserDetailDrawer({
     try {
       if (actionPending === 'grant') {
         await grantOperator(supabase, userId);
-      } else {
+      } else if (actionPending === 'revoke') {
         await revokeOperator(supabase, userId);
+      } else if (actionPending === 'grant_comp') {
+        await grantBillingComp(supabase, {
+          userId,
+          productId: adminProductId,
+          planId: COMP_VIP_PLAN_ID,
+          reason: compReason.trim(),
+        });
+      } else if (actionPending === 'revoke_comp') {
+        await revokeBillingComp(supabase, {
+          userId,
+          productId: adminProductId,
+        });
       }
-      setActionPending(null);
+      dismissDialog();
       await refreshDetail();
       onAccessChanged?.();
     } catch (e) {
       const msg = e instanceof Error ? e.message : 'Action failed';
-      setActionError(
-        msg === 'cannot_self_revoke'
-          ? "You can't revoke your own admin access"
-          : msg
-      );
+      if (msg === 'cannot_self_revoke') {
+        setActionError("You can't revoke your own admin access");
+      } else if (
+        msg === 'stripe_subscription_active' ||
+        msg === 'invalid_reason' ||
+        msg === 'invalid_plan' ||
+        msg === 'no_free_plan'
+      ) {
+        setActionError(compErrorMessage(msg));
+      } else {
+        setActionError(msg);
+      }
     } finally {
       setActionLoading(false);
     }
@@ -106,6 +154,46 @@ export function AdminUserDetailDrawer({
 
   const isSelf =
     userId !== null && currentUserId !== null && userId === currentUserId;
+
+  const hasCompAccess = Boolean(detail?.comp_grant);
+
+  const vipPlanName =
+    billingConfig.plans.find(p => p.id === COMP_VIP_PLAN_ID)?.displayName ??
+    'VIP (complimentary)';
+
+  const confirmTitle = (() => {
+    switch (actionPending) {
+      case 'grant':
+        return 'Grant admin access';
+      case 'revoke':
+        return 'Revoke admin access';
+      case 'grant_comp':
+        return 'Grant complimentary VIP';
+      case 'revoke_comp':
+        return 'Revoke complimentary access';
+      default:
+        return '';
+    }
+  })();
+
+  const confirmBody = (() => {
+    const email = detail?.auth.email ?? 'this user';
+    switch (actionPending) {
+      case 'grant':
+        return `Grant admin access to ${email}?`;
+      case 'revoke':
+        return `Revoke admin access from ${email}?`;
+      case 'grant_comp':
+        return `Grant ${vipPlanName} to ${email}? This does not create a Stripe subscription.`;
+      case 'revoke_comp':
+        return `Revoke complimentary access for ${email}? They will return to the public free plan.`;
+      default:
+        return '';
+    }
+  })();
+
+  const confirmDisabled =
+    actionLoading || (actionPending === 'grant_comp' && !compReason.trim());
 
   return (
     <AdminDetailDrawer open={open} title={title} onClose={onClose}>
@@ -182,12 +270,81 @@ export function AdminUserDetailDrawer({
                   </button>
                 </>
               )}
-              {actionError && (
-                <p className='text-xs text-red-600' role='alert'>
-                  {actionError}
+            </div>
+          </section>
+
+          <section>
+            <h3 className='font-semibold text-gray-900'>Billing</h3>
+            <dl className='mt-2 space-y-1 text-gray-600'>
+              <div className='flex justify-between gap-4'>
+                <dt>Plan</dt>
+                <dd className='text-gray-900'>
+                  {(detail.plan?.['display_name'] as string) ??
+                    detail.subscription?.['plan_id'] ??
+                    '—'}
+                </dd>
+              </div>
+              <div className='flex justify-between gap-4'>
+                <dt>Status</dt>
+                <dd>{(detail.subscription?.['status'] as string) ?? '—'}</dd>
+              </div>
+            </dl>
+            {detail.comp_grant ? (
+              <div className='mt-3 space-y-1 rounded-md bg-indigo-50/80 px-3 py-2 text-xs text-indigo-950'>
+                <p className='font-medium text-indigo-900'>
+                  Complimentary access
                 </p>
+                <p>
+                  <span className='text-indigo-700'>Reason:</span>{' '}
+                  {detail.comp_grant.comp_reason}
+                </p>
+                {detail.comp_grant.comped_by_email ? (
+                  <p>
+                    <span className='text-indigo-700'>Granted by:</span>{' '}
+                    {detail.comp_grant.comped_by_email}
+                  </p>
+                ) : null}
+                <p>
+                  <span className='text-indigo-700'>Granted:</span>{' '}
+                  {formatDate(detail.comp_grant.comped_at)}
+                </p>
+                {detail.comp_grant.comp_expires_at ? (
+                  <p>
+                    <span className='text-indigo-700'>Expires:</span>{' '}
+                    {formatDate(detail.comp_grant.comp_expires_at)}
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+            <div className='mt-3 flex flex-wrap gap-2'>
+              {!hasCompAccess ? (
+                <button
+                  type='button'
+                  disabled={actionLoading}
+                  className='rounded bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-700 disabled:opacity-50'
+                  onClick={() => {
+                    setCompReason('');
+                    setActionPending('grant_comp');
+                  }}
+                >
+                  Grant complimentary VIP
+                </button>
+              ) : (
+                <button
+                  type='button'
+                  disabled={actionLoading}
+                  className='rounded bg-red-50 px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-100 disabled:opacity-50'
+                  onClick={() => setActionPending('revoke_comp')}
+                >
+                  Revoke complimentary access
+                </button>
               )}
             </div>
+            {actionError && actionPending === null ? (
+              <p className='mt-2 text-xs text-red-600' role='alert'>
+                {actionError}
+              </p>
+            ) : null}
           </section>
 
           {actionPending && (
@@ -198,37 +355,48 @@ export function AdminUserDetailDrawer({
               className='fixed inset-0 z-50 flex items-center justify-center bg-black/40'
               data-testid='confirm-dialog'
             >
-              <div className='w-80 rounded-lg bg-white p-6 shadow-xl'>
+              <div className='w-80 max-w-[calc(100vw-2rem)] rounded-lg bg-white p-6 shadow-xl'>
                 <h4
                   id='confirm-dialog-title'
                   className='text-sm font-semibold text-gray-900'
                 >
-                  {actionPending === 'grant'
-                    ? 'Grant admin access'
-                    : 'Revoke admin access'}
+                  {confirmTitle}
                 </h4>
-                <p className='mt-2 text-sm text-gray-600'>
-                  {actionPending === 'grant'
-                    ? `Grant admin access to ${detail.auth.email ?? 'this user'}?`
-                    : `Revoke admin access from ${detail.auth.email ?? 'this user'}?`}
-                </p>
+                <p className='mt-2 text-sm text-gray-600'>{confirmBody}</p>
+                {actionPending === 'grant_comp' ? (
+                  <label className='mt-3 block text-sm text-gray-700'>
+                    <span className='font-medium'>Reason (required)</span>
+                    <textarea
+                      className='mt-1 w-full rounded border border-gray-300 px-2 py-1.5 text-sm'
+                      rows={3}
+                      maxLength={500}
+                      value={compReason}
+                      onChange={e => setCompReason(e.target.value)}
+                      placeholder='e.g. design partner, press access'
+                      data-testid='comp-grant-reason'
+                    />
+                  </label>
+                ) : null}
+                {actionError ? (
+                  <p className='mt-2 text-xs text-red-600' role='alert'>
+                    {actionError}
+                  </p>
+                ) : null}
                 <div className='mt-4 flex justify-end gap-3'>
                   <button
                     type='button'
                     disabled={actionLoading}
                     className='rounded px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 disabled:opacity-50'
-                    onClick={() => {
-                      setActionPending(null);
-                      setActionError(null);
-                    }}
+                    onClick={dismissDialog}
                   >
                     Cancel
                   </button>
                   <button
                     type='button'
-                    disabled={actionLoading}
+                    disabled={confirmDisabled}
                     className={`rounded px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50 ${
-                      actionPending === 'grant'
+                      actionPending === 'grant' ||
+                      actionPending === 'grant_comp'
                         ? 'bg-indigo-600 hover:bg-indigo-700'
                         : 'bg-red-600 hover:bg-red-700'
                     }`}
@@ -258,24 +426,6 @@ export function AdminUserDetailDrawer({
               </dl>
             </section>
           )}
-
-          <section>
-            <h3 className='font-semibold text-gray-900'>Billing</h3>
-            <dl className='mt-2 space-y-1 text-gray-600'>
-              <div className='flex justify-between gap-4'>
-                <dt>Plan</dt>
-                <dd className='text-gray-900'>
-                  {(detail.plan?.['display_name'] as string) ??
-                    detail.subscription?.['plan_id'] ??
-                    '—'}
-                </dd>
-              </div>
-              <div className='flex justify-between gap-4'>
-                <dt>Status</dt>
-                <dd>{(detail.subscription?.['status'] as string) ?? '—'}</dd>
-              </div>
-            </dl>
-          </section>
 
           {detail.usage_aggregates.length > 0 && (
             <section>

--- a/apps/web/src/admin/components/AdminWaitlistDetailDrawer.web.tsx
+++ b/apps/web/src/admin/components/AdminWaitlistDetailDrawer.web.tsx
@@ -1,15 +1,22 @@
 import { useState } from 'react';
 import { AdminDetailDrawer } from '@beakerstack/admin/web';
 import {
-  approveWaitlistEntry,
   buildInviteUrl,
   emitLifecycleEvent,
+  parseStoredProvisioningIntent,
   rejectWaitlistEntry,
   resendWaitlistInvite,
   type WaitlistEntryRow,
 } from '@beakerstack/waitlist';
+import {
+  approveWaitlistEntryWithIntent,
+  setWaitlistEntryProvisioningIntent,
+  WaitlistVipInviteFields,
+  type WaitlistProvisioningIntentInput,
+} from '@beakerstack/waitlist-billing/web';
 import { supabase } from '../../lib/supabase';
 import { waitlistConfig } from '@adopter/config/waitlist';
+import { waitlistBillingConfig } from '@adopter/config/waitlist-billing';
 
 function formatDate(value: string | null | undefined) {
   if (!value) return '—';
@@ -29,6 +36,19 @@ function DetailRow({ label, value }: { label: string; value: string }) {
   );
 }
 
+function mapProvisioningError(code: string): string {
+  switch (code) {
+    case 'invalid_reason':
+      return 'Enter a reason when granting VIP access.';
+    case 'invalid_status':
+      return 'VIP intent can only be saved on pending or approved entries.';
+    case 'plan_not_allowed':
+      return 'That VIP plan is not allowed for waitlist invites.';
+    default:
+      return code;
+  }
+}
+
 export function AdminWaitlistDetailDrawer({
   entry,
   open,
@@ -43,8 +63,19 @@ export function AdminWaitlistDetailDrawer({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [inviteLink, setInviteLink] = useState<string | null>(null);
+  const [approveIntent, setApproveIntent] =
+    useState<WaitlistProvisioningIntentInput | null>(null);
+  const [approveIntentTouched, setApproveIntentTouched] = useState(false);
+  const [approveVipEnabled, setApproveVipEnabled] = useState(false);
+  const [saveIntent, setSaveIntent] =
+    useState<WaitlistProvisioningIntentInput | null>(null);
+  const [saveIntentTouched, setSaveIntentTouched] = useState(false);
+  const [saveVipEnabled, setSaveVipEnabled] = useState(false);
 
   if (!entry) return null;
+
+  const storedIntent = parseStoredProvisioningIntent(entry.metadata);
+  const hasVipIntent = storedIntent?.kind === 'billing_comp';
 
   const sendInviteEmail = async (
     token: string,
@@ -82,11 +113,21 @@ export function AdminWaitlistDetailDrawer({
   };
 
   const handleApprove = async () => {
+    if (approveVipEnabled && !approveIntent) {
+      setError('Enter a reason when granting VIP access.');
+      return;
+    }
+
     setBusy(true);
     setError(null);
     try {
-      const result = await approveWaitlistEntry(supabase, entry.id);
-      if (result?.error) throw new Error(result.error);
+      const result = await approveWaitlistEntryWithIntent(
+        supabase,
+        waitlistBillingConfig,
+        entry.id,
+        approveIntentTouched ? approveIntent : undefined
+      );
+      if (result?.error) throw new Error(mapProvisioningError(result.error));
       if (result?.invite_token && result.email) {
         await sendInviteEmail(result.invite_token, result.email, entry.id);
         await emitLifecycleEvent('waitlist.approved', {
@@ -94,9 +135,35 @@ export function AdminWaitlistDetailDrawer({
           entryId: entry.id,
         });
       }
+      setApproveIntentTouched(false);
       onUpdated();
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Approve failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleSaveVipIntent = async () => {
+    if (saveVipEnabled && !saveIntent) {
+      setError('Enter a reason when granting VIP access.');
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await setWaitlistEntryProvisioningIntent(
+        supabase,
+        waitlistBillingConfig,
+        entry.id,
+        saveIntentTouched ? saveIntent : null
+      );
+      if (result?.error) throw new Error(mapProvisioningError(result.error));
+      setSaveIntentTouched(false);
+      onUpdated();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Save failed');
     } finally {
       setBusy(false);
     }
@@ -146,6 +213,7 @@ export function AdminWaitlistDetailDrawer({
     <AdminDetailDrawer open={open} title={entry.email} onClose={onClose}>
       <dl className='space-y-3 text-sm'>
         <DetailRow label='Status' value={entry.status} />
+        {hasVipIntent ? <DetailRow label='VIP on signup' value='Yes' /> : null}
         <DetailRow label='Submitted' value={formatDate(entry.submitted_at)} />
         <DetailRow label='Approved' value={formatDate(entry.approved_at)} />
         <DetailRow label='Rejected' value={formatDate(entry.rejected_at)} />
@@ -173,6 +241,43 @@ export function AdminWaitlistDetailDrawer({
             onClick={() => void copyLink()}
           >
             Copy invite link
+          </button>
+        </div>
+      ) : null}
+
+      {entry.status === 'pending' ? (
+        <div className='mt-4'>
+          <WaitlistVipInviteFields
+            defaultCompPlanId={waitlistBillingConfig.defaultCompPlanId}
+            disabled={busy}
+            onChange={intent => {
+              setApproveIntentTouched(true);
+              setApproveIntent(intent);
+            }}
+            onVipEnabledChange={setApproveVipEnabled}
+          />
+        </div>
+      ) : null}
+
+      {entry.status === 'approved' ? (
+        <div className='mt-4 space-y-3'>
+          <WaitlistVipInviteFields
+            defaultCompPlanId={waitlistBillingConfig.defaultCompPlanId}
+            initialMetadata={entry.metadata}
+            disabled={busy}
+            onChange={intent => {
+              setSaveIntentTouched(true);
+              setSaveIntent(intent);
+            }}
+            onVipEnabledChange={setSaveVipEnabled}
+          />
+          <button
+            type='button'
+            disabled={busy || !saveIntentTouched}
+            className='px-3 py-1.5 text-sm font-medium rounded-md border border-indigo-600 text-indigo-700 hover:bg-indigo-50 disabled:opacity-50'
+            onClick={() => void handleSaveVipIntent()}
+          >
+            Save VIP intent
           </button>
         </div>
       ) : null}

--- a/apps/web/src/admin/pages/AdminWaitlistSettingsPage.tsx
+++ b/apps/web/src/admin/pages/AdminWaitlistSettingsPage.tsx
@@ -28,15 +28,30 @@ export default function AdminWaitlistSettingsPage() {
     enabled: false,
     label: '',
   });
+  const [loadedDefaultPlanId, setLoadedDefaultPlanId] = useState<string | null>(
+    null
+  );
 
   useEffect(() => {
     void (async () => {
       setLoading(true);
       const data = await getAdminWaitlistSettings(supabase);
-      setSettings(data);
       if (data) {
+        setLoadedDefaultPlanId(data.default_plan_id);
+        const publicPlans = billingConfig.plans.filter(p => p.isPublic);
+        const storedDefaultIsPublic = publicPlans.some(
+          p => p.id === data.default_plan_id
+        );
+        const normalized =
+          !storedDefaultIsPublic && publicPlans[0]
+            ? { ...data, default_plan_id: publicPlans[0].id }
+            : data;
+        setSettings(normalized);
         setUseCaseField(
-          resolveUseCaseFieldEditorState(data.metadata_schema, waitlistConfig)
+          resolveUseCaseFieldEditorState(
+            normalized.metadata_schema,
+            waitlistConfig
+          )
         );
       }
       setLoading(false);
@@ -62,6 +77,7 @@ export default function AdminWaitlistSettingsPage() {
       });
       if (!updated) throw new Error('Failed to save settings');
       setSettings(updated);
+      setLoadedDefaultPlanId(updated.default_plan_id);
       setUseCaseField(
         resolveUseCaseFieldEditorState(updated.metadata_schema, waitlistConfig)
       );
@@ -80,6 +96,11 @@ export default function AdminWaitlistSettingsPage() {
       </div>
     );
   }
+
+  const publicPlans = billingConfig.plans.filter(p => p.isPublic);
+  const storedDefaultIsPublic =
+    loadedDefaultPlanId == null ||
+    publicPlans.some(p => p.id === loadedDefaultPlanId);
 
   return (
     <div className='space-y-6'>
@@ -117,6 +138,17 @@ export default function AdminWaitlistSettingsPage() {
           <span className='text-sm font-medium text-gray-700'>
             Starting plan on invite signup
           </span>
+          {!storedDefaultIsPublic && loadedDefaultPlanId ? (
+            <p
+              className='mt-1 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-950'
+              role='status'
+            >
+              Stored default{' '}
+              <code className='font-mono'>{loadedDefaultPlanId}</code> is not a
+              public plan. Choose a public plan below; use per-invite VIP for
+              complimentary access.
+            </p>
+          ) : null}
           <select
             className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm'
             value={settings.default_plan_id}
@@ -124,7 +156,7 @@ export default function AdminWaitlistSettingsPage() {
               setSettings({ ...settings, default_plan_id: e.target.value })
             }
           >
-            {billingConfig.plans.map(p => (
+            {publicPlans.map(p => (
               <option key={p.id} value={p.id}>
                 {p.displayName} ({p.id})
               </option>

--- a/apps/web/src/components/billing/CurrentPlanCard.web.tsx
+++ b/apps/web/src/components/billing/CurrentPlanCard.web.tsx
@@ -13,6 +13,7 @@ export function CurrentPlanCard({
   plan,
   subscription,
   isFree,
+  isComped = false,
   onManagePayment,
   managePaymentPending = false,
   /** When set, replaces default renewal / trial / end copy for paid rows (e.g. scheduled downgrade). */
@@ -21,6 +22,7 @@ export function CurrentPlanCard({
   plan: Plan | null;
   subscription: SubscriptionRow | null;
   isFree: boolean;
+  isComped?: boolean;
   onManagePayment: () => void;
   managePaymentPending?: boolean;
   periodSubcopy?: string | null;
@@ -44,7 +46,22 @@ export function CurrentPlanCard({
 
   return (
     <div className='space-y-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 sm:p-8 shadow-sm'>
-      {isFree ? (
+      {isComped ? (
+        <>
+          <div className='flex flex-wrap items-center gap-2'>
+            <h2 className='text-2xl font-bold text-gray-900 dark:text-white'>
+              {plan.display_name}
+            </h2>
+            {subscription && (
+              <SubscriptionStatusBadge subscription={subscription} />
+            )}
+          </div>
+          <p className='text-sm text-gray-600 dark:text-gray-300'>
+            Complimentary access — billing is managed by our team. No payment
+            method or checkout is required.
+          </p>
+        </>
+      ) : isFree ? (
         <>
           <h2 className='text-2xl font-bold text-gray-900 dark:text-white'>
             You&apos;re on the Free plan
@@ -83,24 +100,26 @@ export function CurrentPlanCard({
                 : `Renews on ${periodEnd}`}
         </p>
       )}
-      <div className='flex flex-col gap-3 sm:flex-row sm:flex-wrap'>
-        <Link
-          to='/billing/plans'
-          className='inline-flex w-full min-h-[40px] sm:w-auto items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 sm:inline-flex sm:min-w-[8rem]'
-        >
-          {isFree ? 'Upgrade to Pro' : 'Change plan'}
-        </Link>
-        {!isFree && subscription?.stripe_customer_id ? (
-          <Button
-            type='button'
-            variant='secondary'
-            onPress={onManagePayment}
-            loading={managePaymentPending}
+      {!isComped ? (
+        <div className='flex flex-col gap-3 sm:flex-row sm:flex-wrap'>
+          <Link
+            to='/billing/plans'
+            className='inline-flex w-full min-h-[40px] sm:w-auto items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 sm:inline-flex sm:min-w-[8rem]'
           >
-            Manage payment &amp; invoices
-          </Button>
-        ) : null}
-      </div>
+            {isFree ? 'Upgrade to Pro' : 'Change plan'}
+          </Link>
+          {!isFree && subscription?.stripe_customer_id ? (
+            <Button
+              type='button'
+              variant='secondary'
+              onPress={onManagePayment}
+              loading={managePaymentPending}
+            >
+              Manage payment &amp; invoices
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/billing/__tests__/CurrentPlanCard.web.test.tsx
+++ b/apps/web/src/components/billing/__tests__/CurrentPlanCard.web.test.tsx
@@ -216,4 +216,28 @@ describe('CurrentPlanCard', () => {
     );
     expect(screen.getByText(/^Renews on /)).toBeInTheDocument();
   });
+
+  it('renders complimentary access copy when isComped', () => {
+    render(
+      <MemoryRouter>
+        <CurrentPlanCard
+          plan={plan}
+          subscription={{ ...subscription, status: 'comped' }}
+          isFree={false}
+          isComped
+          onManagePayment={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Pro')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Complimentary access — billing is managed by our team/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Manage payment/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /Change plan/i })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/billing/BillingOverviewPage.tsx
+++ b/apps/web/src/pages/billing/BillingOverviewPage.tsx
@@ -52,10 +52,12 @@ export default function BillingOverviewPage() {
   const { count: colCount, loading: colLoad } = useDemoCollectionCount();
   const { user } = useAuthContext();
 
+  const isComped = kind === 'comped';
   const isFree =
-    kind === 'free' ||
-    currentPlan?.price_cents === 0 ||
-    !subscription?.stripe_subscription_id;
+    !isComped &&
+    (kind === 'free' ||
+      currentPlan?.price_cents === 0 ||
+      !subscription?.stripe_subscription_id);
 
   const pendingTargetName =
     subscription?.pending_target_plan_id != null
@@ -111,6 +113,7 @@ export default function BillingOverviewPage() {
             plan={currentPlan}
             subscription={subscription}
             isFree={!!isFree}
+            isComped={isComped}
             onManagePayment={() => void openPortal()}
             managePaymentPending={portalPend}
             periodSubcopy={periodSubcopy}
@@ -178,6 +181,14 @@ function OverviewBanners({
   );
 
   if (kind === 'loading' || kind === 'no_subscription') return null;
+  if (kind === 'comped') {
+    return (
+      <Banner variant='info' title='Complimentary access'>
+        Your plan is included at no charge. Checkout and the Stripe customer
+        portal are not available for complimentary accounts.
+      </Banner>
+    );
+  }
   if (kind === 'payment_failed') {
     return (
       <Banner variant='error' title='Payment problem'>

--- a/apps/web/src/pages/billing/BillingPlansPage.tsx
+++ b/apps/web/src/pages/billing/BillingPlansPage.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../components/billing/CadenceToggle.web';
 import { BillingPageShell } from '../../components/billing/BillingPageShell.web';
 import { BillingTabs } from '../../components/billing/BillingTabs.web';
+import { Banner } from '../../components/billing/Banner.web';
 import { ConfirmDowngradeModal } from '../../components/billing/ConfirmDowngradeModal.web';
 import { PlanCard } from '../../components/billing/PlanCard.web';
 
@@ -145,11 +146,21 @@ export default function BillingPlansPage() {
     [current, colCount, maxItemsInAnyCollection, aiUsed, hasPaidStripe, plans]
   );
 
+  const isComped = billingKind === 'comped';
+
   const getPrimary = useCallback(
     (p: Plan): Primary => {
       if (!current) {
         return {
           label: '…',
+          disabled: true,
+          loading: false,
+        };
+      }
+      if (isComped) {
+        return {
+          label:
+            p.id === current.id ? 'Current plan' : 'Included with your account',
           disabled: true,
           loading: false,
         };
@@ -247,6 +258,7 @@ export default function BillingPlansPage() {
       startCheckout,
       updateSubscription,
       pending,
+      isComped,
     ]
   );
 
@@ -267,6 +279,12 @@ export default function BillingPlansPage() {
       <div className='mt-6'>
         <CadenceToggle />
       </div>
+      {isComped ? (
+        <Banner variant='info' className='mt-6'>
+          You have complimentary access. Plan changes and Stripe checkout are
+          not available on this account.
+        </Banner>
+      ) : null}
       {welcomeFromPricing && welcomePlanMeta ? (
         <div
           role='status'

--- a/apps/web/src/pages/billing/__tests__/BillingOverviewPage.test.tsx
+++ b/apps/web/src/pages/billing/__tests__/BillingOverviewPage.test.tsx
@@ -427,4 +427,24 @@ describe('BillingOverviewPage', () => {
     );
     expect(openPortalSpy).toHaveBeenCalled();
   });
+
+  it('shows complimentary access banner when billing kind is comped', () => {
+    state.kind = 'comped';
+    Object.assign(state.subscription, {
+      stripe_subscription_id: null,
+      status: 'comped',
+      plan_id: 'beakerstack_vip',
+    });
+    render(
+      <MemoryRouter>
+        <BillingOverviewPage />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Complimentary access')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Checkout and the Stripe customer portal are not available/i
+      )
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/billing/__tests__/BillingPlansPage.test.tsx
+++ b/apps/web/src/pages/billing/__tests__/BillingPlansPage.test.tsx
@@ -807,6 +807,40 @@ describe('BillingPlansPage', () => {
     expect(checkoutSpies.scheduleCancelToFree).not.toHaveBeenCalled();
   });
 
+  it('disables plan changes when billing kind is comped', () => {
+    plansState.billingKind = 'comped';
+    plansState.current = plansState.maxPlan;
+    plansState.subscription = {
+      id: 's_vip',
+      user_id: 'u1',
+      product_id: 'beakerstack',
+      plan_id: 'beakerstack_max',
+      stripe_customer_id: null,
+      stripe_subscription_id: null,
+      stripe_price_id: null,
+      status: 'comped',
+      current_period_start: null,
+      current_period_end: null,
+      cancel_at_period_end: false,
+      pending_target_plan_id: null,
+      canceled_at: null,
+      trial_start: null,
+      trial_end: null,
+    };
+    renderPage();
+    expect(
+      screen.getByText(
+        /You have complimentary access\. Plan changes and Stripe checkout are not available on this account\./i
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Current plan' })).toBeDisabled();
+    const included = screen.getAllByRole('button', {
+      name: 'Included with your account',
+    });
+    expect(included.length).toBeGreaterThan(0);
+    included.forEach(btn => expect(btn).toBeDisabled());
+  });
+
   it('does not reload when downgrade modal confirm resolves false', async () => {
     const user = userEvent.setup();
     const reload = vi.fn();

--- a/docs/specs/waitlist-billing-integration-v1.md
+++ b/docs/specs/waitlist-billing-integration-v1.md
@@ -1,0 +1,55 @@
+# Waitlist–billing integration v1
+
+Factory integration between `@beakerstack/waitlist` and `@beakerstack/billing` for per-invite provisioning at conversion time.
+
+## Package
+
+`@beakerstack/waitlist-billing` — adopter config in [`adopter/config/waitlist-billing.ts`](../../adopter/config/waitlist-billing.ts).
+
+```typescript
+{
+  productId: 'beakerstack',
+  compPlanIds: ['beakerstack_vip'],
+  defaultCompPlanId: 'beakerstack_vip',
+}
+```
+
+## Flow
+
+1. Admin sets `provisioning_intent` on invite/approve (`admin_invite_waitlist_email`, `admin_approve_waitlist_entry`) or retroactively (`admin_set_waitlist_entry_provisioning_intent`).
+2. User completes signup; `waitlist_consume_invite` returns `entry_id` + `provisioning_intent` (including OAuth `already_converted`).
+3. `waitlist-ops` calls `waitlist_billing_fulfill_conversion` whenever `entry_id` is present.
+4. Fallback to `waitlist_settings.default_plan_id` only when fulfill did not apply comp/plan.
+
+## RPCs
+
+| RPC                                            | Role                | Purpose                                           |
+| ---------------------------------------------- | ------------------- | ------------------------------------------------- |
+| `admin_set_waitlist_entry_provisioning_intent` | authenticated admin | Set/clear intent on `pending` / `approved`        |
+| `waitlist_billing_fulfill_conversion`          | service_role        | Read intent from entry; apply comp or public plan |
+| `_billing_apply_comp_grant`                    | service_role        | Shared comp grant helper (billing core)           |
+
+## Allowlist
+
+`p_allowed_comp_plan_ids text[]` is passed from adopter TypeScript config at call time. Expanding VIP plans is config-only (no SQL migration).
+
+## Ops CLI
+
+```bash
+BEAKERSTACK_ADMIN_EMAIL=... BEAKERSTACK_ADMIN_PASSWORD=... \
+  npm run admin:invite -- --email user@example.com --vip --reason "Design partner"
+
+npm run admin:waitlist-vip -- --entry-id <uuid> --vip --reason "Retroactive"
+npm run admin:waitlist-vip -- --entry-id <uuid> --clear
+```
+
+## Deploy checklist
+
+Keep these in sync when changing VIP comp plans:
+
+| Surface                                                 | Config source                                                                                   |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Admin UI / CLI / `@beakerstack/waitlist-billing` client | `adopter/config/waitlist-billing.ts` → `compPlanIds`                                            |
+| `waitlist-ops` edge (`consume` fulfill path)            | Supabase secret / env `WAITLIST_COMP_PLAN_IDS` (comma-separated; defaults to `beakerstack_vip`) |
+
+After adding or renaming a comp plan ID, update **both** places and redeploy the edge function. Mismatch surfaces as `plan_not_allowed` at conversion time while admin invite/approve still succeeds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "patch-package": "^8.0.0",
         "react-refresh": "^0.18.0",
         "react-test-renderer": "18.2.0",
-        "sharp": "^0.34.5",
+        "sharp": "^0.35.0",
         "typescript": "^5.3.0"
       }
     },
@@ -400,15 +400,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
@@ -424,15 +415,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
@@ -2398,15 +2380,6 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/preset-flow": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.27.1.tgz",
@@ -3212,9 +3185,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3735,9 +3708,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4032,17 +4005,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@expo/cli/node_modules/@expo/plist": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.1.3.tgz",
-      "integrity": "sha512-GW/7hVlAylYg1tUrEASclw1MMk9FP4ZwyFAY/SUTJIhPDQHtfOlXREyWV3hhrHdX/K+pS73GNgdfT6E/e+kBbg==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "~0.7.7",
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^14.0.0"
-      }
-    },
     "node_modules/@expo/cli/node_modules/@expo/prebuild-config": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-6.8.1.tgz",
@@ -4138,18 +4100,6 @@
         "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
-    "node_modules/@expo/cli/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/@expo/cli/node_modules/ansi-regex": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
@@ -4169,6 +4119,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/@expo/cli/node_modules/cli-cursor": {
@@ -4346,19 +4306,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@expo/cli/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@expo/cli/node_modules/log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -4404,6 +4351,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@expo/cli/node_modules/npm-package-arg": {
@@ -4636,15 +4595,6 @@
       "resolved": "https://registry.npmjs.org/wonka/-/wonka-4.0.15.tgz",
       "integrity": "sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg==",
       "license": "MIT"
-    },
-    "node_modules/@expo/cli/node_modules/xmlbuilder": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
-      "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0"
-      }
     },
     "node_modules/@expo/cli/node_modules/yallist": {
       "version": "4.0.0",
@@ -4998,35 +4948,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/@expo/eas-json/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@expo/eas-json/node_modules/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/eas-json/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -5056,13 +4977,6 @@
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/@expo/eas-json/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/@expo/env": {
       "version": "1.0.7",
@@ -6498,9 +6412,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6554,9 +6468,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -6567,19 +6481,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -6590,19 +6504,39 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -6617,9 +6551,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -6634,13 +6568,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6651,13 +6588,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6668,13 +6608,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6685,13 +6628,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6702,13 +6648,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6719,13 +6668,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6736,13 +6688,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6753,13 +6708,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6770,213 +6728,254 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -6987,16 +6986,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -7007,16 +7006,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -7027,7 +7026,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -7059,6 +7058,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -7076,6 +7076,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7088,6 +7089,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7100,12 +7102,14 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -7123,6 +7127,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -7138,6 +7143,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -7149,6 +7155,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/@isaacs/ttlcache": {
@@ -8334,6 +8361,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8834,27 +8862,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
     },
-    "node_modules/@react-native-community/cli-server-api/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@react-native-community/cli-tools": {
       "version": "12.3.6",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-12.3.6.tgz",
@@ -9320,15 +9327,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@react-native/dev-middleware/node_modules/ws": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.4.tgz",
-      "integrity": "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/@react-native/gradle-plugin": {
@@ -10226,33 +10224,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/cli/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@sentry/core": {
       "version": "8.55.2",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.2.tgz",
@@ -10562,31 +10533,6 @@
       },
       "peerDependencies": {
         "react": "^16.14.0 || 17.x || 18.x || 19.x"
-      }
-    },
-    "node_modules/@sentry/react-native/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@sentry/react-native/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@sentry/types": {
@@ -11788,16 +11734,16 @@
       }
     },
     "node_modules/@vitest/eslint-plugin/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@vitest/eslint-plugin/node_modules/eslint-visitor-keys": {
@@ -12397,12 +12343,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "license": "MIT"
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -12544,9 +12484,9 @@
       }
     },
     "node_modules/babel-plugin-istanbul/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13047,9 +12987,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -14870,9 +14810,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -15123,19 +15063,6 @@
         "xmlbuilder": "^14.0.0"
       }
     },
-    "node_modules/eas-cli/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/eas-cli/node_modules/dotenv": {
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
@@ -15186,20 +15113,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/eas-cli/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/eas-cli/node_modules/ignore": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
@@ -15221,19 +15134,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/eas-cli/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eas-cli/node_modules/minipass": {
@@ -15284,22 +15184,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eas-cli/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eas-cli/node_modules/tr46": {
@@ -15354,17 +15238,11 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/eas-cli/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -16059,16 +15937,16 @@
       }
     },
     "node_modules/eslint-plugin-testing-library/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/eslint-plugin-testing-library/node_modules/eslint-visitor-keys": {
@@ -16161,9 +16039,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17251,9 +17129,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -17621,6 +17499,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -17637,6 +17516,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -17986,9 +17866,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -19490,6 +19370,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -20735,9 +20616,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -22450,27 +22331,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/metro/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -22644,6 +22504,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
       "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.0.4",
@@ -22658,6 +22519,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -22678,6 +22540,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -22687,6 +22550,7 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
       "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^10.3.7"
@@ -22852,9 +22716,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -23162,9 +23026,9 @@
       }
     },
     "node_modules/nyc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23777,6 +23641,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-manager-detector": {
@@ -24015,6 +23880,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -24031,12 +23897,14 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/path-scurry/node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -24348,9 +24216,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -24367,7 +24235,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -24862,27 +24730,6 @@
         "ws": "^7"
       }
     },
-    "node_modules/react-devtools-core/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -25192,15 +25039,6 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/react-native/node_modules/ws": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.4.tgz",
-      "integrity": "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/react-refresh": {
@@ -26174,48 +26012,53 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/shebang-command": {
@@ -26240,9 +26083,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -26775,6 +26618,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -26789,6 +26633,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -26876,6 +26721,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -27141,9 +26987,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -27166,6 +27012,45 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/tar/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/temp": {
@@ -28799,6 +28684,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -29073,7 +28959,7 @@
       "name": "@beakerstack/articles",
       "version": "1.0.0",
       "dependencies": {
-        "dompurify": "^3.4.11",
+        "dompurify": "^3.4.12",
         "jsdom": "^26.1.0"
       },
       "devDependencies": {
@@ -29224,7 +29110,7 @@
       "name": "@beakerstack/help",
       "version": "1.0.0",
       "dependencies": {
-        "dompurify": "^3.4.11",
+        "dompurify": "^3.4.12",
         "jsdom": "^26.1.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2776,6 +2776,10 @@
       "resolved": "packages/waitlist",
       "link": true
     },
+    "node_modules/@beakerstack/waitlist-billing": {
+      "resolved": "packages/waitlist-billing",
+      "link": true
+    },
     "node_modules/@changesets/apply-release-plan": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.1.tgz",
@@ -29459,6 +29463,35 @@
         "@beakerstack/lifecycle-events": "^1.0.0",
         "@supabase/supabase-js": "^2.38.0",
         "zod": "^3.22.0"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.4.2",
+        "@testing-library/react": "^14.1.2",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/react": "18.2.0",
+        "@types/react-dom": "18.2.0",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
+        "@vitest/coverage-v8": "^4.1.8",
+        "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.1.0",
+        "jsdom": "^26.1.0",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "typescript": "^5.3.0",
+        "vitest": "^4.1.8"
+      },
+      "peerDependencies": {
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
+      }
+    },
+    "packages/waitlist-billing": {
+      "name": "@beakerstack/waitlist-billing",
+      "version": "1.0.0",
+      "dependencies": {
+        "@beakerstack/waitlist": "^1.0.0",
+        "@supabase/supabase-js": "^2.38.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -246,22 +246,25 @@
     "@types/react": "18.2.0",
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "node-forge": "^1.3.4",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "qs": "6.15.2",
     "semver": "^7.6.3",
     "send": "^0.19.0",
-    "shell-quote": "1.8.4",
-    "tar": "7.5.16",
+    "shell-quote": "1.9.0",
+    "tar": "7.5.22",
     "tmp": "^0.2.6",
     "yaml": "^2.8.3",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.0",
     "gray-matter": {
-      "js-yaml": "4.2.0"
+      "js-yaml": "4.3.0"
     },
+    "brace-expansion@1": "1.1.18",
+    "brace-expansion@2": "2.1.4",
+    "brace-expansion@5": "5.0.9",
     "joi": "17.13.4",
     "ts-deepmerge": "8.0.0",
     "cacache": {
-      "tar": "7.5.16"
+      "tar": "7.5.22"
     },
     "@expo/image-utils": {
       "semver": "^7.6.3"
@@ -280,7 +283,7 @@
     },
     "form-data": "4.0.6",
     "ws": "^8.21.0",
-    "fast-uri": "^3.1.2",
+    "fast-uri": "3.1.4",
     "fast-xml-builder": "^1.1.7",
     "@react-native-community/cli-platform-android@12.3.6": {
       "fast-xml-parser": "5.7.1"
@@ -306,23 +309,23 @@
       "node-forge": "^1.3.4",
       "send": "^0.19.0",
       "form-data": "4.0.6",
-      "tar": "7.5.16",
+      "tar": "7.5.22",
       "diff": "^8.0.3",
       "joi": "17.13.4",
       "ts-deepmerge": "8.0.0",
       "uuid": "14.0.0",
-      "js-yaml": "4.2.0"
+      "js-yaml": "4.3.0"
     },
     "@expo/cli": {
       "@xmldom/xmldom": "0.8.13",
       "@expo/plist": "0.5.2",
       "form-data": "3.0.5",
-      "tar": "7.5.16",
-      "js-yaml": "4.2.0",
+      "tar": "7.5.22",
+      "js-yaml": "4.3.0",
       "send": "^0.19.0"
     },
     "@expo/metro-config": {
-      "postcss": "^8.5.10"
+      "postcss": "^8.5.18"
     },
     "@expo/steps": {
       "uuid": "14.0.0"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "gen:types:staging": "supabase gen types typescript --project-id $STAGING_PROJECT_REF > apps/mobile/src/types/database.ts && cp apps/mobile/src/types/database.ts apps/web/src/types/database.ts",
     "test": "npm run test:unit && npm run test:integration && npm run test:db",
     "test:all": "npm run test && npm run test:e2e",
-    "test:unit": "npm run test:unit:mobile && npm run test:unit:web && npm run test:unit:shared && npm run test:unit:billing && npm run test:unit:admin && npm run test:unit:lifecycle-events && npm run test:unit:waitlist && npm run test:unit:email && npm run test:unit:marketing-email && npm run test:unit:help && npm run test:unit:articles && npm run test:unit:logger && npm run test:unit:observability && npm run test:unit:connections && npm run test:unit:scripts",
+    "test:unit": "npm run test:unit:mobile && npm run test:unit:web && npm run test:unit:shared && npm run test:unit:billing && npm run test:unit:admin && npm run test:unit:lifecycle-events && npm run test:unit:waitlist && npm run test:unit:waitlist-billing && npm run test:unit:email && npm run test:unit:marketing-email && npm run test:unit:help && npm run test:unit:articles && npm run test:unit:logger && npm run test:unit:observability && npm run test:unit:connections && npm run test:unit:scripts",
     "test:unit:mobile": "cd apps/mobile && npm test && cd ../../packages/adopter-tests && npm test",
     "test:unit:web": "cd apps/web && npm test",
     "test:unit:shared": "cd packages/shared-tests && npm run test",
@@ -86,6 +86,7 @@
     "test:unit:admin": "cd packages/admin && npm test",
     "test:unit:lifecycle-events": "cd packages/lifecycle-events && npm test",
     "test:unit:waitlist": "cd packages/waitlist && npm test",
+    "test:unit:waitlist-billing": "cd packages/waitlist-billing && npm test",
     "test:unit:email": "cd packages/email && npm test",
     "test:unit:marketing-email": "cd packages/marketing-email && npm test",
     "test:unit:help": "cd packages/help && npm test",
@@ -204,6 +205,8 @@
     "billing:apply-plans": "tsx scripts/apply-billing-plans-from-config.ts",
     "admin:grant": "tsx scripts/grant-admin.ts",
     "admin:revoke": "tsx scripts/revoke-admin.ts",
+    "admin:invite": "node scripts/admin-waitlist-invite.mjs",
+    "admin:waitlist-vip": "node scripts/admin-waitlist-vip.mjs",
     "functions:sync-shared": "node scripts/sync-edge-shared.mjs"
   },
   "devDependencies": {

--- a/packages/admin/src/adminClient.test.ts
+++ b/packages/admin/src/adminClient.test.ts
@@ -3,9 +3,11 @@ import {
   checkIsAdmin,
   getUser,
   grantOperator,
+  grantBillingComp,
   listUsers,
   recordAuditEvent,
   revokeOperator,
+  revokeBillingComp,
 } from './adminClient.js';
 
 function mockSupabase(
@@ -233,5 +235,100 @@ describe('adminClient', () => {
   it('revokeOperator throws when RPC errors', async () => {
     const sb = mockSupabase(() => null, { error: { message: 'denied' } });
     await expect(revokeOperator(sb, 'u2')).rejects.toThrow('denied');
+  });
+
+  it('grantBillingComp calls admin_grant_billing_comp RPC', async () => {
+    const sb = mockSupabase(name =>
+      name === 'admin_grant_billing_comp' ? { ok: true } : null
+    );
+    await grantBillingComp(sb, {
+      userId: 'u1',
+      productId: 'beakerstack',
+      planId: 'beakerstack_vip',
+      reason: 'VIP partner',
+      expiresAt: '2027-01-01T00:00:00Z',
+    });
+    expect(sb.rpc).toHaveBeenCalledWith('admin_grant_billing_comp', {
+      p_user_id: 'u1',
+      p_product_id: 'beakerstack',
+      p_plan_id: 'beakerstack_vip',
+      p_reason: 'VIP partner',
+      p_expires_at: '2027-01-01T00:00:00Z',
+    });
+  });
+
+  it('grantBillingComp maps RPC error codes', async () => {
+    const cases = [
+      { data: { error: 'not_found' }, err: 'not_found' },
+      { data: { error: 'invalid_reason' }, err: 'invalid_reason' },
+      { data: { error: 'invalid_plan' }, err: 'invalid_plan' },
+      {
+        data: { error: 'stripe_subscription_active' },
+        err: 'stripe_subscription_active',
+      },
+    ] as const;
+    for (const { data, err } of cases) {
+      const sb = mockSupabase(name =>
+        name === 'admin_grant_billing_comp' ? data : null
+      );
+      await expect(
+        grantBillingComp(sb, {
+          userId: 'u1',
+          productId: 'beakerstack',
+          planId: 'beakerstack_vip',
+          reason: 'x',
+        })
+      ).rejects.toThrow(err);
+    }
+  });
+
+  it('grantBillingComp passes null expiresAt to RPC', async () => {
+    const sb = mockSupabase(name =>
+      name === 'admin_grant_billing_comp' ? { ok: true } : null
+    );
+    await grantBillingComp(sb, {
+      userId: 'u1',
+      productId: 'beakerstack',
+      planId: 'beakerstack_vip',
+      reason: 'VIP partner',
+      expiresAt: null,
+    });
+    expect(sb.rpc).toHaveBeenCalledWith('admin_grant_billing_comp', {
+      p_user_id: 'u1',
+      p_product_id: 'beakerstack',
+      p_plan_id: 'beakerstack_vip',
+      p_reason: 'VIP partner',
+      p_expires_at: null,
+    });
+  });
+
+  it('grantBillingComp throws on unexpected RPC error codes', async () => {
+    const sb = mockSupabase(name =>
+      name === 'admin_grant_billing_comp' ? { error: 'no_free_plan' } : null
+    );
+    await expect(
+      grantBillingComp(sb, {
+        userId: 'u1',
+        productId: 'beakerstack',
+        planId: 'beakerstack_vip',
+        reason: 'x',
+      })
+    ).rejects.toThrow('no_free_plan');
+  });
+
+  it('revokeBillingComp calls admin_revoke_billing_comp RPC', async () => {
+    const sb = mockSupabase(name =>
+      name === 'admin_revoke_billing_comp' ? { ok: true } : null
+    );
+    await revokeBillingComp(sb, {
+      userId: 'u1',
+      productId: 'beakerstack',
+      reason: 'done',
+    });
+    expect(sb.rpc).toHaveBeenCalledWith('admin_revoke_billing_comp', {
+      p_user_id: 'u1',
+      p_product_id: 'beakerstack',
+      p_reason: 'done',
+    });
   });
 });

--- a/packages/admin/src/adminClient.ts
+++ b/packages/admin/src/adminClient.ts
@@ -119,6 +119,55 @@ export async function revokeOperator(
   if (code === 'cannot_self_revoke') throw new Error('cannot_self_revoke');
 }
 
+export type GrantBillingCompParams = {
+  userId: string;
+  productId: string;
+  planId: string;
+  reason: string;
+  expiresAt?: string | null;
+};
+
+export type RevokeBillingCompParams = {
+  userId: string;
+  productId: string;
+  reason?: string;
+};
+
+function throwIfRpcPayloadError(data: unknown): void {
+  const code = errorCode(data);
+  if (code && code !== 'not_found') throw new Error(code);
+}
+
+export async function grantBillingComp(
+  supabase: SupabaseClient,
+  params: GrantBillingCompParams
+): Promise<void> {
+  const { data, error } = await supabase.rpc('admin_grant_billing_comp', {
+    p_user_id: params.userId,
+    p_product_id: params.productId,
+    p_plan_id: params.planId,
+    p_reason: params.reason,
+    p_expires_at: params.expiresAt ?? null,
+  });
+  if (error) throw rpcError(error);
+  if (isNotFound(data)) throw new Error('not_found');
+  throwIfRpcPayloadError(data);
+}
+
+export async function revokeBillingComp(
+  supabase: SupabaseClient,
+  params: RevokeBillingCompParams
+): Promise<void> {
+  const { data, error } = await supabase.rpc('admin_revoke_billing_comp', {
+    p_user_id: params.userId,
+    p_product_id: params.productId,
+    p_reason: params.reason ?? undefined,
+  });
+  if (error) throw rpcError(error);
+  if (isNotFound(data)) throw new Error('not_found');
+  throwIfRpcPayloadError(data);
+}
+
 export async function recordAuditEvent(
   supabase: SupabaseClient,
   input: RecordAuditEventInput

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -4,8 +4,12 @@ export {
   getUser,
   grantOperator,
   revokeOperator,
+  grantBillingComp,
+  revokeBillingComp,
   recordAuditEvent,
   type ListUsersParams,
+  type GrantBillingCompParams,
+  type RevokeBillingCompParams,
 } from './adminClient.js';
 export { useIsAdmin, type UseIsAdminResult } from './hooks/useIsAdmin.js';
 export type {

--- a/packages/admin/src/types.ts
+++ b/packages/admin/src/types.ts
@@ -33,6 +33,15 @@ export type AdminUserDetail = {
   profile: Record<string, unknown> | null;
   subscription: Record<string, unknown> | null;
   plan: Record<string, unknown> | null;
+  comp_grant?: {
+    id: string;
+    plan_id: string;
+    comped_at: string;
+    comped_by: string;
+    comped_by_email: string | null;
+    comp_reason: string;
+    comp_expires_at: string | null;
+  } | null;
   admin: {
     is_admin: boolean;
     granted_at: string | null;

--- a/packages/articles/package.json
+++ b/packages/articles/package.json
@@ -21,7 +21,7 @@
     "test:coverage": "vitest --coverage --run"
   },
   "dependencies": {
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.12",
     "jsdom": "^26.1.0"
   },
   "peerDependencies": {

--- a/packages/billing/src/components/SubscriptionStatusBadge.native.tsx
+++ b/packages/billing/src/components/SubscriptionStatusBadge.native.tsx
@@ -27,6 +27,10 @@ export function SubscriptionStatusBadge({
 
   if (st === 'free') {
     label = 'Free';
+  } else if (st === 'comped') {
+    label = 'Complimentary';
+    bg = '#E0E7FF';
+    fg = '#3730A3';
   } else if (st === 'past_due') {
     label = 'Payment failed';
     bg = '#FEE2E2';

--- a/packages/billing/src/components/SubscriptionStatusBadge.web.tsx
+++ b/packages/billing/src/components/SubscriptionStatusBadge.web.tsx
@@ -29,6 +29,9 @@ export function SubscriptionStatusBadge({
   if (st === 'free') {
     label = 'Free';
     classes += 'bg-gray-100 text-gray-800';
+  } else if (st === 'comped') {
+    label = 'Complimentary';
+    classes += 'bg-indigo-100 text-indigo-800';
   } else if (st === 'past_due') {
     label = 'Payment failed';
     classes += 'bg-red-100 text-red-800';

--- a/packages/billing/src/hooks/useBillingState.test.tsx
+++ b/packages/billing/src/hooks/useBillingState.test.tsx
@@ -125,6 +125,16 @@ describe('useBillingState', () => {
     expect(result.current.kind).toBe('free');
   });
 
+  it('classifies comped without stripe subscription as comped', () => {
+    hp.subscription = testSubscription({
+      status: 'comped',
+      stripe_subscription_id: null,
+      plan_id: 'beakerstack_vip',
+    });
+    const { result } = renderHook(() => useBillingState());
+    expect(result.current.kind).toBe('comped');
+  });
+
   it('classifies active with stripe as paid_active', () => {
     hp.subscription = testSubscription({
       status: 'active',

--- a/packages/billing/src/hooks/useBillingState.ts
+++ b/packages/billing/src/hooks/useBillingState.ts
@@ -18,7 +18,8 @@ export type BillingUiStateKind =
   | 'payment_failed'
   | 'trialing'
   | 'trial_ending'
-  | 'downgrade_pending';
+  | 'downgrade_pending'
+  | 'comped';
 
 export type BillingUiState = {
   kind: BillingUiStateKind;
@@ -37,6 +38,7 @@ function deriveKind(
 
   const st = subscription.status.toLowerCase();
   if (st === 'free') return 'free';
+  if (st === 'comped') return 'comped';
   if (st === 'past_due') return 'payment_failed';
 
   if (st === 'trialing') {

--- a/packages/billing/src/utils/subscriptionStatusLabel.ts
+++ b/packages/billing/src/utils/subscriptionStatusLabel.ts
@@ -20,5 +20,8 @@ export function subscriptionStatusLabel(
   if (sub.status === 'free') {
     return 'Free';
   }
+  if (sub.status === 'comped') {
+    return 'Complimentary';
+  }
   return sub.status;
 }

--- a/packages/help/package.json
+++ b/packages/help/package.json
@@ -21,7 +21,7 @@
     "test:coverage": "vitest --coverage --run"
   },
   "dependencies": {
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.12",
     "jsdom": "^26.1.0"
   },
   "peerDependencies": {

--- a/packages/waitlist-billing/package.json
+++ b/packages/waitlist-billing/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@beakerstack/waitlist-billing",
+  "version": "1.0.0",
+  "description": "Waitlist conversion billing fulfillment for BeakerStack adopters",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./web": "./src/web.ts",
+    "./edge": "./src/edge.ts"
+  },
+  "scripts": {
+    "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "type-check": "tsc --noEmit",
+    "test": "vitest --run",
+    "test:coverage": "vitest --coverage --run"
+  },
+  "dependencies": {
+    "@beakerstack/waitlist": "^1.0.0",
+    "@supabase/supabase-js": "^2.38.0"
+  },
+  "peerDependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/react": "18.2.0",
+    "@types/react-dom": "18.2.0",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "@vitest/coverage-v8": "^4.1.8",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "jsdom": "^26.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "typescript": "^5.3.0",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/waitlist-billing/src/WaitlistVipInviteFields.web.tsx
+++ b/packages/waitlist-billing/src/WaitlistVipInviteFields.web.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import {
+  buildCompProvisioningIntent,
+  parseStoredProvisioningIntent,
+  type WaitlistProvisioningIntentInput,
+} from './provisioningHelpers.js';
+
+export type WaitlistVipInviteFieldsProps = {
+  defaultCompPlanId: string;
+  initialMetadata?: Record<string, unknown> | null;
+  disabled?: boolean;
+  onChange: (intent: WaitlistProvisioningIntentInput | null) => void;
+  onVipEnabledChange?: (enabled: boolean) => void;
+};
+
+export function WaitlistVipInviteFields({
+  defaultCompPlanId,
+  initialMetadata,
+  disabled = false,
+  onChange,
+  onVipEnabledChange,
+}: WaitlistVipInviteFieldsProps) {
+  const stored = parseStoredProvisioningIntent(initialMetadata ?? undefined);
+  const storedComp = stored?.kind === 'billing_comp' ? stored : null;
+
+  const [vipEnabled, setVipEnabled] = useState(Boolean(storedComp));
+  const [reason, setReason] = useState(storedComp?.reason ?? '');
+
+  const emitChange = (enabled: boolean, nextReason: string) => {
+    if (!enabled) {
+      onChange(null);
+      return;
+    }
+    const trimmed = nextReason.trim();
+    if (!trimmed) {
+      onChange(null);
+      return;
+    }
+    onChange(buildCompProvisioningIntent(defaultCompPlanId, trimmed));
+  };
+
+  const toggleVip = (checked: boolean) => {
+    setVipEnabled(checked);
+    onVipEnabledChange?.(checked);
+    const nextReason = checked ? reason : '';
+    if (!checked) {
+      setReason('');
+    }
+    emitChange(checked, nextReason);
+  };
+
+  const updateReason = (nextReason: string) => {
+    setReason(nextReason);
+    emitChange(vipEnabled, nextReason);
+  };
+
+  return (
+    <div className='space-y-3 rounded-md border border-indigo-100 bg-indigo-50/40 p-3'>
+      <label className='flex items-start gap-2'>
+        <input
+          type='checkbox'
+          className='mt-0.5 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500'
+          checked={vipEnabled}
+          disabled={disabled}
+          onChange={e => toggleVip(e.target.checked)}
+        />
+        <span>
+          <span className='block text-sm font-medium text-gray-900'>
+            Grant complimentary VIP on signup
+          </span>
+          <span className='block text-xs text-gray-600'>
+            Applies Max-equivalent comp access when they complete signup.
+          </span>
+        </span>
+      </label>
+
+      {vipEnabled ? (
+        <label className='block'>
+          <span className='text-sm font-medium text-gray-700'>
+            Reason (required)
+          </span>
+          <textarea
+            className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 disabled:opacity-50'
+            rows={2}
+            maxLength={500}
+            value={reason}
+            disabled={disabled}
+            placeholder='Design partner, founder friend, etc.'
+            onChange={e => updateReason(e.target.value)}
+          />
+        </label>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/waitlist-billing/src/__tests__/WaitlistVipInviteFields.test.tsx
+++ b/packages/waitlist-billing/src/__tests__/WaitlistVipInviteFields.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WaitlistVipInviteFields } from '../WaitlistVipInviteFields.web.js';
+
+describe('WaitlistVipInviteFields', () => {
+  it('emits null when VIP is unchecked', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <WaitlistVipInviteFields
+        defaultCompPlanId='beakerstack_vip'
+        onChange={onChange}
+      />
+    );
+
+    await user.click(
+      screen.getByRole('checkbox', { name: /grant complimentary vip/i })
+    );
+    await user.click(
+      screen.getByRole('checkbox', { name: /grant complimentary vip/i })
+    );
+
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('emits comp intent when reason is provided', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <WaitlistVipInviteFields
+        defaultCompPlanId='beakerstack_vip'
+        onChange={onChange}
+      />
+    );
+
+    await user.click(
+      screen.getByRole('checkbox', { name: /grant complimentary vip/i })
+    );
+    await user.type(screen.getByLabelText(/reason/i), 'Design partner');
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      kind: 'billing_comp',
+      planId: 'beakerstack_vip',
+      reason: 'Design partner',
+    });
+  });
+
+  it('hydrates from stored metadata', () => {
+    render(
+      <WaitlistVipInviteFields
+        defaultCompPlanId='beakerstack_vip'
+        initialMetadata={{
+          provisioning_intent: {
+            kind: 'billing_comp',
+            planId: 'beakerstack_vip',
+            reason: 'Existing',
+            grantedBy: 'admin',
+          },
+        }}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('checkbox', { name: /grant complimentary vip/i })
+    ).toBeChecked();
+    expect(screen.getByLabelText(/reason/i)).toHaveValue('Existing');
+  });
+});

--- a/packages/waitlist-billing/src/__tests__/provisioningHelpers.test.ts
+++ b/packages/waitlist-billing/src/__tests__/provisioningHelpers.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCompProvisioningIntent,
+  parseStoredProvisioningIntent,
+} from '../provisioningHelpers.js';
+
+describe('waitlist-billing provisioning helpers', () => {
+  it('builds comp intent input', () => {
+    expect(
+      buildCompProvisioningIntent('beakerstack_vip', '  Partner  ')
+    ).toEqual({
+      kind: 'billing_comp',
+      planId: 'beakerstack_vip',
+      reason: 'Partner',
+    });
+  });
+
+  it('re-exports parseStoredProvisioningIntent', () => {
+    expect(
+      parseStoredProvisioningIntent({
+        provisioning_intent: {
+          kind: 'billing_plan',
+          planId: 'skein_free',
+        },
+      })
+    ).toEqual({ kind: 'billing_plan', planId: 'skein_free' });
+  });
+});

--- a/packages/waitlist-billing/src/edge.ts
+++ b/packages/waitlist-billing/src/edge.ts
@@ -1,0 +1,5 @@
+export { fulfillWaitlistConversion } from './fulfillConversion.js';
+export type {
+  FulfillWaitlistConversionResult,
+  WaitlistBillingConfig,
+} from './types.js';

--- a/packages/waitlist-billing/src/fulfillConversion.ts
+++ b/packages/waitlist-billing/src/fulfillConversion.ts
@@ -1,0 +1,23 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  FulfillWaitlistConversionResult,
+  WaitlistBillingConfig,
+} from './types.js';
+
+export async function fulfillWaitlistConversion(
+  adminClient: SupabaseClient,
+  config: WaitlistBillingConfig,
+  ctx: { userId: string; entryId: string }
+): Promise<FulfillWaitlistConversionResult> {
+  const { data, error } = await adminClient.rpc(
+    'waitlist_billing_fulfill_conversion',
+    {
+      p_user_id: ctx.userId,
+      p_entry_id: ctx.entryId,
+      p_product_id: config.productId,
+      p_allowed_comp_plan_ids: [...config.compPlanIds],
+    }
+  );
+  if (error) return { error: error.message };
+  return data as FulfillWaitlistConversionResult;
+}

--- a/packages/waitlist-billing/src/index.ts
+++ b/packages/waitlist-billing/src/index.ts
@@ -1,0 +1,21 @@
+export type {
+  WaitlistBillingConfig,
+  FulfillWaitlistConversionResult,
+} from './types.js';
+export {
+  parseStoredProvisioningIntent as parseProvisioningIntent,
+  buildCompProvisioningIntent,
+  toRpcProvisioningIntent,
+} from './provisioningHelpers.js';
+export {
+  setWaitlistEntryProvisioningIntent,
+  inviteWaitlistEmailWithIntent,
+  approveWaitlistEntryWithIntent,
+} from './waitlistBillingClient.js';
+export { fulfillWaitlistConversion } from './fulfillConversion.js';
+export type {
+  WaitlistCompIntentInput,
+  WaitlistPlanIntentInput,
+  WaitlistProvisioningIntent,
+  WaitlistProvisioningIntentInput,
+} from '@beakerstack/waitlist';

--- a/packages/waitlist-billing/src/provisioningHelpers.ts
+++ b/packages/waitlist-billing/src/provisioningHelpers.ts
@@ -1,0 +1,21 @@
+import {
+  parseStoredProvisioningIntent,
+  toRpcProvisioningIntent,
+  type WaitlistCompIntentInput,
+  type WaitlistProvisioningIntentInput,
+} from '@beakerstack/waitlist';
+
+export { parseStoredProvisioningIntent, toRpcProvisioningIntent };
+
+export function buildCompProvisioningIntent(
+  planId: string,
+  reason: string
+): WaitlistCompIntentInput {
+  return {
+    kind: 'billing_comp',
+    planId,
+    reason: reason.trim(),
+  };
+}
+
+export type { WaitlistProvisioningIntentInput };

--- a/packages/waitlist-billing/src/types.ts
+++ b/packages/waitlist-billing/src/types.ts
@@ -1,0 +1,13 @@
+export type WaitlistBillingConfig = {
+  productId: string;
+  compPlanIds: readonly string[];
+  defaultCompPlanId?: string;
+};
+
+export type FulfillWaitlistConversionResult = {
+  ok?: boolean;
+  error?: string;
+  comp_applied?: boolean;
+  plan_applied?: boolean;
+  unchanged?: boolean;
+};

--- a/packages/waitlist-billing/src/waitlistBillingClient.ts
+++ b/packages/waitlist-billing/src/waitlistBillingClient.ts
@@ -1,0 +1,66 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  approveWaitlistEntry,
+  inviteWaitlistEmail,
+  toRpcProvisioningIntent,
+  type WaitlistProvisioningIntentInput,
+} from '@beakerstack/waitlist';
+import type { WaitlistBillingConfig } from './types.js';
+
+function compPlanIdsArray(config: WaitlistBillingConfig): string[] {
+  return [...config.compPlanIds];
+}
+
+export async function inviteWaitlistEmailWithIntent(
+  supabase: SupabaseClient,
+  config: WaitlistBillingConfig,
+  email: string,
+  options: {
+    metadata?: Record<string, unknown>;
+    provisioningIntent?: WaitlistProvisioningIntentInput | null;
+  } = {}
+) {
+  return inviteWaitlistEmail(supabase, email, {
+    metadata: options.metadata,
+    provisioningIntent: options.provisioningIntent,
+    allowedCompPlanIds: compPlanIdsArray(config),
+  });
+}
+
+export async function approveWaitlistEntryWithIntent(
+  supabase: SupabaseClient,
+  config: WaitlistBillingConfig,
+  entryId: string,
+  provisioningIntent?: WaitlistProvisioningIntentInput | null
+) {
+  return approveWaitlistEntry(supabase, entryId, {
+    provisioningIntent,
+    allowedCompPlanIds: compPlanIdsArray(config),
+  });
+}
+
+export async function setWaitlistEntryProvisioningIntent(
+  supabase: SupabaseClient,
+  config: WaitlistBillingConfig,
+  entryId: string,
+  provisioningIntent: WaitlistProvisioningIntentInput | null
+): Promise<{
+  ok?: boolean;
+  error?: string;
+  provisioning_intent?: unknown;
+} | null> {
+  const { data, error } = await supabase.rpc(
+    'admin_set_waitlist_entry_provisioning_intent',
+    {
+      p_entry_id: entryId,
+      p_provisioning_intent: toRpcProvisioningIntent(provisioningIntent),
+      p_allowed_comp_plan_ids: compPlanIdsArray(config),
+    }
+  );
+  if (error) return { error: error.message };
+  return data as {
+    ok?: boolean;
+    error?: string;
+    provisioning_intent?: unknown;
+  };
+}

--- a/packages/waitlist-billing/src/web.ts
+++ b/packages/waitlist-billing/src/web.ts
@@ -1,0 +1,22 @@
+export {
+  parseStoredProvisioningIntent,
+  buildCompProvisioningIntent,
+  toRpcProvisioningIntent,
+} from './provisioningHelpers.js';
+export {
+  setWaitlistEntryProvisioningIntent,
+  inviteWaitlistEmailWithIntent,
+  approveWaitlistEntryWithIntent,
+} from './waitlistBillingClient.js';
+export { fulfillWaitlistConversion } from './fulfillConversion.js';
+export { WaitlistVipInviteFields } from './WaitlistVipInviteFields.web.js';
+export type {
+  WaitlistBillingConfig,
+  FulfillWaitlistConversionResult,
+} from './types.js';
+export type {
+  WaitlistCompIntentInput,
+  WaitlistPlanIntentInput,
+  WaitlistProvisioningIntent,
+  WaitlistProvisioningIntentInput,
+} from '@beakerstack/waitlist';

--- a/packages/waitlist-billing/tsconfig.json
+++ b/packages/waitlist-billing/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true
+  },
+  "include": ["src"]
+}

--- a/packages/waitlist-billing/tsup.config.edge.ts
+++ b/packages/waitlist-billing/tsup.config.edge.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/edge.ts'],
+  format: ['esm'],
+  dts: true,
+  bundle: true,
+  splitting: false,
+  clean: true,
+  outDir: 'dist',
+  external: ['@supabase/supabase-js'],
+});

--- a/packages/waitlist-billing/vitest.config.ts
+++ b/packages/waitlist-billing/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+  },
+});

--- a/packages/waitlist-billing/vitest.setup.ts
+++ b/packages/waitlist-billing/vitest.setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/waitlist/src/index.ts
+++ b/packages/waitlist/src/index.ts
@@ -17,8 +17,20 @@ export {
   rejectWaitlistEntry,
   resendWaitlistInvite,
   inviteWaitlistEmail,
+  normalizeInviteWaitlistEmailOptions,
+  setWaitlistEntryProvisioningIntent,
   buildInviteUrl,
+  type InviteWaitlistEmailOptions,
 } from './waitlistClient.js';
+export {
+  parseStoredProvisioningIntent,
+  toRpcProvisioningIntent,
+  isWaitlistCompIntentInput,
+  type WaitlistCompIntentInput,
+  type WaitlistPlanIntentInput,
+  type WaitlistProvisioningIntent,
+  type WaitlistProvisioningIntentInput,
+} from './provisioning.js';
 export {
   useSignupMode,
   type UseSignupModeResult,

--- a/packages/waitlist/src/provisioning.test.ts
+++ b/packages/waitlist/src/provisioning.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isWaitlistCompIntentInput,
+  parseStoredProvisioningIntent,
+  toRpcProvisioningIntent,
+} from './provisioning.js';
+
+describe('provisioning', () => {
+  it('parses stored billing_comp intent', () => {
+    expect(
+      parseStoredProvisioningIntent({
+        provisioning_intent: {
+          kind: 'billing_comp',
+          planId: 'beakerstack_vip',
+          reason: 'Design partner',
+          grantedBy: 'admin-uuid',
+        },
+      })
+    ).toEqual({
+      kind: 'billing_comp',
+      planId: 'beakerstack_vip',
+      reason: 'Design partner',
+      grantedBy: 'admin-uuid',
+    });
+  });
+
+  it('serializes admin comp input without grantedBy', () => {
+    expect(
+      toRpcProvisioningIntent({
+        kind: 'billing_comp',
+        planId: 'beakerstack_vip',
+        reason: '  Founder friend  ',
+      })
+    ).toEqual({
+      kind: 'billing_comp',
+      planId: 'beakerstack_vip',
+      reason: 'Founder friend',
+    });
+  });
+
+  it('returns null RPC payload when clearing intent', () => {
+    expect(toRpcProvisioningIntent(null)).toBeNull();
+  });
+
+  it('serializes billing_plan intent', () => {
+    expect(
+      toRpcProvisioningIntent({
+        kind: 'billing_plan',
+        planId: 'beakerstack_free',
+      })
+    ).toEqual({ kind: 'billing_plan', planId: 'beakerstack_free' });
+  });
+
+  it('returns null for invalid stored metadata', () => {
+    expect(parseStoredProvisioningIntent(null)).toBeNull();
+    expect(parseStoredProvisioningIntent({})).toBeNull();
+    expect(
+      parseStoredProvisioningIntent({ provisioning_intent: { kind: 'bad' } })
+    ).toBeNull();
+    expect(
+      parseStoredProvisioningIntent({
+        provisioning_intent: { kind: 'billing_comp', planId: 'x', reason: '' },
+      })
+    ).toBeNull();
+  });
+
+  it('parses billing_plan and nullable grantedBy', () => {
+    expect(
+      parseStoredProvisioningIntent({
+        provisioning_intent: {
+          kind: 'billing_plan',
+          planId: 'beakerstack_free',
+        },
+      })
+    ).toEqual({ kind: 'billing_plan', planId: 'beakerstack_free' });
+    expect(
+      parseStoredProvisioningIntent({
+        provisioning_intent: {
+          kind: 'billing_comp',
+          planId: 'beakerstack_vip',
+          reason: 'x',
+          grantedBy: '',
+        },
+      })?.kind
+    ).toBe('billing_comp');
+  });
+
+  it('identifies comp intent input', () => {
+    expect(
+      isWaitlistCompIntentInput({
+        kind: 'billing_comp',
+        planId: 'beakerstack_vip',
+        reason: 'x',
+      })
+    ).toBe(true);
+    expect(
+      isWaitlistCompIntentInput({
+        kind: 'billing_plan',
+        planId: 'beakerstack_free',
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/waitlist/src/provisioning.ts
+++ b/packages/waitlist/src/provisioning.ts
@@ -1,0 +1,74 @@
+/** Admin/client input — no grantedBy (server sets it on store). */
+export type WaitlistCompIntentInput = {
+  kind: 'billing_comp';
+  planId: string;
+  reason: string;
+};
+
+export type WaitlistPlanIntentInput = {
+  kind: 'billing_plan';
+  planId: string;
+};
+
+export type WaitlistProvisioningIntentInput =
+  | WaitlistCompIntentInput
+  | WaitlistPlanIntentInput;
+
+/** Stored on entry metadata after admin RPC. */
+export type WaitlistProvisioningIntent =
+  | {
+      kind: 'billing_comp';
+      planId: string;
+      reason: string;
+      grantedBy: string | null;
+    }
+  | { kind: 'billing_plan'; planId: string };
+
+export function isWaitlistCompIntentInput(
+  intent: WaitlistProvisioningIntentInput
+): intent is WaitlistCompIntentInput {
+  return intent.kind === 'billing_comp';
+}
+
+export function parseStoredProvisioningIntent(
+  metadata: Record<string, unknown> | null | undefined
+): WaitlistProvisioningIntent | null {
+  if (!metadata || typeof metadata !== 'object') return null;
+  const raw = metadata['provisioning_intent'];
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+
+  const kind = (raw as { kind?: unknown }).kind;
+  const planId = (raw as { planId?: unknown }).planId;
+  if (kind !== 'billing_comp' && kind !== 'billing_plan') return null;
+  if (typeof planId !== 'string' || planId.length === 0) return null;
+
+  if (kind === 'billing_plan') {
+    return { kind: 'billing_plan', planId };
+  }
+
+  const reason = (raw as { reason?: unknown }).reason;
+  const grantedBy = (raw as { grantedBy?: unknown }).grantedBy;
+  if (typeof reason !== 'string' || reason.trim().length === 0) return null;
+
+  return {
+    kind: 'billing_comp',
+    planId,
+    reason,
+    grantedBy:
+      typeof grantedBy === 'string' && grantedBy.length > 0 ? grantedBy : null,
+  };
+}
+
+export function toRpcProvisioningIntent(
+  intent: WaitlistProvisioningIntentInput | null
+): Record<string, unknown> | null {
+  if (!intent) return null;
+  if (intent.kind === 'billing_comp') {
+    return {
+      kind: 'billing_comp',
+      planId: intent.planId,
+      reason: intent.reason.trim(),
+    };
+  }
+  return { kind: 'billing_plan', planId: intent.planId };
+}

--- a/packages/waitlist/src/waitlistClient.test.ts
+++ b/packages/waitlist/src/waitlistClient.test.ts
@@ -12,6 +12,7 @@ import {
   listWaitlistEntries,
   rejectWaitlistEntry,
   resendWaitlistInvite,
+  setWaitlistEntryProvisioningIntent,
   updateAdminWaitlistSettings,
   validateInvite,
 } from './waitlistClient.js';
@@ -391,6 +392,9 @@ describe('waitlistClient', () => {
       expect(args).toEqual({
         p_email: 'new@example.com',
         p_metadata: { note: 'vip' },
+        p_provisioning_intent: null,
+        p_update_provisioning_intent: false,
+        p_allowed_comp_plan_ids: null,
       });
       return {
         data: {
@@ -404,7 +408,9 @@ describe('waitlistClient', () => {
       };
     });
     expect(
-      await inviteWaitlistEmail(ok, 'new@example.com', { note: 'vip' })
+      await inviteWaitlistEmail(ok, 'new@example.com', {
+        metadata: { note: 'vip' },
+      })
     ).toEqual({
       ok: true,
       invite_token: 'tok',
@@ -433,12 +439,71 @@ describe('waitlistClient', () => {
       expect(args).toEqual({
         p_email: 'x@y.com',
         p_metadata: {},
+        p_provisioning_intent: null,
+        p_update_provisioning_intent: false,
+        p_allowed_comp_plan_ids: null,
       });
       return { data: { ok: true }, error: null };
     });
     expect(await inviteWaitlistEmail(defaultMeta, 'x@y.com')).toEqual({
       ok: true,
     });
+  });
+
+  it('inviteWaitlistEmail accepts legacy bare metadata object', async () => {
+    const legacy = createSupabase((name, args) => {
+      expect(name).toBe('admin_invite_waitlist_email');
+      expect(args).toEqual({
+        p_email: 'legacy@example.com',
+        p_metadata: { note: 'vip' },
+        p_provisioning_intent: null,
+        p_update_provisioning_intent: false,
+        p_allowed_comp_plan_ids: null,
+      });
+      return { data: { ok: true }, error: null };
+    });
+    expect(
+      await inviteWaitlistEmail(legacy, 'legacy@example.com', { note: 'vip' })
+    ).toEqual({ ok: true });
+  });
+
+  it('approveWaitlistEntry forwards provisioning intent options', async () => {
+    const client = createSupabase((name, args) => {
+      expect(name).toBe('admin_approve_waitlist_entry');
+      expect(args).toEqual({
+        p_id: 'e1',
+        p_provisioning_intent: {
+          kind: 'billing_comp',
+          planId: 'beakerstack_vip',
+          reason: 'Partner',
+        },
+        p_update_provisioning_intent: true,
+        p_allowed_comp_plan_ids: ['beakerstack_vip'],
+      });
+      return { data: { ok: true }, error: null };
+    });
+    expect(
+      await approveWaitlistEntry(client, 'e1', {
+        provisioningIntent: {
+          kind: 'billing_comp',
+          planId: 'beakerstack_vip',
+          reason: 'Partner',
+        },
+        allowedCompPlanIds: ['beakerstack_vip'],
+      })
+    ).toEqual({ ok: true });
+  });
+
+  it('setWaitlistEntryProvisioningIntent maps rpc results', async () => {
+    const ok = createSupabase(() => ({
+      data: { ok: true, provisioning_intent: { kind: 'billing_comp' } },
+      error: null,
+    }));
+    expect(
+      await setWaitlistEntryProvisioningIntent(ok, 'e1', null, [
+        'beakerstack_vip',
+      ])
+    ).toEqual({ ok: true, provisioning_intent: { kind: 'billing_comp' } });
   });
 
   it('buildInviteUrl strips trailing slash and encodes token', () => {

--- a/packages/waitlist/src/waitlistClient.ts
+++ b/packages/waitlist/src/waitlistClient.ts
@@ -8,6 +8,35 @@ import type {
   WaitlistMetadataField,
   WaitlistPublicSettings,
 } from './types.js';
+import {
+  toRpcProvisioningIntent,
+  type WaitlistProvisioningIntentInput,
+} from './provisioning.js';
+
+export type InviteWaitlistEmailOptions = {
+  metadata?: Record<string, unknown>;
+  provisioningIntent?: WaitlistProvisioningIntentInput | null;
+  allowedCompPlanIds?: string[];
+};
+
+function isInviteWaitlistEmailOptions(
+  value: Record<string, unknown>
+): value is InviteWaitlistEmailOptions {
+  return (
+    'metadata' in value ||
+    'provisioningIntent' in value ||
+    'allowedCompPlanIds' in value
+  );
+}
+
+/** Supports legacy callers that passed a bare metadata object as the third arg. */
+export function normalizeInviteWaitlistEmailOptions(
+  options?: InviteWaitlistEmailOptions | Record<string, unknown>
+): InviteWaitlistEmailOptions {
+  if (!options) return {};
+  if (isInviteWaitlistEmailOptions(options)) return options;
+  return { metadata: options };
+}
 
 export const DEFAULT_WAITLIST_ADMIN_SETTINGS: WaitlistAdminSettings = {
   signup_mode: 'open',
@@ -89,14 +118,28 @@ export async function consumeInvite(
   token: string,
   userId: string,
   userEmail?: string | null
-): Promise<{ ok?: boolean; error?: string; default_plan_id?: string }> {
+): Promise<{
+  ok?: boolean;
+  error?: string;
+  already_converted?: boolean;
+  entry_id?: string;
+  default_plan_id?: string;
+  provisioning_intent?: unknown;
+}> {
   const { data, error } = await supabase.rpc('waitlist_consume_invite', {
     p_token: token,
     p_user_id: userId,
     p_user_email: userEmail ?? null,
   });
   if (error) return { error: error.message };
-  return data as { ok?: boolean; error?: string; default_plan_id?: string };
+  return data as {
+    ok?: boolean;
+    error?: string;
+    already_converted?: boolean;
+    entry_id?: string;
+    default_plan_id?: string;
+    provisioning_intent?: unknown;
+  };
 }
 
 export async function listWaitlistEntries(
@@ -173,15 +216,25 @@ export async function updateAdminWaitlistSettings(
 
 export async function approveWaitlistEntry(
   supabase: SupabaseClient,
-  id: string
+  id: string,
+  options: {
+    provisioningIntent?: WaitlistProvisioningIntentInput | null;
+    allowedCompPlanIds?: string[];
+  } = {}
 ): Promise<{
   ok?: boolean;
   invite_token?: string;
   email?: string;
   error?: string;
 } | null> {
+  const updateIntent = options.provisioningIntent !== undefined;
   const { data, error } = await supabase.rpc('admin_approve_waitlist_entry', {
     p_id: id,
+    p_provisioning_intent: updateIntent
+      ? toRpcProvisioningIntent(options.provisioningIntent ?? null)
+      : null,
+    p_update_provisioning_intent: updateIntent,
+    p_allowed_comp_plan_ids: options.allowedCompPlanIds ?? null,
   });
   if (error) return { error: error.message };
   if ((data as { error?: string })?.error) return data as { error: string };
@@ -223,7 +276,7 @@ export async function resendWaitlistInvite(
 export async function inviteWaitlistEmail(
   supabase: SupabaseClient,
   email: string,
-  metadata?: Record<string, unknown>
+  options?: InviteWaitlistEmailOptions | Record<string, unknown>
 ): Promise<{
   ok?: boolean;
   entry_id?: string;
@@ -232,9 +285,16 @@ export async function inviteWaitlistEmail(
   created?: boolean;
   error?: string;
 } | null> {
+  const normalized = normalizeInviteWaitlistEmailOptions(options);
+  const updateIntent = normalized.provisioningIntent !== undefined;
   const { data, error } = await supabase.rpc('admin_invite_waitlist_email', {
     p_email: email,
-    p_metadata: metadata ?? {},
+    p_metadata: normalized.metadata ?? {},
+    p_provisioning_intent: updateIntent
+      ? toRpcProvisioningIntent(normalized.provisioningIntent ?? null)
+      : null,
+    p_update_provisioning_intent: updateIntent,
+    p_allowed_comp_plan_ids: normalized.allowedCompPlanIds ?? null,
   });
   if (error) return { error: error.message };
   if ((data as { error?: string })?.error) return data as { error: string };
@@ -244,6 +304,32 @@ export async function inviteWaitlistEmail(
     invite_token?: string;
     email?: string;
     created?: boolean;
+  };
+}
+
+export async function setWaitlistEntryProvisioningIntent(
+  supabase: SupabaseClient,
+  entryId: string,
+  provisioningIntent: WaitlistProvisioningIntentInput | null,
+  allowedCompPlanIds?: string[]
+): Promise<{
+  ok?: boolean;
+  error?: string;
+  provisioning_intent?: unknown;
+} | null> {
+  const { data, error } = await supabase.rpc(
+    'admin_set_waitlist_entry_provisioning_intent',
+    {
+      p_entry_id: entryId,
+      p_provisioning_intent: toRpcProvisioningIntent(provisioningIntent),
+      p_allowed_comp_plan_ids: allowedCompPlanIds ?? null,
+    }
+  );
+  if (error) return { error: error.message };
+  return data as {
+    ok?: boolean;
+    error?: string;
+    provisioning_intent?: unknown;
   };
 }
 

--- a/scripts/admin-waitlist-invite.mjs
+++ b/scripts/admin-waitlist-invite.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Admin CLI: invite a waitlist email (optional VIP comp on signup).
+ *
+ * Usage:
+ *   SUPABASE_URL=... SUPABASE_ANON_KEY=... BEAKERSTACK_ADMIN_EMAIL=... BEAKERSTACK_ADMIN_PASSWORD=... \
+ *     npm run admin:invite -- --email user@example.com [--vip] [--reason "Design partner"]
+ */
+import { createClient } from '@supabase/supabase-js';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+  options: {
+    email: { type: 'string' },
+    vip: { type: 'boolean', default: false },
+    reason: { type: 'string' },
+  },
+  strict: true,
+  allowPositionals: false,
+});
+
+const url = process.env.SUPABASE_URL;
+const anonKey = process.env.SUPABASE_ANON_KEY;
+const adminEmail = process.env.BEAKERSTACK_ADMIN_EMAIL;
+const adminPassword = process.env.BEAKERSTACK_ADMIN_PASSWORD;
+const compPlanIds = (process.env.WAITLIST_COMP_PLAN_IDS ?? 'beakerstack_vip')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean);
+
+if (!url || !anonKey || !adminEmail || !adminPassword) {
+  console.error(
+    'Required: SUPABASE_URL, SUPABASE_ANON_KEY, BEAKERSTACK_ADMIN_EMAIL, BEAKERSTACK_ADMIN_PASSWORD'
+  );
+  process.exit(1);
+}
+
+const email = values.email?.trim().toLowerCase();
+if (!email) {
+  console.error('--email is required');
+  process.exit(1);
+}
+
+if (values.vip && !values.reason?.trim()) {
+  console.error('--reason is required when --vip is set');
+  process.exit(1);
+}
+
+const supabase = createClient(url, anonKey);
+const { error: signInErr } = await supabase.auth.signInWithPassword({
+  email: adminEmail,
+  password: adminPassword,
+});
+if (signInErr) {
+  console.error('Admin sign-in failed:', signInErr.message);
+  process.exit(1);
+}
+
+const provisioningIntent = values.vip
+  ? {
+      kind: 'billing_comp',
+      planId: compPlanIds[0] ?? 'beakerstack_vip',
+      reason: values.reason.trim(),
+    }
+  : null;
+
+const { data, error } = await supabase.rpc('admin_invite_waitlist_email', {
+  p_email: email,
+  p_metadata: {},
+  p_provisioning_intent: provisioningIntent,
+  p_update_provisioning_intent: values.vip,
+  p_allowed_comp_plan_ids: compPlanIds,
+});
+
+if (error || data?.error) {
+  console.error('Invite failed:', error?.message ?? data?.error);
+  process.exit(1);
+}
+
+console.log(JSON.stringify(data, null, 2));

--- a/scripts/admin-waitlist-vip.mjs
+++ b/scripts/admin-waitlist-vip.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Admin CLI: set/clear VIP provisioning intent on a pending or approved waitlist entry.
+ *
+ * Usage:
+ *   npm run admin:waitlist-vip -- --entry-id <uuid> [--vip] [--reason "Design partner"]
+ *   npm run admin:waitlist-vip -- --entry-id <uuid> --clear
+ */
+import { createClient } from '@supabase/supabase-js';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+  options: {
+    'entry-id': { type: 'string' },
+    vip: { type: 'boolean', default: false },
+    reason: { type: 'string' },
+    clear: { type: 'boolean', default: false },
+  },
+  strict: true,
+  allowPositionals: false,
+});
+
+const url = process.env.SUPABASE_URL;
+const anonKey = process.env.SUPABASE_ANON_KEY;
+const adminEmail = process.env.BEAKERSTACK_ADMIN_EMAIL;
+const adminPassword = process.env.BEAKERSTACK_ADMIN_PASSWORD;
+const compPlanIds = (process.env.WAITLIST_COMP_PLAN_IDS ?? 'beakerstack_vip')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean);
+
+if (!url || !anonKey || !adminEmail || !adminPassword) {
+  console.error(
+    'Required: SUPABASE_URL, SUPABASE_ANON_KEY, BEAKERSTACK_ADMIN_EMAIL, BEAKERSTACK_ADMIN_PASSWORD'
+  );
+  process.exit(1);
+}
+
+const entryId = values['entry-id']?.trim();
+if (!entryId) {
+  console.error('--entry-id is required');
+  process.exit(1);
+}
+
+if (values.clear && values.vip) {
+  console.error('Use either --clear or --vip, not both');
+  process.exit(1);
+}
+
+if (values.vip && !values.reason?.trim()) {
+  console.error('--reason is required when --vip is set');
+  process.exit(1);
+}
+
+if (!values.clear && !values.vip) {
+  console.error('Pass --vip with --reason, or --clear');
+  process.exit(1);
+}
+
+const supabase = createClient(url, anonKey);
+const { error: signInErr } = await supabase.auth.signInWithPassword({
+  email: adminEmail,
+  password: adminPassword,
+});
+if (signInErr) {
+  console.error('Admin sign-in failed:', signInErr.message);
+  process.exit(1);
+}
+
+const provisioningIntent = values.clear
+  ? null
+  : {
+      kind: 'billing_comp',
+      planId: compPlanIds[0] ?? 'beakerstack_vip',
+      reason: values.reason.trim(),
+    };
+
+const { data, error } = await supabase.rpc(
+  'admin_set_waitlist_entry_provisioning_intent',
+  {
+    p_entry_id: entryId,
+    p_provisioning_intent: provisioningIntent,
+    p_allowed_comp_plan_ids: compPlanIds,
+  }
+);
+
+if (error || data?.error) {
+  console.error('Set intent failed:', error?.message ?? data?.error);
+  process.exit(1);
+}
+
+console.log(JSON.stringify(data, null, 2));

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -5,6 +5,7 @@
     "@beakerstack/observability/edge": "./_shared/_generated/observability/edge.js",
     "@beakerstack/lifecycle-events": "./_shared/_generated/lifecycle-events/index.js",
     "@beakerstack/marketing-email/kit": "./_shared/_generated/marketing-email-kit/edge.js",
-    "@beakerstack/marketing-email/edge": "./_shared/_generated/marketing-email-edge/edge.js"
+    "@beakerstack/marketing-email/edge": "./_shared/_generated/marketing-email-edge/edge.js",
+    "@beakerstack/waitlist-billing/edge": "./_shared/_generated/waitlist-billing/edge.js"
   }
 }

--- a/supabase/functions/edge-shared.manifest.json
+++ b/supabase/functions/edge-shared.manifest.json
@@ -16,9 +16,7 @@
       "tsupConfig": "tsup.config.ts",
       "outDir": "supabase/functions/_shared/_generated/email",
       "npmName": "@beakerstack/email",
-      "dependsOn": [
-        "logger"
-      ]
+      "dependsOn": ["logger"]
     },
     {
       "id": "observability-edge",
@@ -27,9 +25,7 @@
       "tsupConfig": "tsup.config.edge.ts",
       "outDir": "supabase/functions/_shared/_generated/observability",
       "npmName": "@beakerstack/observability/edge",
-      "dependsOn": [
-        "logger"
-      ]
+      "dependsOn": ["logger"]
     },
     {
       "id": "lifecycle-events",
@@ -38,9 +34,7 @@
       "tsupConfig": "tsup.config.ts",
       "outDir": "supabase/functions/_shared/_generated/lifecycle-events",
       "npmName": "@beakerstack/lifecycle-events",
-      "dependsOn": [
-        "logger"
-      ]
+      "dependsOn": ["logger"]
     },
     {
       "id": "marketing-email-kit",
@@ -58,10 +52,16 @@
       "tsupConfig": "tsup.config.marketing-edge.ts",
       "outDir": "supabase/functions/_shared/_generated/marketing-email-edge",
       "npmName": "@beakerstack/marketing-email/edge",
-      "dependsOn": [
-        "logger",
-        "lifecycle-events"
-      ]
+      "dependsOn": ["logger", "lifecycle-events"]
+    },
+    {
+      "id": "waitlist-billing-edge",
+      "package": "packages/waitlist-billing",
+      "entry": "src/edge.ts",
+      "tsupConfig": "tsup.config.edge.ts",
+      "outDir": "supabase/functions/_shared/_generated/waitlist-billing",
+      "npmName": "@beakerstack/waitlist-billing/edge",
+      "dependsOn": []
     }
   ]
 }

--- a/supabase/functions/waitlist-ops/index.ts
+++ b/supabase/functions/waitlist-ops/index.ts
@@ -4,6 +4,7 @@ import {
   jsonResponse,
 } from '../_shared/waitlist-origins.ts';
 import { enqueueMarketingEmail } from '@beakerstack/marketing-email/edge';
+import { fulfillWaitlistConversion } from '@beakerstack/waitlist-billing/edge';
 import {
   createLogEmailAdapter,
   createResendEmailAdapter,
@@ -150,33 +151,98 @@ Deno.serve(async req => {
       ok?: boolean;
       error?: string;
       already_converted?: boolean;
+      entry_id?: string;
       default_plan_id?: string;
+      provisioning_intent?: unknown;
     };
     if (consumeResult?.error) {
       return jsonResponse({ error: consumeResult.error }, 400, req);
     }
 
-    if (consumeResult.ok && !consumeResult.already_converted) {
-      if (consumeResult.default_plan_id) {
-        // Billing productId may be caller-supplied (admin choosing product for billing).
-        const billingProductId =
-          body.productId?.trim() ||
-          Deno.env.get('WAITLIST_PRODUCT_ID') ||
-          'beakerstack';
-        const { error: planErr } = await admin.rpc(
-          'billing_ensure_subscription_plan',
-          {
-            p_product_id: billingProductId,
-            p_plan_id: consumeResult.default_plan_id,
-            p_user_id: userId,
-          }
-        );
-        if (planErr) {
-          console.error('billing_ensure_subscription_plan', planErr.message);
-          return jsonResponse({ error: 'plan_provision_failed' }, 500, req);
-        }
-      }
+    const billingProductId =
+      body.productId?.trim() ||
+      Deno.env.get('WAITLIST_PRODUCT_ID') ||
+      'beakerstack';
+    const compPlanIds = (
+      Deno.env.get('WAITLIST_COMP_PLAN_IDS') ?? 'beakerstack_vip'
+    )
+      .split(',')
+      .map(id => id.trim())
+      .filter(Boolean);
 
+    let fulfillResult: {
+      comp_applied?: boolean;
+      plan_applied?: boolean;
+      unchanged?: boolean;
+      error?: string;
+    } | null = null;
+
+    if (consumeResult.ok && consumeResult.entry_id) {
+      fulfillResult = await fulfillWaitlistConversion(
+        admin,
+        {
+          productId: billingProductId,
+          compPlanIds,
+        },
+        {
+          userId,
+          entryId: consumeResult.entry_id,
+        }
+      );
+      if (fulfillResult?.error) {
+        const fulfillError = fulfillResult.error;
+        const isAllowlistMisconfig =
+          fulfillError === 'plan_not_allowed' ||
+          fulfillError === 'invalid_plan';
+        console.error(
+          JSON.stringify({
+            event: 'waitlist_billing_fulfill_conversion_failed',
+            error: fulfillError,
+            severity: isAllowlistMisconfig
+              ? 'config_mismatch'
+              : 'provision_error',
+            entry_id: consumeResult.entry_id,
+            user_id: userId,
+            comp_plan_ids: compPlanIds,
+          })
+        );
+        return jsonResponse(
+          {
+            error: isAllowlistMisconfig
+              ? fulfillError
+              : 'plan_provision_failed',
+          },
+          500,
+          req
+        );
+      }
+    }
+
+    const provisionedByIntent =
+      fulfillResult?.comp_applied === true ||
+      fulfillResult?.plan_applied === true ||
+      fulfillResult?.unchanged === true;
+
+    if (
+      consumeResult.ok &&
+      !provisionedByIntent &&
+      consumeResult.default_plan_id
+    ) {
+      const { error: planErr } = await admin.rpc(
+        'billing_ensure_subscription_plan',
+        {
+          p_product_id: billingProductId,
+          p_plan_id: consumeResult.default_plan_id,
+          p_user_id: userId,
+        }
+      );
+      if (planErr) {
+        console.error('billing_ensure_subscription_plan', planErr.message);
+        return jsonResponse({ error: 'plan_provision_failed' }, 500, req);
+      }
+    }
+
+    if (consumeResult.ok && !consumeResult.already_converted) {
       // Use the JWT-verified email only — never the caller-supplied userEmail,
       // which could route the Kit event to an arbitrary address.
       const consumeEmail = user.email?.toLowerCase().trim() ?? null;

--- a/supabase/migrations/20260630120000_billing_comp_grants_v1.sql
+++ b/supabase/migrations/20260630120000_billing_comp_grants_v1.sql
@@ -1,0 +1,87 @@
+-- Complimentary billing grants: admin-only metadata table + free-plan provisioning fix.
+
+-- ---------------------------------------------------------------------------
+-- billing_comp_grants (no authenticated RLS — admin RPCs only)
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.billing_comp_grants (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+    product_id text NOT NULL REFERENCES public.billing_products (id) ON DELETE CASCADE,
+    plan_id text NOT NULL REFERENCES public.billing_plans (id) ON DELETE RESTRICT,
+    comped_at timestamptz NOT NULL DEFAULT now(),
+    comped_by uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+    comp_reason text NOT NULL,
+    comp_expires_at timestamptz,
+    revoked_at timestamptz,
+    revoked_by uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+    revoke_reason text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT billing_comp_grants_reason_len CHECK (char_length(comp_reason) <= 500),
+    CONSTRAINT billing_comp_grants_revoke_reason_len CHECK (
+        revoke_reason IS NULL OR char_length(revoke_reason) <= 500
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS billing_comp_grants_active_user_product
+    ON public.billing_comp_grants (user_id, product_id)
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS billing_comp_grants_user_product
+    ON public.billing_comp_grants (user_id, product_id);
+
+ALTER TABLE public.billing_comp_grants ENABLE ROW LEVEL SECURITY;
+
+-- updated_at is set explicitly in admin grant/revoke RPCs (no public.set_updated_at in template migrations)
+
+-- ---------------------------------------------------------------------------
+-- ensure_billing_subscription: only auto-provision the public free plan
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.ensure_billing_subscription(p_product_id text)
+RETURNS public.billing_subscriptions
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_uid uuid := auth.uid();
+    v_free_plan_id text;
+    r public.billing_subscriptions;
+BEGIN
+    IF v_uid IS NULL THEN
+        RAISE EXCEPTION 'not authenticated';
+    END IF;
+
+    SELECT p.id INTO v_free_plan_id
+    FROM public.billing_plans p
+    WHERE p.product_id = p_product_id
+      AND p.billing_period = 'free'
+      AND p.is_public = true
+    ORDER BY p.display_order NULLS LAST, p.id
+    LIMIT 1;
+
+    IF v_free_plan_id IS NULL THEN
+        RAISE EXCEPTION 'no free plan for product %', p_product_id;
+    END IF;
+
+    INSERT INTO public.billing_subscriptions (
+        user_id, product_id, plan_id, status,
+        stripe_customer_id, stripe_subscription_id,
+        current_period_start, current_period_end
+    )
+    VALUES (
+        v_uid, p_product_id, v_free_plan_id, 'free',
+        NULL, NULL,
+        date_trunc('month', now() AT TIME ZONE 'utc'),
+        date_trunc('month', now() AT TIME ZONE 'utc') + interval '1 month'
+    )
+    ON CONFLICT (user_id, product_id) DO NOTHING;
+
+    SELECT * INTO r FROM public.billing_subscriptions s
+    WHERE s.user_id = v_uid AND s.product_id = p_product_id;
+
+    RETURN r;
+END;
+$$;

--- a/supabase/migrations/20260630120100_admin_billing_comp_rpcs.sql
+++ b/supabase/migrations/20260630120100_admin_billing_comp_rpcs.sql
@@ -1,0 +1,360 @@
+-- Admin RPCs: grant / revoke complimentary billing access.
+
+-- Grant RPC is defined in 20260630120200_billing_apply_comp_grant_internal.sql
+-- (thin admin wrapper around _billing_apply_comp_grant).
+
+-- ---------------------------------------------------------------------------
+-- RPC: revoke complimentary billing
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.admin_revoke_billing_comp(
+    p_user_id uuid,
+    p_product_id text,
+    p_reason text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_uid uuid := auth.uid();
+    v_free_plan_id text;
+    v_grant public.billing_comp_grants;
+    v_has_active_grant boolean;
+    v_revoke_plan_id text;
+    v_revoke_reason text;
+BEGIN
+    IF v_uid IS NULL OR NOT public.admin_is_admin() THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    IF p_user_id IS NULL OR p_product_id IS NULL THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    SELECT * INTO v_grant
+    FROM public.billing_comp_grants g
+    WHERE g.user_id = p_user_id
+      AND g.product_id = p_product_id
+      AND g.revoked_at IS NULL;
+
+    v_has_active_grant := FOUND;
+
+    IF NOT v_has_active_grant
+       AND NOT EXISTS (
+            SELECT 1 FROM public.billing_subscriptions s
+            WHERE s.user_id = p_user_id
+              AND s.product_id = p_product_id
+              AND s.status = 'comped'
+        ) THEN
+        RETURN jsonb_build_object('ok', true, 'unchanged', true);
+    END IF;
+
+    SELECT p.id INTO v_free_plan_id
+    FROM public.billing_plans p
+    WHERE p.product_id = p_product_id
+      AND p.billing_period = 'free'
+      AND p.is_public = true
+    ORDER BY p.display_order NULLS LAST, p.id
+    LIMIT 1;
+
+    IF v_free_plan_id IS NULL THEN
+        RETURN jsonb_build_object('error', 'no_free_plan');
+    END IF;
+
+    v_revoke_reason := nullif(btrim(p_reason), '');
+    IF v_revoke_reason IS NOT NULL AND char_length(v_revoke_reason) > 500 THEN
+        RETURN jsonb_build_object('error', 'invalid_reason');
+    END IF;
+
+    IF v_has_active_grant THEN
+        v_revoke_plan_id := v_grant.plan_id;
+        UPDATE public.billing_comp_grants g
+        SET revoked_at = now(),
+            revoked_by = v_uid,
+            revoke_reason = v_revoke_reason,
+            updated_at = now()
+        WHERE g.id = v_grant.id;
+    ELSE
+        SELECT s.plan_id INTO v_revoke_plan_id
+        FROM public.billing_subscriptions s
+        WHERE s.user_id = p_user_id AND s.product_id = p_product_id;
+    END IF;
+
+    UPDATE public.billing_subscriptions s
+    SET plan_id = v_free_plan_id,
+        status = 'free',
+        stripe_subscription_id = NULL,
+        current_period_start = date_trunc('month', now() AT TIME ZONE 'utc'),
+        current_period_end = date_trunc('month', now() AT TIME ZONE 'utc') + interval '1 month',
+        updated_at = now()
+    WHERE s.user_id = p_user_id
+      AND s.product_id = p_product_id
+      AND s.stripe_subscription_id IS NULL
+      AND (
+          s.status = 'comped'
+          OR (v_has_active_grant AND s.plan_id = v_grant.plan_id)
+      );
+
+    PERFORM public._admin_insert_audit(
+        v_uid,
+        'admin.billing.comp.revoke',
+        'user',
+        p_user_id::text,
+        jsonb_build_object(
+            'product_id', p_product_id,
+            'plan_id', v_revoke_plan_id
+        )
+    );
+
+    RETURN jsonb_build_object('ok', true);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.admin_revoke_billing_comp(uuid, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.admin_revoke_billing_comp(uuid, text, text) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Extend admin_get_user with active comp grant (admin-only metadata)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.admin_get_user(
+    p_user_id uuid,
+    p_product_id text DEFAULT 'beakerstack'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_uid uuid := auth.uid();
+    v_auth jsonb;
+    v_profile jsonb;
+    v_subscription jsonb;
+    v_plan_id text;
+    v_plan jsonb;
+    v_usage_aggregates jsonb;
+    v_usage_events jsonb;
+    v_invoices jsonb;
+    v_is_admin boolean;
+    v_granted_at timestamptz;
+    v_granted_by_email text;
+    v_comp_grant jsonb;
+BEGIN
+    IF v_uid IS NULL OR NOT public.admin_is_admin() THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    IF p_user_id IS NULL THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    SELECT jsonb_build_object(
+        'id', u.id,
+        'email', u.email,
+        'created_at', u.created_at,
+        'last_sign_in_at', u.last_sign_in_at,
+        'email_confirmed_at', u.email_confirmed_at
+    )
+    INTO v_auth
+    FROM auth.users u
+    WHERE u.id = p_user_id;
+
+    IF v_auth IS NULL THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    PERFORM public._admin_insert_audit(
+        v_uid,
+        'admin.users.view',
+        'user',
+        p_user_id::text,
+        jsonb_build_object('product_id', p_product_id)
+    );
+
+    SELECT
+        au.granted_at,
+        granter.email
+    INTO v_granted_at, v_granted_by_email
+    FROM public.admin_users au
+    LEFT JOIN auth.users granter ON granter.id = au.granted_by
+    WHERE au.user_id = p_user_id AND au.revoked_at IS NULL;
+
+    v_is_admin := FOUND;
+
+    SELECT jsonb_build_object(
+        'display_name', p.display_name,
+        'username', p.username,
+        'avatar_url', p.avatar_url,
+        'bio', p.bio,
+        'website', p.website,
+        'location', p.location,
+        'created_at', p.created_at,
+        'updated_at', p.updated_at
+    )
+    INTO v_profile
+    FROM public.user_profiles p
+    WHERE p.user_id = p_user_id;
+
+    SELECT
+        jsonb_build_object(
+            'product_id', s.product_id,
+            'plan_id', s.plan_id,
+            'status', s.status,
+            'current_period_start', s.current_period_start,
+            'current_period_end', s.current_period_end,
+            'cancel_at_period_end', s.cancel_at_period_end,
+            'canceled_at', s.canceled_at,
+            'trial_start', s.trial_start,
+            'trial_end', s.trial_end,
+            'created_at', s.created_at,
+            'updated_at', s.updated_at
+        ),
+        s.plan_id
+    INTO v_subscription, v_plan_id
+    FROM public.billing_subscriptions s
+    WHERE s.user_id = p_user_id AND s.product_id = p_product_id;
+
+    IF v_plan_id IS NOT NULL THEN
+        SELECT jsonb_build_object(
+            'id', pl.id,
+            'display_name', pl.display_name,
+            'description', pl.description,
+            'price_cents', pl.price_cents,
+            'billing_period', pl.billing_period,
+            'features', pl.features,
+            'usage_limits', pl.usage_limits,
+            'trial_period_days', pl.trial_period_days,
+            'is_public', pl.is_public,
+            'display_order', pl.display_order
+        )
+        INTO v_plan
+        FROM public.billing_plans pl
+        WHERE pl.id = v_plan_id;
+    END IF;
+
+    SELECT jsonb_build_object(
+        'id', g.id,
+        'plan_id', g.plan_id,
+        'comped_at', g.comped_at,
+        'comped_by', g.comped_by,
+        'comped_by_email', granter.email,
+        'comp_reason', g.comp_reason,
+        'comp_expires_at', g.comp_expires_at
+    )
+    INTO v_comp_grant
+    FROM public.billing_comp_grants g
+    LEFT JOIN auth.users granter ON granter.id = g.comped_by
+    WHERE g.user_id = p_user_id
+      AND g.product_id = p_product_id
+      AND g.revoked_at IS NULL;
+
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'event_type', a.event_type,
+                'product_id', a.product_id,
+                'period_start', a.period_start,
+                'period_end', a.period_end,
+                'count', a.count
+            )
+            ORDER BY a.event_type
+        ),
+        '[]'::jsonb
+    )
+    INTO v_usage_aggregates
+    FROM public.billing_usage_aggregates a
+    WHERE a.user_id = p_user_id
+      AND a.product_id = p_product_id
+      AND a.period_start <= now()
+      AND a.period_end > now();
+
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'event_type', e.event_type,
+                'product_id', e.product_id,
+                'quantity', e.quantity,
+                'created_at', e.created_at
+            )
+            ORDER BY e.created_at DESC
+        ),
+        '[]'::jsonb
+    )
+    INTO v_usage_events
+    FROM (
+        SELECT e.event_type, e.product_id, e.quantity, e.created_at
+        FROM public.billing_usage_events e
+        WHERE e.user_id = p_user_id
+          AND e.product_id = p_product_id
+        ORDER BY e.created_at DESC
+        LIMIT 100
+    ) e;
+
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'id', i.id,
+                'stripe_invoice_id', i.stripe_invoice_id,
+                'status', i.status,
+                'amount_due', i.amount_due,
+                'amount_paid', i.amount_paid,
+                'currency', i.currency,
+                'description', i.description,
+                'hosted_invoice_url', i.hosted_invoice_url,
+                'period_start', i.period_start,
+                'period_end', i.period_end,
+                'created_at', i.created_at,
+                'finalized_at', i.finalized_at,
+                'paid_at', i.paid_at
+            )
+            ORDER BY i.created_at DESC
+        ),
+        '[]'::jsonb
+    )
+    INTO v_invoices
+    FROM (
+        SELECT
+            i.id,
+            i.stripe_invoice_id,
+            i.status,
+            i.amount_due,
+            i.amount_paid,
+            i.currency,
+            i.description,
+            i.hosted_invoice_url,
+            i.period_start,
+            i.period_end,
+            i.created_at,
+            i.finalized_at,
+            i.paid_at
+        FROM public.billing_invoices i
+        WHERE i.user_id = p_user_id
+        ORDER BY i.created_at DESC
+        LIMIT 20
+    ) i;
+
+    RETURN jsonb_build_object(
+        'auth', v_auth,
+        'profile', v_profile,
+        'subscription', v_subscription,
+        'plan', v_plan,
+        'comp_grant', v_comp_grant,
+        'admin', jsonb_build_object(
+            'is_admin', v_is_admin,
+            'granted_at', v_granted_at,
+            'granted_by_email', v_granted_by_email
+        ),
+        'usage_aggregates', v_usage_aggregates,
+        'usage_events', v_usage_events,
+        'invoices', v_invoices
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.admin_get_user(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.admin_get_user(uuid, text) TO authenticated;

--- a/supabase/migrations/20260630120200_billing_apply_comp_grant_internal.sql
+++ b/supabase/migrations/20260630120200_billing_apply_comp_grant_internal.sql
@@ -1,0 +1,200 @@
+-- Extract internal comp-grant helper for admin + waitlist-billing integration paths.
+
+CREATE OR REPLACE FUNCTION public._billing_apply_comp_grant(
+    p_user_id uuid,
+    p_product_id text,
+    p_plan_id text,
+    p_reason text,
+    p_granted_by uuid DEFAULT NULL,
+    p_expires_at timestamptz DEFAULT NULL,
+    p_source text DEFAULT 'admin'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_reason text;
+    v_sub public.billing_subscriptions;
+    v_free_plan_id text;
+    v_period_start timestamptz;
+    v_period_end timestamptz;
+    v_existing_grant public.billing_comp_grants;
+    v_source text;
+BEGIN
+    IF p_user_id IS NULL OR p_product_id IS NULL OR p_plan_id IS NULL THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    v_reason := nullif(btrim(p_reason), '');
+    IF v_reason IS NULL OR char_length(v_reason) > 500 THEN
+        RETURN jsonb_build_object('error', 'invalid_reason');
+    END IF;
+
+    v_source := nullif(btrim(p_source), '');
+    IF v_source IS NULL THEN
+        v_source := 'admin';
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = p_user_id) THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM public.billing_plans pl
+        WHERE pl.id = p_plan_id
+          AND pl.product_id = p_product_id
+          AND pl.is_public = false
+    ) THEN
+        RETURN jsonb_build_object('error', 'invalid_plan');
+    END IF;
+
+    SELECT p.id INTO v_free_plan_id
+    FROM public.billing_plans p
+    WHERE p.product_id = p_product_id
+      AND p.billing_period = 'free'
+      AND p.is_public = true
+    ORDER BY p.display_order NULLS LAST, p.id
+    LIMIT 1;
+
+    IF v_free_plan_id IS NULL THEN
+        RETURN jsonb_build_object('error', 'no_free_plan');
+    END IF;
+
+    INSERT INTO public.billing_subscriptions (
+        user_id, product_id, plan_id, status,
+        stripe_customer_id, stripe_subscription_id,
+        current_period_start, current_period_end
+    )
+    VALUES (
+        p_user_id, p_product_id, v_free_plan_id, 'free',
+        NULL, NULL,
+        date_trunc('month', now() AT TIME ZONE 'utc'),
+        date_trunc('month', now() AT TIME ZONE 'utc') + interval '1 month'
+    )
+    ON CONFLICT (user_id, product_id) DO NOTHING;
+
+    SELECT * INTO v_sub
+    FROM public.billing_subscriptions s
+    WHERE s.user_id = p_user_id AND s.product_id = p_product_id
+    FOR UPDATE;
+
+    IF v_sub.stripe_subscription_id IS NOT NULL THEN
+        RETURN jsonb_build_object('error', 'stripe_subscription_active');
+    END IF;
+
+    IF v_sub.status = 'comped'
+       AND v_sub.plan_id = p_plan_id
+       AND EXISTS (
+            SELECT 1 FROM public.billing_comp_grants g
+            WHERE g.user_id = p_user_id
+              AND g.product_id = p_product_id
+              AND g.revoked_at IS NULL
+              AND g.plan_id = p_plan_id
+              AND (g.comp_expires_at IS NOT DISTINCT FROM p_expires_at)
+        ) THEN
+        RETURN jsonb_build_object('ok', true, 'unchanged', true);
+    END IF;
+
+    v_period_start := date_trunc('month', now() AT TIME ZONE 'utc');
+    v_period_end := v_period_start + interval '1 month';
+
+    SELECT * INTO v_existing_grant
+    FROM public.billing_comp_grants g
+    WHERE g.user_id = p_user_id
+      AND g.product_id = p_product_id
+      AND g.revoked_at IS NULL;
+
+    IF FOUND THEN
+        UPDATE public.billing_comp_grants g
+        SET revoked_at = now(),
+            revoked_by = p_granted_by,
+            revoke_reason = 'superseded by new grant',
+            updated_at = now()
+        WHERE g.id = v_existing_grant.id;
+    END IF;
+
+    UPDATE public.billing_subscriptions s
+    SET plan_id = p_plan_id,
+        status = 'comped',
+        stripe_subscription_id = NULL,
+        current_period_start = v_period_start,
+        current_period_end = v_period_end,
+        cancel_at_period_end = false,
+        canceled_at = NULL,
+        pending_target_plan_id = NULL,
+        updated_at = now()
+    WHERE s.user_id = p_user_id
+      AND s.product_id = p_product_id
+      AND s.stripe_subscription_id IS NULL;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('error', 'stripe_subscription_active');
+    END IF;
+
+    INSERT INTO public.billing_comp_grants (
+        user_id, product_id, plan_id, comped_by, comp_reason, comp_expires_at
+    )
+    VALUES (
+        p_user_id, p_product_id, p_plan_id, p_granted_by, v_reason, p_expires_at
+    );
+
+    IF p_granted_by IS NOT NULL THEN
+        PERFORM public._admin_insert_audit(
+            p_granted_by,
+            'admin.billing.comp.grant',
+            'user',
+            p_user_id::text,
+            jsonb_build_object(
+                'product_id', p_product_id,
+                'plan_id', p_plan_id,
+                'expires_at', p_expires_at,
+                'reason', left(v_reason, 200),
+                'source', v_source
+            )
+        );
+    END IF;
+
+    RETURN jsonb_build_object('ok', true, 'comp_applied', true);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._billing_apply_comp_grant(uuid, text, text, text, uuid, timestamptz, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public._billing_apply_comp_grant(uuid, text, text, text, uuid, timestamptz, text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.admin_grant_billing_comp(
+    p_user_id uuid,
+    p_product_id text,
+    p_plan_id text,
+    p_reason text,
+    p_expires_at timestamptz DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_uid uuid := auth.uid();
+BEGIN
+    IF v_uid IS NULL OR NOT public.admin_is_admin() THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    RETURN public._billing_apply_comp_grant(
+        p_user_id,
+        p_product_id,
+        p_plan_id,
+        p_reason,
+        v_uid,
+        p_expires_at,
+        'admin'
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.admin_grant_billing_comp(uuid, text, text, text, timestamptz) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.admin_grant_billing_comp(uuid, text, text, text, timestamptz) TO authenticated;

--- a/supabase/migrations/20260630120300_waitlist_provisioning_intent.sql
+++ b/supabase/migrations/20260630120300_waitlist_provisioning_intent.sql
@@ -1,0 +1,622 @@
+-- Waitlist provisioning intent: per-invite VIP/plan pre-configuration (billing-agnostic).
+
+-- Shape + allowlist validation for admin-set intent. Reads billing_plans (existence,
+-- is_public) but intentionally omits product_id — waitlist_billing_fulfill_conversion
+-- enforces product_id at conversion time.
+CREATE OR REPLACE FUNCTION public._waitlist_validate_provisioning_intent(
+    p_intent jsonb,
+    p_granted_by uuid,
+    p_allowed_comp_plan_ids text[] DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SET search_path = public
+AS $$
+DECLARE
+    v_kind text;
+    v_plan_id text;
+    v_reason text;
+BEGIN
+    IF p_intent IS NULL THEN
+        RETURN jsonb_build_object('ok', true, 'clear', true);
+    END IF;
+
+    IF jsonb_typeof(p_intent) <> 'object' THEN
+        RETURN jsonb_build_object('error', 'invalid_intent');
+    END IF;
+
+    v_kind := nullif(btrim(p_intent->>'kind'), '');
+    IF v_kind NOT IN ('billing_comp', 'billing_plan') THEN
+        RETURN jsonb_build_object('error', 'invalid_intent_kind');
+    END IF;
+
+    v_plan_id := nullif(btrim(p_intent->>'planId'), '');
+    IF v_plan_id IS NULL THEN
+        RETURN jsonb_build_object('error', 'invalid_plan_id');
+    END IF;
+
+    IF v_kind = 'billing_comp' THEN
+        v_reason := nullif(btrim(p_intent->>'reason'), '');
+        IF v_reason IS NULL OR char_length(v_reason) > 500 THEN
+            RETURN jsonb_build_object('error', 'invalid_reason');
+        END IF;
+
+        IF p_allowed_comp_plan_ids IS NOT NULL
+           AND NOT (v_plan_id = ANY (p_allowed_comp_plan_ids)) THEN
+            RETURN jsonb_build_object('error', 'plan_not_allowed');
+        END IF;
+
+        IF NOT EXISTS (
+            SELECT 1 FROM public.billing_plans pl
+            WHERE pl.id = v_plan_id AND pl.is_public = false
+        ) THEN
+            RETURN jsonb_build_object('error', 'invalid_comp_plan');
+        END IF;
+
+        RETURN jsonb_build_object(
+            'ok', true,
+            'intent', jsonb_build_object(
+                'kind', 'billing_comp',
+                'planId', v_plan_id,
+                'reason', v_reason,
+                'grantedBy', p_granted_by
+            )
+        );
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM public.billing_plans pl
+        WHERE pl.id = v_plan_id AND pl.is_public = true
+    ) THEN
+        RETURN jsonb_build_object('error', 'invalid_public_plan');
+    END IF;
+
+    RETURN jsonb_build_object(
+        'ok', true,
+        'intent', jsonb_build_object(
+            'kind', 'billing_plan',
+            'planId', v_plan_id
+        )
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._waitlist_validate_provisioning_intent(jsonb, uuid, text[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public._waitlist_validate_provisioning_intent(jsonb, uuid, text[]) TO service_role;
+
+CREATE OR REPLACE FUNCTION public._waitlist_merge_provisioning_intent(
+    p_metadata jsonb,
+    p_validated jsonb
+)
+RETURNS jsonb
+LANGUAGE sql
+IMMUTABLE
+SET search_path = public
+AS $$
+    SELECT CASE
+        WHEN COALESCE((p_validated->>'clear')::boolean, false) THEN
+            COALESCE(p_metadata, '{}'::jsonb) - 'provisioning_intent'
+        WHEN p_validated ? 'intent' THEN
+            jsonb_set(
+                COALESCE(p_metadata, '{}'::jsonb),
+                '{provisioning_intent}',
+                p_validated->'intent',
+                true
+            )
+        ELSE COALESCE(p_metadata, '{}'::jsonb)
+    END;
+$$;
+
+REVOKE ALL ON FUNCTION public._waitlist_merge_provisioning_intent(jsonb, jsonb) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public._waitlist_merge_provisioning_intent(jsonb, jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public._waitlist_consume_response(
+    p_entry_id uuid,
+    p_default_plan_id text,
+    p_already_converted boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_intent jsonb;
+BEGIN
+    SELECT e.metadata->'provisioning_intent'
+      INTO v_intent
+    FROM public.waitlist_entries e
+    WHERE e.id = p_entry_id;
+
+    IF p_already_converted THEN
+        RETURN jsonb_build_object(
+            'ok', true,
+            'already_converted', true,
+            'entry_id', p_entry_id,
+            'default_plan_id', p_default_plan_id,
+            'provisioning_intent', v_intent
+        );
+    END IF;
+
+    RETURN jsonb_build_object(
+        'ok', true,
+        'entry_id', p_entry_id,
+        'default_plan_id', p_default_plan_id,
+        'provisioning_intent', v_intent
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._waitlist_consume_response(uuid, text, boolean) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public._waitlist_consume_response(uuid, text, boolean) TO service_role;
+
+DROP FUNCTION IF EXISTS public.admin_invite_waitlist_email(text, jsonb);
+
+CREATE OR REPLACE FUNCTION public.admin_invite_waitlist_email(
+    p_email text,
+    p_metadata jsonb DEFAULT '{}'::jsonb,
+    p_provisioning_intent jsonb DEFAULT NULL,
+    p_update_provisioning_intent boolean DEFAULT false,
+    p_allowed_comp_plan_ids text[] DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_uid uuid := auth.uid();
+    v_email text;
+    v_entry public.waitlist_entries;
+    v_invite record;
+    v_created boolean := false;
+    v_validated jsonb;
+    v_metadata jsonb;
+BEGIN
+    IF v_uid IS NULL OR NOT public.admin_is_admin() THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    v_email := lower(trim(p_email));
+    IF NOT public.is_valid_email(v_email) THEN
+        RETURN jsonb_build_object('error', 'invalid_email');
+    END IF;
+
+    IF p_update_provisioning_intent THEN
+        v_validated := public._waitlist_validate_provisioning_intent(
+            p_provisioning_intent,
+            v_uid,
+            p_allowed_comp_plan_ids
+        );
+        IF v_validated ? 'error' THEN
+            RETURN jsonb_build_object('error', v_validated->>'error');
+        END IF;
+    END IF;
+
+    SELECT * INTO v_entry FROM public.waitlist_entries WHERE email = v_email FOR UPDATE;
+
+    IF NOT FOUND THEN
+        v_metadata := jsonb_build_object('source', 'admin_invite') || COALESCE(p_metadata, '{}'::jsonb);
+        IF p_update_provisioning_intent THEN
+            v_metadata := public._waitlist_merge_provisioning_intent(v_metadata, v_validated);
+        END IF;
+        INSERT INTO public.waitlist_entries (email, metadata)
+        VALUES (v_email, v_metadata)
+        RETURNING * INTO v_entry;
+        v_created := true;
+    ELSIF v_entry.status = 'converted' THEN
+        RETURN jsonb_build_object('error', 'already_converted');
+    ELSE
+        v_metadata := COALESCE(v_entry.metadata, '{}'::jsonb) || COALESCE(p_metadata, '{}'::jsonb);
+        IF p_update_provisioning_intent THEN
+            v_metadata := public._waitlist_merge_provisioning_intent(v_metadata, v_validated);
+        END IF;
+        UPDATE public.waitlist_entries
+        SET metadata = v_metadata
+        WHERE id = v_entry.id
+        RETURNING * INTO v_entry;
+    END IF;
+
+    SELECT * INTO v_invite
+    FROM public._waitlist_create_invite(v_entry.id, v_uid);
+
+    UPDATE public.waitlist_entries
+    SET
+        status = 'approved',
+        approved_at = COALESCE(approved_at, now()),
+        rejected_at = NULL
+    WHERE id = v_entry.id;
+
+    PERFORM public._admin_insert_audit(
+        v_uid,
+        'waitlist.entry.invite_email',
+        'waitlist_entry',
+        v_entry.id::text,
+        jsonb_build_object(
+            'email', v_email,
+            'created', v_created,
+            'provisioning_intent', CASE
+                WHEN p_update_provisioning_intent THEN v_metadata->'provisioning_intent'
+                ELSE NULL
+            END
+        )
+    );
+
+    RETURN jsonb_build_object(
+        'ok', true,
+        'entry_id', v_entry.id,
+        'invite_token', v_invite.raw_token,
+        'email', v_email,
+        'created', v_created
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.admin_invite_waitlist_email(text, jsonb, jsonb, boolean, text[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.admin_invite_waitlist_email(text, jsonb, jsonb, boolean, text[]) TO authenticated;
+
+DROP FUNCTION IF EXISTS public.admin_approve_waitlist_entry(uuid);
+
+CREATE OR REPLACE FUNCTION public.admin_approve_waitlist_entry(
+    p_id uuid,
+    p_provisioning_intent jsonb DEFAULT NULL,
+    p_update_provisioning_intent boolean DEFAULT false,
+    p_allowed_comp_plan_ids text[] DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_uid uuid := auth.uid();
+    v_entry public.waitlist_entries;
+    v_invite record;
+    v_validated jsonb;
+    v_metadata jsonb;
+BEGIN
+    IF v_uid IS NULL OR NOT public.admin_is_admin() THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    SELECT * INTO v_entry FROM public.waitlist_entries WHERE id = p_id FOR UPDATE;
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    IF v_entry.status NOT IN ('pending', 'approved') THEN
+        RETURN jsonb_build_object('error', 'invalid_status');
+    END IF;
+
+    IF p_update_provisioning_intent THEN
+        v_validated := public._waitlist_validate_provisioning_intent(
+            p_provisioning_intent,
+            v_uid,
+            p_allowed_comp_plan_ids
+        );
+        IF v_validated ? 'error' THEN
+            RETURN jsonb_build_object('error', v_validated->>'error');
+        END IF;
+        v_metadata := public._waitlist_merge_provisioning_intent(
+            COALESCE(v_entry.metadata, '{}'::jsonb),
+            v_validated
+        );
+        UPDATE public.waitlist_entries
+        SET metadata = v_metadata
+        WHERE id = p_id
+        RETURNING * INTO v_entry;
+    END IF;
+
+    SELECT * INTO v_invite
+    FROM public._waitlist_create_invite(p_id, v_uid);
+
+    UPDATE public.waitlist_entries
+    SET
+        status = 'approved',
+        approved_at = COALESCE(approved_at, now()),
+        rejected_at = NULL
+    WHERE id = p_id;
+
+    PERFORM public._admin_insert_audit(
+        v_uid,
+        'waitlist.entry.approve',
+        'waitlist_entry',
+        p_id::text,
+        jsonb_build_object(
+            'email', v_entry.email,
+            'provisioning_intent', CASE
+                WHEN p_update_provisioning_intent THEN v_entry.metadata->'provisioning_intent'
+                ELSE NULL
+            END
+        )
+    );
+
+    RETURN jsonb_build_object(
+        'ok', true,
+        'entry_id', p_id,
+        'invite_token', v_invite.raw_token,
+        'email', v_entry.email
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.admin_approve_waitlist_entry(uuid, jsonb, boolean, text[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.admin_approve_waitlist_entry(uuid, jsonb, boolean, text[]) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.admin_set_waitlist_entry_provisioning_intent(
+    p_entry_id uuid,
+    p_provisioning_intent jsonb DEFAULT NULL,
+    p_allowed_comp_plan_ids text[] DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_uid uuid := auth.uid();
+    v_entry public.waitlist_entries;
+    v_validated jsonb;
+    v_metadata jsonb;
+BEGIN
+    IF v_uid IS NULL OR NOT public.admin_is_admin() THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    SELECT * INTO v_entry FROM public.waitlist_entries WHERE id = p_entry_id FOR UPDATE;
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    IF v_entry.status NOT IN ('pending', 'approved') THEN
+        RETURN jsonb_build_object('error', 'invalid_status');
+    END IF;
+
+    v_validated := public._waitlist_validate_provisioning_intent(
+        p_provisioning_intent,
+        v_uid,
+        p_allowed_comp_plan_ids
+    );
+    IF v_validated ? 'error' THEN
+        RETURN jsonb_build_object('error', v_validated->>'error');
+    END IF;
+
+    v_metadata := public._waitlist_merge_provisioning_intent(
+        COALESCE(v_entry.metadata, '{}'::jsonb),
+        v_validated
+    );
+
+    UPDATE public.waitlist_entries
+    SET metadata = v_metadata
+    WHERE id = p_entry_id;
+
+    PERFORM public._admin_insert_audit(
+        v_uid,
+        'waitlist.entry.set_provisioning_intent',
+        'waitlist_entry',
+        p_entry_id::text,
+        jsonb_build_object(
+            'email', v_entry.email,
+            'provisioning_intent', v_metadata->'provisioning_intent'
+        )
+    );
+
+    RETURN jsonb_build_object(
+        'ok', true,
+        'entry_id', p_entry_id,
+        'provisioning_intent', v_metadata->'provisioning_intent'
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.admin_set_waitlist_entry_provisioning_intent(uuid, jsonb, text[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.admin_set_waitlist_entry_provisioning_intent(uuid, jsonb, text[]) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.waitlist_consume_invite(
+    p_token text,
+    p_user_id uuid,
+    p_user_email text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_valid         jsonb;
+    v_entry_id      uuid;
+    v_entry         public.waitlist_entries;
+    v_inv           public.waitlist_invites;
+    v_hash          text;
+    v_settings      public.waitlist_settings;
+    v_uid           uuid := auth.uid();
+    v_pre_used_at   timestamptz;
+    v_pre_converted uuid;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RETURN jsonb_build_object('error', 'invalid_user');
+    END IF;
+
+    IF v_uid IS NOT NULL AND v_uid IS DISTINCT FROM p_user_id THEN
+        RETURN jsonb_build_object('error', 'forbidden');
+    END IF;
+
+    v_hash := public._waitlist_hash_token(trim(p_token));
+    SELECT i.used_at, e.converted_user_id, e.id
+      INTO v_pre_used_at, v_pre_converted, v_entry_id
+    FROM public.waitlist_invites i
+    JOIN public.waitlist_entries e ON e.id = i.entry_id
+    WHERE i.token_hash = v_hash;
+
+    IF FOUND
+       AND v_pre_used_at   IS NOT NULL
+       AND v_pre_converted IS NOT DISTINCT FROM p_user_id THEN
+        SELECT * INTO v_settings FROM public._waitlist_settings_row();
+        RETURN public._waitlist_consume_response(
+            v_entry_id,
+            v_settings.default_plan_id,
+            true
+        );
+    END IF;
+
+    v_valid := public.waitlist_validate_invite(p_token);
+    IF NOT COALESCE((v_valid->>'valid')::boolean, false) THEN
+        RETURN jsonb_build_object('error', 'invalid_invite');
+    END IF;
+
+    v_entry_id := (v_valid->>'entry_id')::uuid;
+
+    SELECT * INTO v_inv   FROM public.waitlist_invites  WHERE token_hash = v_hash FOR UPDATE;
+    SELECT * INTO v_entry FROM public.waitlist_entries  WHERE id = v_entry_id     FOR UPDATE;
+    SELECT * INTO v_settings FROM public._waitlist_settings_row();
+
+    IF v_inv.used_at IS NOT NULL OR v_inv.revoked_at IS NOT NULL THEN
+        RETURN jsonb_build_object('error', 'invite_already_used');
+    END IF;
+
+    IF v_entry.status = 'converted' AND v_entry.converted_user_id = p_user_id THEN
+        RETURN public._waitlist_consume_response(
+            v_entry_id,
+            v_settings.default_plan_id,
+            true
+        );
+    END IF;
+
+    IF v_entry.status = 'converted' THEN
+        RETURN jsonb_build_object('error', 'already_converted');
+    END IF;
+
+    IF v_settings.identity_match_mode = 'strict'
+       AND p_user_email IS NOT NULL
+       AND lower(trim(p_user_email)) IS DISTINCT FROM v_entry.email THEN
+        RETURN jsonb_build_object('error', 'email_mismatch');
+    END IF;
+
+    IF v_settings.identity_match_mode = 'lenient'
+       AND p_user_email IS NOT NULL
+       AND lower(trim(p_user_email)) IS DISTINCT FROM v_entry.email THEN
+        PERFORM public._admin_insert_audit(
+            p_user_id,
+            'waitlist.invite.email_mismatch',
+            'waitlist_entry',
+            v_entry_id::text,
+            jsonb_build_object(
+                'waitlist_email', v_entry.email,
+                'auth_email',     lower(trim(p_user_email))
+            )
+        );
+    END IF;
+
+    UPDATE public.waitlist_invites
+    SET used_at = now()
+    WHERE id = v_inv.id;
+
+    UPDATE public.waitlist_entries
+    SET
+        status            = 'converted',
+        converted_at      = now(),
+        converted_user_id = p_user_id,
+        active_invite_id  = NULL
+    WHERE id = v_entry_id;
+
+    RETURN public._waitlist_consume_response(
+        v_entry_id,
+        v_settings.default_plan_id,
+        false
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_update_waitlist_settings(
+    p_signup_mode text DEFAULT NULL,
+    p_default_plan_id text DEFAULT NULL,
+    p_invite_ttl_days integer DEFAULT NULL,
+    p_identity_match_mode text DEFAULT NULL,
+    p_copy jsonb DEFAULT NULL,
+    p_metadata_schema jsonb DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_uid uuid := auth.uid();
+BEGIN
+    IF v_uid IS NULL OR NOT public.admin_is_admin() THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    IF p_signup_mode IS NOT NULL
+       AND p_signup_mode NOT IN ('open', 'waitlist', 'invite_only', 'closed') THEN
+        RETURN jsonb_build_object('error', 'invalid_signup_mode');
+    END IF;
+
+    IF p_identity_match_mode IS NOT NULL
+       AND p_identity_match_mode NOT IN ('lenient', 'strict') THEN
+        RETURN jsonb_build_object('error', 'invalid_identity_match_mode');
+    END IF;
+
+    IF p_invite_ttl_days IS NOT NULL AND p_invite_ttl_days < 1 THEN
+        RETURN jsonb_build_object('error', 'invalid_invite_ttl_days');
+    END IF;
+
+    IF p_default_plan_id IS NOT NULL
+       AND NOT EXISTS (
+            SELECT 1 FROM public.billing_plans pl
+            WHERE pl.id = p_default_plan_id AND pl.is_public = true
+        ) THEN
+        RETURN jsonb_build_object('error', 'invalid_default_plan_id');
+    END IF;
+
+    UPDATE public.waitlist_settings
+    SET
+        signup_mode = COALESCE(p_signup_mode, signup_mode),
+        default_plan_id = COALESCE(p_default_plan_id, default_plan_id),
+        invite_ttl_days = COALESCE(p_invite_ttl_days, invite_ttl_days),
+        identity_match_mode = COALESCE(p_identity_match_mode, identity_match_mode),
+        copy = COALESCE(p_copy, copy),
+        metadata_schema = COALESCE(p_metadata_schema, metadata_schema),
+        updated_at = now(),
+        updated_by = v_uid
+    WHERE id = 1;
+
+    PERFORM public._admin_insert_audit(
+        v_uid,
+        'waitlist.settings.update',
+        'waitlist_settings',
+        '1',
+        jsonb_build_object(
+            'signup_mode', p_signup_mode,
+            'default_plan_id', p_default_plan_id,
+            'invite_ttl_days', p_invite_ttl_days,
+            'identity_match_mode', p_identity_match_mode,
+            'copy', p_copy,
+            'metadata_schema', p_metadata_schema
+        )
+    );
+
+    RETURN public.admin_get_waitlist_settings();
+END;
+$$;
+
+DO $$
+DECLARE
+    v_bad text;
+BEGIN
+    SELECT default_plan_id INTO v_bad
+    FROM public.waitlist_settings
+    WHERE id = 1
+      AND EXISTS (
+            SELECT 1 FROM public.billing_plans pl
+            WHERE pl.id = waitlist_settings.default_plan_id
+              AND pl.is_public = false
+        );
+
+    IF v_bad IS NOT NULL THEN
+        RAISE WARNING 'waitlist_settings.default_plan_id % references a non-public plan; update via Admin → Waitlist settings', v_bad;
+    END IF;
+END;
+$$;

--- a/supabase/migrations/20260630120400_waitlist_billing_fulfill_conversion.sql
+++ b/supabase/migrations/20260630120400_waitlist_billing_fulfill_conversion.sql
@@ -1,0 +1,155 @@
+-- Waitlist-billing integration: fulfill provisioning intent at conversion time.
+
+CREATE OR REPLACE FUNCTION public.waitlist_billing_fulfill_conversion(
+    p_user_id uuid,
+    p_entry_id uuid,
+    p_product_id text,
+    p_allowed_comp_plan_ids text[] DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_entry public.waitlist_entries;
+    v_intent jsonb;
+    v_kind text;
+    v_plan_id text;
+    v_reason text;
+    v_granted_by uuid;
+    v_grant jsonb;
+    v_sub public.billing_subscriptions;
+BEGIN
+    IF p_user_id IS NULL OR p_entry_id IS NULL OR p_product_id IS NULL THEN
+        RETURN jsonb_build_object('error', 'invalid_request');
+    END IF;
+
+    SELECT * INTO v_entry
+    FROM public.waitlist_entries e
+    WHERE e.id = p_entry_id;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('error', 'not_found');
+    END IF;
+
+    IF v_entry.status <> 'converted' OR v_entry.converted_user_id IS DISTINCT FROM p_user_id THEN
+        RETURN jsonb_build_object('error', 'not_converted');
+    END IF;
+
+    v_intent := v_entry.metadata->'provisioning_intent';
+    IF v_intent IS NULL OR jsonb_typeof(v_intent) <> 'object' THEN
+        RETURN jsonb_build_object('ok', true);
+    END IF;
+
+    v_kind := nullif(btrim(v_intent->>'kind'), '');
+    v_plan_id := nullif(btrim(v_intent->>'planId'), '');
+
+    IF v_kind = 'billing_comp' THEN
+        IF v_plan_id IS NULL THEN
+            RETURN jsonb_build_object('error', 'invalid_intent');
+        END IF;
+
+        IF p_allowed_comp_plan_ids IS NOT NULL
+           AND NOT (v_plan_id = ANY (p_allowed_comp_plan_ids)) THEN
+            RETURN jsonb_build_object('error', 'plan_not_allowed');
+        END IF;
+
+        IF NOT EXISTS (
+            SELECT 1 FROM public.billing_plans pl
+            WHERE pl.id = v_plan_id
+              AND pl.product_id = p_product_id
+              AND pl.is_public = false
+        ) THEN
+            RETURN jsonb_build_object('error', 'invalid_plan');
+        END IF;
+
+        v_reason := nullif(btrim(v_intent->>'reason'), '');
+        IF v_reason IS NULL THEN
+            RETURN jsonb_build_object('error', 'invalid_reason');
+        END IF;
+
+        BEGIN
+            v_granted_by := (v_intent->>'grantedBy')::uuid;
+        EXCEPTION WHEN invalid_text_representation THEN
+            v_granted_by := NULL;
+        END;
+
+        SELECT * INTO v_sub
+        FROM public.billing_subscriptions s
+        WHERE s.user_id = p_user_id AND s.product_id = p_product_id;
+
+        IF v_sub.status = 'comped'
+           AND v_sub.plan_id = v_plan_id
+           AND EXISTS (
+                SELECT 1 FROM public.billing_comp_grants g
+                WHERE g.user_id = p_user_id
+                  AND g.product_id = p_product_id
+                  AND g.revoked_at IS NULL
+                  AND g.plan_id = v_plan_id
+                  AND g.comp_expires_at IS NULL
+            ) THEN
+            RETURN jsonb_build_object('ok', true, 'unchanged', true);
+        END IF;
+
+        v_grant := public._billing_apply_comp_grant(
+            p_user_id,
+            p_product_id,
+            v_plan_id,
+            v_reason,
+            v_granted_by,
+            NULL,
+            'waitlist_invite'
+        );
+
+        IF v_grant ? 'error' THEN
+            RETURN v_grant;
+        END IF;
+
+        IF COALESCE((v_grant->>'unchanged')::boolean, false) THEN
+            RETURN jsonb_build_object('ok', true, 'unchanged', true);
+        END IF;
+
+        RETURN jsonb_build_object('ok', true, 'comp_applied', true);
+    END IF;
+
+    IF v_kind = 'billing_plan' THEN
+        IF v_plan_id IS NULL THEN
+            RETURN jsonb_build_object('error', 'invalid_intent');
+        END IF;
+
+        IF NOT EXISTS (
+            SELECT 1 FROM public.billing_plans pl
+            WHERE pl.id = v_plan_id
+              AND pl.product_id = p_product_id
+              AND pl.is_public = true
+        ) THEN
+            RETURN jsonb_build_object('error', 'invalid_plan');
+        END IF;
+
+        SELECT * INTO v_sub
+        FROM public.billing_subscriptions s
+        WHERE s.user_id = p_user_id AND s.product_id = p_product_id;
+
+        IF FOUND AND v_sub.plan_id = v_plan_id THEN
+            RETURN jsonb_build_object('ok', true, 'unchanged', true);
+        END IF;
+
+        PERFORM public.billing_ensure_subscription_plan(
+            p_product_id,
+            v_plan_id,
+            p_user_id
+        );
+
+        RETURN jsonb_build_object('ok', true, 'plan_applied', true);
+    END IF;
+
+    RETURN jsonb_build_object('error', 'invalid_intent_kind');
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.waitlist_billing_fulfill_conversion(uuid, uuid, text, text[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.waitlist_billing_fulfill_conversion(uuid, uuid, text, text[]) FROM authenticated;
+REVOKE EXECUTE ON FUNCTION public.waitlist_billing_fulfill_conversion(uuid, uuid, text, text[]) FROM anon;
+GRANT EXECUTE ON FUNCTION public.waitlist_billing_fulfill_conversion(uuid, uuid, text, text[]) TO service_role;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -65,6 +65,22 @@ VALUES
     5,
     true,
     3
+),
+(
+    'beakerstack_vip',
+    'beakerstack',
+    'VIP (complimentary)',
+    'Complimentary Max-equivalent access (operator-granted only)',
+    0,
+    'monthly',
+    NULL,
+    NULL,
+    NULL,
+    '{"containers_per_account_max": -1, "items_per_container_max": -1, "feature_a": true, "feature_b": true}'::jsonb,
+    '{"ai_summarize": -1}'::jsonb,
+    0,
+    false,
+    99
 )
 ON CONFLICT (id) DO NOTHING;
 

--- a/supabase/tests/billing_comp_grants.test.sql
+++ b/supabase/tests/billing_comp_grants.test.sql
@@ -1,0 +1,339 @@
+-- pgTAP: complimentary billing grants — schema, RPC access, grant/revoke flows
+BEGIN;
+SELECT plan(27);
+
+-- ── Schema / security ────────────────────────────────────────────────────────
+SELECT has_table('public', 'billing_comp_grants', 'billing_comp_grants table exists');
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public' AND c.relname = 'billing_comp_grants' AND c.relrowsecurity = true
+    ),
+    'RLS enabled on billing_comp_grants'
+);
+
+SELECT is(
+    (SELECT count(*)::int FROM pg_policies WHERE tablename = 'billing_comp_grants'),
+    0,
+    'billing_comp_grants has no RLS policies for client roles'
+);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM information_schema.routines
+        WHERE routine_schema = 'public' AND routine_name = 'admin_grant_billing_comp'
+    ),
+    'admin_grant_billing_comp exists'
+);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM information_schema.routines
+        WHERE routine_schema = 'public' AND routine_name = 'admin_revoke_billing_comp'
+    ),
+    'admin_revoke_billing_comp exists'
+);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND indexname = 'billing_comp_grants_active_user_product'
+    ),
+    'partial unique index on active comp grants exists'
+);
+
+SELECT ok(
+    NOT EXISTS (
+        SELECT 1 FROM public.billing_plans p
+        WHERE p.product_id = 'beakerstack'
+          AND p.billing_period = 'free'
+          AND p.is_public = false
+    ),
+    'beakerstack free-tier selector guard: no hidden plans use billing_period free'
+);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM public.billing_plans
+        WHERE id = 'beakerstack_vip' AND product_id = 'beakerstack' AND is_public = false
+    ),
+    'beakerstack_vip hidden plan exists in billing_plans'
+);
+
+SELECT ok(
+    (SELECT (features ->> 'feature_b')::boolean FROM public.billing_plans WHERE id = 'beakerstack_vip'),
+    'beakerstack_vip includes Max-equivalent feature_b'
+);
+
+SELECT is(
+    (SELECT features FROM public.billing_plans WHERE id = 'beakerstack_vip'),
+    (SELECT features FROM public.billing_plans WHERE id = 'beakerstack_max'),
+    'beakerstack_vip features match beakerstack_max'
+);
+
+SELECT is(
+    (SELECT usage_limits FROM public.billing_plans WHERE id = 'beakerstack_vip'),
+    (SELECT usage_limits FROM public.billing_plans WHERE id = 'beakerstack_max'),
+    'beakerstack_vip usage_limits match beakerstack_max'
+);
+
+-- ── Fixtures ─────────────────────────────────────────────────────────────────
+DO $$
+BEGIN
+  INSERT INTO auth.users (
+      id, instance_id, email, encrypted_password, email_confirmed_at,
+      raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role
+  ) VALUES (
+      'c1000000-0000-0000-0000-000000000001',
+      '00000000-0000-0000-0000-000000000000',
+      'comp-test-user@example.com',
+      crypt('pw', gen_salt('bf')),
+      now(),
+      '{"provider":"email","providers":["email"]}'::jsonb,
+      '{}'::jsonb,
+      now(), now(), 'authenticated', 'authenticated'
+  ) ON CONFLICT (id) DO NOTHING;
+
+  INSERT INTO auth.users (
+      id, instance_id, email, encrypted_password, email_confirmed_at,
+      raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role
+  ) VALUES (
+      'c1000000-0000-0000-0000-000000000002',
+      '00000000-0000-0000-0000-000000000000',
+      'comp-test-admin@example.com',
+      crypt('pw', gen_salt('bf')),
+      now(),
+      '{"provider":"email","providers":["email"]}'::jsonb,
+      '{}'::jsonb,
+      now(), now(), 'authenticated', 'authenticated'
+  ) ON CONFLICT (id) DO NOTHING;
+END;
+$$;
+
+INSERT INTO public.admin_users (user_id)
+VALUES ('c1000000-0000-0000-0000-000000000002')
+ON CONFLICT (user_id) DO UPDATE SET revoked_at = NULL;
+
+DELETE FROM public.billing_comp_grants
+WHERE user_id = 'c1000000-0000-0000-0000-000000000001';
+
+DELETE FROM public.billing_subscriptions
+WHERE user_id = 'c1000000-0000-0000-0000-000000000001' AND product_id = 'beakerstack';
+
+-- ── Non-admin denied ─────────────────────────────────────────────────────────
+SELECT set_config('request.jwt.claims',
+    '{"sub":"c1000000-0000-0000-0000-000000000001","role":"authenticated"}',
+    true);
+SET LOCAL ROLE authenticated;
+
+SELECT is(
+    public.admin_grant_billing_comp(
+        'c1000000-0000-0000-0000-000000000001'::uuid,
+        'beakerstack', 'beakerstack_vip', 'test'
+    ) ->> 'error',
+    'not_found',
+    'non-admin admin_grant_billing_comp returns not_found'
+);
+
+SELECT is(
+    public.admin_revoke_billing_comp(
+        'c1000000-0000-0000-0000-000000000001'::uuid,
+        'beakerstack'
+    ) ->> 'error',
+    'not_found',
+    'non-admin admin_revoke_billing_comp returns not_found'
+);
+
+-- ── Admin grant / revoke happy path ───────────────────────────────────────────
+SELECT set_config('request.jwt.claims',
+    '{"sub":"c1000000-0000-0000-0000-000000000002","role":"authenticated"}',
+    true);
+SET LOCAL ROLE authenticated;
+
+SELECT is(
+    public.admin_grant_billing_comp(
+        'c1000000-0000-0000-0000-000000000001'::uuid,
+        'beakerstack', 'beakerstack_vip', 'design partner'
+    ) ->> 'ok',
+    'true',
+    'admin grant comp returns ok'
+);
+
+RESET ROLE;
+
+SELECT is(
+    (
+        SELECT s.status
+        FROM public.billing_subscriptions s
+        WHERE s.user_id = 'c1000000-0000-0000-0000-000000000001'
+          AND s.product_id = 'beakerstack'
+    ),
+    'comped',
+    'grant sets subscription status to comped'
+);
+
+SELECT is(
+    (
+        SELECT s.plan_id
+        FROM public.billing_subscriptions s
+        WHERE s.user_id = 'c1000000-0000-0000-0000-000000000001'
+          AND s.product_id = 'beakerstack'
+    ),
+    'beakerstack_vip',
+    'grant sets subscription plan_id to beakerstack_vip'
+);
+
+SELECT is(
+    (
+        SELECT count(*)::int
+        FROM public.billing_comp_grants g
+        WHERE g.user_id = 'c1000000-0000-0000-0000-000000000001'
+          AND g.product_id = 'beakerstack'
+          AND g.revoked_at IS NULL
+    ),
+    1,
+    'grant creates one active billing_comp_grants row'
+);
+
+SELECT is(
+    (
+        SELECT g.comp_reason
+        FROM public.billing_comp_grants g
+        WHERE g.user_id = 'c1000000-0000-0000-0000-000000000001'
+          AND g.revoked_at IS NULL
+    ),
+    'design partner',
+    'grant stores comp_reason'
+);
+
+SELECT set_config('request.jwt.claims',
+    '{"sub":"c1000000-0000-0000-0000-000000000002","role":"authenticated"}',
+    true);
+SET LOCAL ROLE authenticated;
+
+SELECT ok(
+    (
+        public.admin_get_user(
+            'c1000000-0000-0000-0000-000000000001'::uuid,
+            'beakerstack'
+        ) -> 'comp_grant'
+    ) IS NOT NULL,
+    'admin_get_user includes comp_grant for comped user'
+);
+
+SELECT is(
+    public.admin_grant_billing_comp(
+        'c1000000-0000-0000-0000-000000000001'::uuid,
+        'beakerstack', 'beakerstack_vip', 'design partner'
+    ) ->> 'unchanged',
+    'true',
+    'idempotent grant returns unchanged'
+);
+
+SELECT is(
+    public.admin_grant_billing_comp(
+        'c1000000-0000-0000-0000-000000000001'::uuid,
+        'beakerstack', 'beakerstack_vip', ''
+    ) ->> 'error',
+    'invalid_reason',
+    'empty grant reason returns invalid_reason'
+);
+
+SELECT is(
+    public.admin_revoke_billing_comp(
+        'c1000000-0000-0000-0000-000000000001'::uuid,
+        'beakerstack',
+        'offboarding'
+    ) ->> 'ok',
+    'true',
+    'admin revoke comp returns ok'
+);
+
+SELECT is(
+    public.admin_revoke_billing_comp(
+        'c1000000-0000-0000-0000-000000000001'::uuid,
+        'beakerstack'
+    ) ->> 'unchanged',
+    'true',
+    'revoke with no active grant returns unchanged'
+);
+
+RESET ROLE;
+
+SELECT is(
+    (
+        SELECT s.status
+        FROM public.billing_subscriptions s
+        WHERE s.user_id = 'c1000000-0000-0000-0000-000000000001'
+          AND s.product_id = 'beakerstack'
+    ),
+    'free',
+    'revoke resets subscription status to free'
+);
+
+SELECT ok(
+    (
+        SELECT g.revoked_at IS NOT NULL
+        FROM public.billing_comp_grants g
+        WHERE g.user_id = 'c1000000-0000-0000-0000-000000000001'
+          AND g.product_id = 'beakerstack'
+        ORDER BY g.created_at DESC
+        LIMIT 1
+    ),
+    'revoke marks grant row revoked'
+);
+
+-- ── Stripe guard ─────────────────────────────────────────────────────────────
+INSERT INTO public.billing_subscriptions (
+    user_id, product_id, plan_id, status,
+    stripe_customer_id, stripe_subscription_id
+)
+VALUES (
+    'c1000000-0000-0000-0000-000000000001',
+    'beakerstack',
+    'beakerstack_pro',
+    'active',
+    'cus_comp_test',
+    'sub_comp_test'
+)
+ON CONFLICT (user_id, product_id) DO UPDATE SET
+    plan_id = EXCLUDED.plan_id,
+    status = EXCLUDED.status,
+    stripe_customer_id = EXCLUDED.stripe_customer_id,
+    stripe_subscription_id = EXCLUDED.stripe_subscription_id;
+
+SELECT set_config('request.jwt.claims',
+    '{"sub":"c1000000-0000-0000-0000-000000000002","role":"authenticated"}',
+    true);
+SET LOCAL ROLE authenticated;
+
+SELECT is(
+    public.admin_grant_billing_comp(
+        'c1000000-0000-0000-0000-000000000001'::uuid,
+        'beakerstack', 'beakerstack_vip', 'should fail'
+    ) ->> 'error',
+    'stripe_subscription_active',
+    'grant blocked when stripe_subscription_id is set'
+);
+
+RESET ROLE;
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM public.admin_audit_log
+        WHERE action = 'admin.billing.comp.grant'
+          AND target_id = 'c1000000-0000-0000-0000-000000000001'
+    )
+    OR EXISTS (
+        SELECT 1 FROM public.admin_audit_log
+        WHERE action = 'admin.billing.comp.revoke'
+          AND target_id = 'c1000000-0000-0000-0000-000000000001'
+    ),
+    'comp grant or revoke wrote admin audit log'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/waitlist_billing.test.sql
+++ b/supabase/tests/waitlist_billing.test.sql
@@ -1,0 +1,274 @@
+-- pgTAP: waitlist provisioning intent + waitlist-billing fulfill conversion
+BEGIN;
+SELECT plan(14);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM information_schema.routines
+        WHERE routine_schema = 'public'
+          AND routine_name = 'admin_set_waitlist_entry_provisioning_intent'
+    ),
+    'admin_set_waitlist_entry_provisioning_intent exists'
+);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM information_schema.routines
+        WHERE routine_schema = 'public'
+          AND routine_name = 'waitlist_billing_fulfill_conversion'
+    ),
+    'waitlist_billing_fulfill_conversion exists'
+);
+
+SELECT ok(
+    NOT has_function_privilege(
+        'authenticated',
+        'public.waitlist_billing_fulfill_conversion(uuid, uuid, text, text[])',
+        'EXECUTE'
+    ),
+    'authenticated cannot execute waitlist_billing_fulfill_conversion'
+);
+
+DO $$
+BEGIN
+  INSERT INTO auth.users (
+      id, instance_id, email, encrypted_password, email_confirmed_at,
+      raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role
+  ) VALUES (
+      'd1000000-0000-0000-0000-000000000001',
+      '00000000-0000-0000-0000-000000000000',
+      'vip-waitlist-admin@example.com',
+      crypt('pw', gen_salt('bf')),
+      now(),
+      '{"provider":"email","providers":["email"]}'::jsonb,
+      '{}'::jsonb,
+      now(), now(), 'authenticated', 'authenticated'
+  ) ON CONFLICT (id) DO NOTHING;
+
+  INSERT INTO auth.users (
+      id, instance_id, email, encrypted_password, email_confirmed_at,
+      raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role
+  ) VALUES (
+      'd1000000-0000-0000-0000-000000000002',
+      '00000000-0000-0000-0000-000000000000',
+      'vip-waitlist-user@example.com',
+      crypt('pw', gen_salt('bf')),
+      now(),
+      '{"provider":"email","providers":["email"]}'::jsonb,
+      '{}'::jsonb,
+      now(), now(), 'authenticated', 'authenticated'
+  ) ON CONFLICT (id) DO NOTHING;
+END;
+$$;
+
+INSERT INTO public.admin_users (user_id)
+VALUES ('d1000000-0000-0000-0000-000000000001')
+ON CONFLICT (user_id) DO UPDATE SET revoked_at = NULL;
+
+INSERT INTO public.waitlist_entries (
+    id, email, status, metadata, converted_at, converted_user_id
+)
+VALUES (
+    'd1000000-0000-0000-0000-000000000010',
+    'vip-waitlist-user@example.com',
+    'converted',
+    jsonb_build_object(
+        'provisioning_intent', jsonb_build_object(
+            'kind', 'billing_comp',
+            'planId', 'beakerstack_vip',
+            'reason', 'Design partner',
+            'grantedBy', 'd1000000-0000-0000-0000-000000000001'
+        )
+    ),
+    now(),
+    'd1000000-0000-0000-0000-000000000002'
+)
+ON CONFLICT (email) DO UPDATE SET
+    status = EXCLUDED.status,
+    metadata = EXCLUDED.metadata,
+    converted_at = EXCLUDED.converted_at,
+    converted_user_id = EXCLUDED.converted_user_id;
+
+SELECT is(
+    public.waitlist_billing_fulfill_conversion(
+        'd1000000-0000-0000-0000-000000000002'::uuid,
+        'd1000000-0000-0000-0000-000000000010'::uuid,
+        'beakerstack',
+        ARRAY['beakerstack_vip']::text[]
+    )->>'comp_applied',
+    'true',
+    'fulfill applies comp grant for billing_comp intent'
+);
+
+SELECT is(
+    public.waitlist_billing_fulfill_conversion(
+        'd1000000-0000-0000-0000-000000000002'::uuid,
+        'd1000000-0000-0000-0000-000000000010'::uuid,
+        'beakerstack',
+        ARRAY['beakerstack_vip']::text[]
+    )->>'unchanged',
+    'true',
+    'fulfill is idempotent on re-run'
+);
+
+SELECT is(
+    (
+        SELECT s.status
+        FROM public.billing_subscriptions s
+        WHERE s.user_id = 'd1000000-0000-0000-0000-000000000002'
+          AND s.product_id = 'beakerstack'
+    ),
+    'comped',
+    'fulfill leaves subscription comped'
+);
+
+DO $$
+BEGIN
+  INSERT INTO auth.users (
+      id, instance_id, email, encrypted_password, email_confirmed_at,
+      raw_app_meta_data, raw_user_meta_data, created_at, updated_at, aud, role
+  ) VALUES (
+      'd1000000-0000-0000-0000-000000000003',
+      '00000000-0000-0000-0000-000000000000',
+      'vip-plan-intent@example.com',
+      crypt('pw', gen_salt('bf')),
+      now(),
+      '{"provider":"email","providers":["email"]}'::jsonb,
+      '{}'::jsonb,
+      now(), now(), 'authenticated', 'authenticated'
+  ) ON CONFLICT (id) DO NOTHING;
+END;
+$$;
+
+INSERT INTO public.waitlist_entries (
+    id, email, status, metadata, converted_at, converted_user_id
+)
+VALUES (
+    'd1000000-0000-0000-0000-000000000012',
+    'vip-plan-intent@example.com',
+    'converted',
+    jsonb_build_object(
+        'provisioning_intent', jsonb_build_object(
+            'kind', 'billing_plan',
+            'planId', 'beakerstack_free'
+        )
+    ),
+    now(),
+    'd1000000-0000-0000-0000-000000000003'
+)
+ON CONFLICT (email) DO UPDATE SET
+    status = EXCLUDED.status,
+    metadata = EXCLUDED.metadata,
+    converted_at = EXCLUDED.converted_at,
+    converted_user_id = EXCLUDED.converted_user_id;
+
+SELECT is(
+    public.waitlist_billing_fulfill_conversion(
+        'd1000000-0000-0000-0000-000000000003'::uuid,
+        'd1000000-0000-0000-0000-000000000012'::uuid,
+        'beakerstack',
+        ARRAY['beakerstack_vip']::text[]
+    )->>'plan_applied',
+    'true',
+    'fulfill applies public plan for billing_plan intent'
+);
+
+SELECT is(
+    (
+        SELECT s.plan_id
+        FROM public.billing_subscriptions s
+        WHERE s.user_id = 'd1000000-0000-0000-0000-000000000003'
+          AND s.product_id = 'beakerstack'
+    ),
+    'beakerstack_free',
+    'fulfill billing_plan intent sets subscription plan'
+);
+
+INSERT INTO public.waitlist_entries (id, email, status)
+VALUES (
+    'd1000000-0000-0000-0000-000000000011',
+    'vip-approved-only@example.com',
+    'approved'
+)
+ON CONFLICT (email) DO UPDATE SET status = 'approved';
+
+SET LOCAL role TO authenticated;
+SELECT set_config(
+    'request.jwt.claims',
+    '{"sub":"d1000000-0000-0000-0000-000000000001","role":"authenticated"}',
+    true
+);
+SELECT set_config('request.jwt.claim.sub', 'd1000000-0000-0000-0000-000000000001', true);
+
+SELECT ok(
+    public.admin_is_admin(),
+    'vip waitlist admin fixture is recognized as admin'
+);
+
+SELECT is(
+    public.admin_set_waitlist_entry_provisioning_intent(
+        'd1000000-0000-0000-0000-000000000011'::uuid,
+        jsonb_build_object(
+            'kind', 'billing_comp',
+            'planId', 'beakerstack_vip',
+            'reason', 'Retroactive VIP'
+        ),
+        ARRAY['beakerstack_vip']::text[]
+    )->>'ok',
+    'true',
+    'set-intent on approved entry succeeds'
+);
+
+SELECT is(
+    public.admin_set_waitlist_entry_provisioning_intent(
+        'd1000000-0000-0000-0000-000000000011'::uuid,
+        NULL,
+        ARRAY['beakerstack_vip']::text[]
+    )->>'ok',
+    'true',
+    'null intent clears provisioning_intent'
+);
+
+RESET role;
+
+SELECT ok(
+    NOT (
+        SELECT (metadata ? 'provisioning_intent')
+        FROM public.waitlist_entries
+        WHERE id = 'd1000000-0000-0000-0000-000000000011'
+    ),
+    'cleared intent removed from metadata'
+);
+
+SET LOCAL role TO authenticated;
+SELECT set_config(
+    'request.jwt.claims',
+    '{"sub":"d1000000-0000-0000-0000-000000000001","role":"authenticated"}',
+    true
+);
+SELECT set_config('request.jwt.claim.sub', 'd1000000-0000-0000-0000-000000000001', true);
+
+SELECT is(
+    public.admin_set_waitlist_entry_provisioning_intent(
+        'd1000000-0000-0000-0000-000000000010'::uuid,
+        jsonb_build_object(
+            'kind', 'billing_comp',
+            'planId', 'beakerstack_vip',
+            'reason', 'Too late'
+        ),
+        ARRAY['beakerstack_vip']::text[]
+    )->>'error',
+    'invalid_status',
+    'set-intent rejects converted entries'
+);
+
+SELECT is(
+    public.admin_update_waitlist_settings(p_default_plan_id := 'beakerstack_vip')->>'error',
+    'invalid_default_plan_id',
+    'settings rejects non-public default plan'
+);
+
+RESET role;
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
   ],
   moduleNameMapper: {
     '^@/utils/(.*)$': '<rootDir>/utils/$1',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   setupFilesAfterEnv: ['<rootDir>/utils/integration-setup.ts'],
   testTimeout: 60000,


### PR DESCRIPTION
## CalVer release notes

### Summary

This promotion ships complimentary VIP billing grants with waitlist→billing conversion, plus a surgical npm advisory pin pass. Operators can grant and revoke Max-equivalent `beakerstack_vip` access from Admin, attach VIP intent on waitlist invite/approve (including retroactive save), and fulfill comps when waitlist conversion completes—including the OAuth `already_converted` path. Dependency overrides clear open Dependabot findings without an Expo upgrade; the two moderate React Router 6.30.4 advisories remain intentional until a React 19 / Router upgrade is ready.

### Highlights

- **Billing / VIP comps (#405):** Complimentary grants foundation (`billing_comp_grants`, admin grant/revoke RPCs), hidden Max-equivalent `beakerstack_vip` plan, and `comped` billing UI state on overview/plans and subscription badges.
- **Waitlist ↔ billing (#405):** New `@beakerstack/waitlist-billing` package; admin waitlist VIP invite/approve/retroactive save; `waitlist-ops` fulfill on conversion; ops CLIs `admin:invite` and `admin:waitlist-vip`; five Supabase migrations with pgTAP coverage.
- **Dependencies (#408):** Refresh root overrides for `tar`, `js-yaml`, `shell-quote`, `fast-uri`, `postcss`, and major-keyed `brace-expansion`; bump `dompurify` and `sharp` without upgrading Expo.

### Adopter notes

| Area                       | Action |
| -------------------------- | ------ |
| **Secrets**                | Set `WAITLIST_COMP_PLAN_IDS=beakerstack_vip` on the deployed `waitlist-ops` edge function |
| **Database**               | Apply migrations `supabase/migrations/20260630120000_billing_comp_grants_v1.sql`, `20260630120100_admin_billing_comp_rpcs.sql`, `20260630120200_billing_apply_comp_grant_internal.sql`, `20260630120300_waitlist_provisioning_intent.sql`, `20260630120400_waitlist_billing_fulfill_conversion.sql`; run `npm run db:apply-adopter` for the `beakerstack_vip` plan seed |
| **Likely merge conflicts** | `adopter/config/billing.ts`, new `adopter/config/waitlist-billing.ts`, admin waitlist/user drawers, `package-lock.json` |
| **npm packages**           | None pending via changesets; new workspace package `@beakerstack/waitlist-billing` lands in-tree |

- **Landing:** https://beakerstack.com
- **Quick start:** https://github.com/Artificer-Innovations/BeakerStack/blob/main/QUICKSTART.md
- **Feedback:** https://github.com/Artificer-Innovations/BeakerStack/discussions
- **Upgrade guide:** https://github.com/Artificer-Innovations/BeakerStack/blob/main/docs/UPGRADING.md

2 commits, +4798 / −668 lines since `2026.007`.

---

## Maintainer checklist

### Merge instructions

**Use “Create a merge commit” — do NOT squash.** Required by [CONTRIBUTING.md](../../CONTRIBUTING.md) and enforced by [check-merge-strategy.yml](../workflows/check-merge-strategy.yml).

### Post-merge

1. Monitor **Deploy Production** workflow on `main`
2. Review auto-opened **“chore: release packages”** PR from changesets (if any); merge if correct
3. Run **Release Template** workflow on `main` (uses this PR’s CalVer section + git-cliff changelog)

### Test plan

- [x] CI green on `develop` at promotion SHA
- [ ] Staging smoke: auth, dashboard, billing
- [ ] After merge: production deploy succeeds
- [ ] After **Release Template**: GitHub Release body matches **CalVer release notes** above + changelog
