### PR TITLE
fix(deps): pin fast-uri 3.1.5 for npm audit zero

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/package-lock.json
+++ b/package-lock.json
@@ -15533,9 +15533,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -298,7 +298,7 @@
       "mime-types": "2.1.35"
     },
     "ws": "8.21.0",
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "fast-xml-builder": "^1.1.7",
     "@xmldom/xmldom": "0.8.13",
     "@expo/plist": "0.5.2",


### PR DESCRIPTION
## Summary
- Bump the root `fast-uri` override from `3.1.4` to `3.1.5` to clear [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) (Dependabot alert #57)
- Add a project `.npmrc` pinning `registry=https://registry.npmjs.org` 
- Refresh `package-lock.json` so `fast-uri` resolves to `3.1.5` from the public registry

## Test plan
- [ ] CI `npm-audit` job passes (`npm audit --audit-level=low`)
- [ ] Confirm lockfile entry for `node_modules/fast-uri` is `3.1.5` from `registry.npmjs.org`
- [ ] Local `npm ci` uses public npm even if user-level registry is CodeArtifact