### PR TITLE
release: promote develop to main (calver bump fix)

### DIFF
--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -44,8 +44,9 @@ jobs:
             YEAR=$(date +%Y)
             # CalVer YYYY.NNN only (exclude semver-shaped tags like 2026.1.0)
             LAST_N=$(git tag -l | grep -E "^${YEAR}\\.[0-9]{3}$" | sed "s/${YEAR}\.//" | sort -n | tail -1)
-            NEXT_N=$(( ${LAST_N:-0} + 1 ))
-            printf -v PADDED_N "%03d" $NEXT_N
+            # 10# forces decimal: bare 008 is invalid octal in bash arithmetic
+            NEXT_N=$(( 10#${LAST_N:-0} + 1 ))
+            printf -v PADDED_N "%03d" "$NEXT_N"
             echo "tag=${YEAR}.${PADDED_N}" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## CalVer release notes

### Summary

This promotion lands the Release Template CalVer bump fix (#413) so production can cut `2026.009` after the previous release run failed on `2026.008` (bash octal arithmetic). The public notes for this cut also cover the audit-zero stack already merged via #412 (#410) — Node ≥22.22, React 19.2.8, Expo SDK 57 / RN 0.86, and `react-router@8.3.0` — which never received a CalVer GitHub Release because tagging aborted. No new secrets or Supabase migrations.

### Highlights

- **CI / release:** Force decimal when bumping CalVer past `.008` (`10#${LAST_N}`) so Release Template can compute `2026.009` (#413).
- **Dependencies / security:** Audit-zero via React Router 8, React 19, and Expo 57 (#410); exact-pin advisory-related packages; document lockfile + overrides policy; CI `npm-audit` gate.
- **Web:** `react-router-dom` → `react-router@8.3.0`; PR preview scope classifies against full `base..head`.
- **Mobile:** Expo SDK 57 / RN 0.86 tooling refresh; static Sentry imports for reliable native boot.
- **Tooling:** Node engines / Actions ≥22.22; remove obsolete Expo 50 patch-package patches.

### Adopter notes

| Area                       | Action |
| -------------------------- | ------ |
| **Secrets**                | None new |
| **Database**               | No new migrations |
| **Likely merge conflicts** | `.github/workflows/release-template.yml` for this hotfix; otherwise same as #412 (`package.json` / lockfile, web router imports, mobile Expo/Jest, removed `patches/@expo*`) |
| **npm packages**           | None (no pending changesets on `develop`) |

- **Landing:** https://beakerstack.com
- **Quick start:** https://github.com/Artificer-Innovations/BeakerStack/blob/main/QUICKSTART.md
- **Feedback:** https://github.com/Artificer-Innovations/BeakerStack/discussions
- **Upgrade guide:** https://github.com/Artificer-Innovations/BeakerStack/blob/main/docs/UPGRADING.md

**Stats:** 2 commits since `2026.008` (#410, #413); this PR’s main↔develop delta is #413 only. Diff since tag: 186 files, +4875 / −14605.

---

## Maintainer checklist

### Merge instructions

**Use “Create a merge commit” — do NOT squash.** Required by [CONTRIBUTING.md](../../CONTRIBUTING.md) and enforced by [check-merge-strategy.yml](../workflows/check-merge-strategy.yml).

### Post-merge

1. Monitor **Deploy Production** workflow on `main`
2. Review auto-opened **“chore: release packages”** PR from changesets (if any); merge if correct
3. Run **Release Template** workflow on `main` (uses this PR’s CalVer section + git-cliff changelog)

### Test plan

- [x] CI green on `develop` at promotion SHA
- [ ] Staging smoke: auth, dashboard, billing
- [ ] After merge: production deploy succeeds
- [ ] After **Release Template**: GitHub Release body matches **CalVer release notes** above + changelog (`2026.009`)
