### PR TITLE
fix(ci): force decimal when bumping CalVer past .008

### DIFF
--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -44,8 +44,9 @@ jobs:
             YEAR=$(date +%Y)
             # CalVer YYYY.NNN only (exclude semver-shaped tags like 2026.1.0)
             LAST_N=$(git tag -l | grep -E "^${YEAR}\\.[0-9]{3}$" | sed "s/${YEAR}\.//" | sort -n | tail -1)
-            NEXT_N=$(( ${LAST_N:-0} + 1 ))
-            printf -v PADDED_N "%03d" $NEXT_N
+            # 10# forces decimal: bare 008 is invalid octal in bash arithmetic
+            NEXT_N=$(( 10#${LAST_N:-0} + 1 ))
+            printf -v PADDED_N "%03d" "$NEXT_N"
             echo "tag=${YEAR}.${PADDED_N}" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## Summary
- Release Template failed computing the next tag after `2026.008`: bash `$((008 + 1))` treats leading-zero values as octal (`value too great for base`).
- Force decimal with `10#${LAST_N}` so `2026.008` → `2026.009`.

## Test plan
- [x] Locally: `LAST_N=008` with `10#` yields `009`; `007` → `008`; empty → `001`
- [ ] Merge to `develop`, then promote / merge to `main`
- [ ] Re-run **Release Template** on `main` after the fix is there